### PR TITLE
feat: add cmux-orchestration workspace skill and browser-reload CLI command

### DIFF
--- a/.agents/skills/cmux-orchestration/SKILL.md
+++ b/.agents/skills/cmux-orchestration/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: cmux-orchestration
+description: Orchestrate cmux-mux panes, agents, and browser tabs from a natural-language layout request
+argument-hint: <describe the panes, agents, and browser tabs you want, in plain English>
+---
+
+You are orchestrating **cmux-mux**, the terminal multiplexer this Claude Code session
+is (probably) running inside of. The user's request is:
+
+$ARGUMENTS
+
+Turn that request into real panes/tabs by driving the `cmux-mux` CLI with the `bash`
+tool. Do not just describe a plan — actually create the layout, launch the agent(s),
+and report back what you built (pane/surface ids, what's running where).
+
+## 0. Preconditions
+
+Run `env | grep '^CMUX_MUX_'`. You need both `CMUX_MUX_SOCKET` and `CMUX_MUX_SURFACE`
+set — every pane spawned by a running `cmux-mux` session gets these automatically.
+If either is missing, stop and tell the user this only works from inside a pane of a
+live `cmux-mux` session (`cmux-mux` to start one, or `cmux-mux attach --session <name>`
+to join one already running) — there's nothing to orchestrate otherwise.
+
+`cmux-mux <verb> ...` reads `CMUX_MUX_SOCKET` itself, so you don't need `--socket` on
+any command below.
+
+## 1. Find out where you are
+
+Run `cmux-mux list-workspaces`. It prints the whole tree: workspaces → screens →
+panes → tabs (surfaces), one line each, e.g.:
+
+```
+pane id=2 screen=3 name=null active_tab=0
+tab surface=1 pane=2 kind=pty browser_source=null name=null title="" cols=80 rows=24
+```
+
+Find the tab whose `surface=` matches `$CMUX_MUX_SURFACE` — its `pane=` is the pane
+you (this Claude session) are running in. That's your anchor for "left"/"here"/"this
+pane" in the user's request; other panes are laid out relative to it with `split`.
+
+## 2. CLI cheat sheet (exact flags — nothing else is accepted)
+
+```
+cmux-mux split --pane <pane> --dir right|down [--cols N --rows N]
+    → creates a new pane (splitting the given one) with a fresh shell tab.
+      Prints the new surface id. There is no --cwd; cd inside it via `send`.
+
+cmux-mux new-tab --pane <pane> [--cwd <dir>] [--cols N --rows N]
+    → new shell tab in an existing pane (not a new pane/split). Prints surface id.
+
+cmux-mux new-browser-tab --url <url> --pane <pane> [--cols N --rows N]
+    → new browser tab in a pane. Prints surface id.
+
+cmux-mux send --surface <id> --text "<text>"
+    → types literal text into a pty surface. Include your own trailing \n to
+      submit a shell command, e.g.: --text $'cd /some/dir && claude "do the thing"\n'
+      Does NOT work on browser surfaces (see below).
+
+cmux-mux read-screen --surface <id>
+    → dumps a pty surface's visible screen text. Browser surfaces reject this
+      with "browser surface does not support PTY/VT socket commands" — don't
+      try to introspect a browser tab's content this way, it's expected to fail.
+
+cmux-mux browser-reload --surface <id>
+    → reloads/refreshes a browser tab.
+
+cmux-mux close-surface --surface <id>
+    → closes one tab/surface (pane/screen/workspace stay if other tabs remain).
+
+cmux-mux list-agents [--state working|blocked|idle|done]
+    → shows Claude Code hook-reported agent state per surface, if the hook is
+      installed (`cmux-mux claude install-hooks`). Useful to check whether an
+      agent you launched is still working vs. waiting on you.
+```
+
+## 3. Building the layout
+
+- Map each thing the user describes ("Claude Code on the left", "a browser on the
+  right") to a pane. Use `split --pane <anchor-pane> --dir right` (or `down`) for
+  each additional pane; note the returned surface id each time.
+- To launch an agent in a pane: `send --surface <id> --text $'cd <dir> && claude "<task, quoted>"\n'`.
+  Prefer passing the task as `claude`'s prompt argument over a bare `claude` +
+  a second `send`, so it starts working immediately without you having to guess
+  timing.
+- To open a browser pointed at a URL: `new-browser-tab --url <url> --pane <pane>`.
+- If the user wants a dev server (e.g. "build a tiny web app" + "point the browser at
+  its dev server"), run the scaffolding/dev-server command in the agent's own pane
+  (as part of its task, or via a `new-tab` you drive yourself first) — don't try to
+  run it from your own pane, since your pane keeps running this command.
+
+## 4. "Reload the browser when the code changes"
+
+You can reload/refresh a browser tab in-place using:
+
+    cmux-mux browser-reload --surface <browser-surface-id>
+
+For watching the agent's working directory for changes, prefer:
+
+```
+command -v inotifywait >/dev/null && inotifywait -r -m -e modify,create,delete,move <dir>
+```
+
+as a background loop that reloads the browser tab on each event. If `inotifywait`
+isn't installed, fall back to a polling loop (check mtimes every ~1s) — write it as a
+small script under the scratchpad directory (not the user's project), launch it with
+`nohup ... >/dev/null 2>&1 & disown`, and mention that a real filesystem watcher would
+be more efficient if the user wants to `apt/dnf/pacman install inotify-tools`.
+
+## 5. Report back
+
+Once built, tell the user plainly what you created: which pane/surface has the agent,
+which has the browser, what URL, and how the reload loop is running (and its PID, so
+they can kill it later). If any step failed (e.g. dev server didn't come up in time),
+say so and what you'd try next — don't claim success you didn't verify.

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -267,6 +267,13 @@ const VERBS: &[VerbSpec] = &[
         print: print_agents,
         stream: false,
     },
+    VerbSpec {
+        name: "browser-reload",
+        allowed: &["surface"],
+        build: build_surface,
+        print: print_empty,
+        stream: false,
+    },
 ];
 
 pub fn is_cli_invocation(args: &[String]) -> bool {

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -85,7 +85,8 @@ CLI VERBS
   close-workspace, rename-pane, rename-surface, rename-screen,
   rename-workspace, resize-surface, focus-pane, select-tab,
   select-screen, select-workspace, move-tab, move-workspace,
-  scroll-surface, subscribe, attach-surface, report-agent, list-agents
+  scroll-surface, subscribe, attach-surface, report-agent, list-agents,
+  browser-reload
 
 CLAUDE CODE HOOK INTEGRATION
   cmux-mux claude install-hooks [--uninstall]


### PR DESCRIPTION
This PR adds the cmux-orchestration workspace skill and implements the native browser-reload command in the cmux-mux CLI.