### PR TITLE
feat: per-workspace colour + manual flash trigger

### DIFF
--- a/mux/crates/mux-core/src/model.rs
+++ b/mux/crates/mux-core/src/model.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::{PaneId, ScreenId, SplitDir, Surface, SurfaceId, WorkspaceId};
+use crate::{PaneId, Rgb, ScreenId, SplitDir, Surface, SurfaceId, WorkspaceId};
 
 /// Binary split tree over panes for one screen.
 #[derive(Debug, Clone)]
@@ -137,6 +137,7 @@ pub struct Workspace {
     pub name: String,
     pub screens: Vec<Screen>,
     pub active_screen: usize,
+    pub color: Option<Rgb>,
 }
 
 impl Workspace {

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -49,6 +49,14 @@ pub enum MuxEvent {
         title: String,
         body: String,
     },
+    /// A manual flash was triggered for a workspace (e.g. via the
+    /// `trigger-flash` command), for frontends to render a transient
+    /// visual pulse. `surface` is advisory context about which surface
+    /// triggered it, if any — not validated.
+    Flash {
+        workspace: WorkspaceId,
+        surface: Option<SurfaceId>,
+    },
 }
 
 /// The multiplexer. Shared by frontends and the control socket server.
@@ -986,6 +994,20 @@ impl Mux {
             self.emit(MuxEvent::TreeChanged);
         }
         changed
+    }
+
+    /// Emits `MuxEvent::Flash` for a workspace, for frontends to render a
+    /// transient visual pulse (e.g. a manual "look here" signal). Doesn't
+    /// mutate state, so no `TreeChanged` follows.
+    pub fn trigger_flash(&self, workspace: WorkspaceId, surface: Option<SurfaceId>) -> bool {
+        let exists = {
+            let state = self.state.lock().unwrap();
+            state.workspaces.iter().any(|ws| ws.id == workspace)
+        };
+        if exists {
+            self.emit(MuxEvent::Flash { workspace, surface });
+        }
+        exists
     }
 
     /// Set a pane's user-visible name. An empty name clears it (the pane

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use crate::browser::{self, BrowserBootstrap, BrowserRuntime};
 use crate::model::{Node, Pane, Screen, State, Workspace};
 use crate::surface::{AgentReport, AgentState, AgentStateSource, DefaultColors, Surface, SurfaceOptions};
-use crate::{PaneId, ScreenId, SplitDir, SurfaceId, WorkspaceId};
+use crate::{PaneId, Rgb, ScreenId, SplitDir, SurfaceId, WorkspaceId};
 
 /// Events pushed to subscribed frontends.
 #[derive(Debug, Clone)]
@@ -311,6 +311,9 @@ impl Mux {
             None => self.new_workspace(Some(ws.name.to_string()), None)?,
         };
         let ws_id = self.with_state(|s| s.workspaces.last().unwrap().id);
+        if let Some(color) = ws.color {
+            self.set_workspace_color(ws_id, Some(color));
+        }
         let (screen_id, pane_id) = self.with_state(|s| {
             let pane_id = s.pane_of(first_surface.id).unwrap();
             let (wi, si) = s.screen_of(pane_id).unwrap();
@@ -553,6 +556,7 @@ impl Mux {
                     active_pane: pane_id,
                 }],
                 active_screen: 0,
+                color: None,
             });
             state.active_workspace = state.workspaces.len() - 1;
         }
@@ -715,6 +719,7 @@ impl Mux {
                         active_pane: pane_id,
                     }],
                     active_screen: 0,
+                    color: None,
                 });
                 state.active_workspace = state.workspaces.len() - 1;
             }
@@ -964,6 +969,23 @@ impl Mux {
             self.emit(MuxEvent::TreeChanged);
         }
         renamed
+    }
+
+    pub fn set_workspace_color(&self, target: WorkspaceId, color: Option<Rgb>) -> bool {
+        let changed = {
+            let mut state = self.state.lock().unwrap();
+            match state.workspaces.iter_mut().find(|ws| ws.id == target) {
+                Some(ws) => {
+                    ws.color = color;
+                    true
+                }
+                None => false,
+            }
+        };
+        if changed {
+            self.emit(MuxEvent::TreeChanged);
+        }
+        changed
     }
 
     /// Set a pane's user-visible name. An empty name clears it (the pane
@@ -1470,6 +1492,7 @@ mod tests {
                     active_pane: p3,
                 }],
                 active_screen: 0,
+                color: None,
             }],
             active_workspace: 0,
             panes: HashMap::from([

--- a/mux/crates/mux-core/src/persist.rs
+++ b/mux/crates/mux-core/src/persist.rs
@@ -22,7 +22,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::model::{Node, Screen, State};
-use crate::{PaneId, SplitDir};
+use crate::{PaneId, Rgb, SplitDir};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 enum DirSnapshot {
@@ -103,6 +103,8 @@ struct WorkspaceSnapshot {
     name: String,
     screens: Vec<ScreenSnapshot>,
     active_screen: usize,
+    #[serde(default)]
+    color: Option<String>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -145,6 +147,7 @@ pub fn capture(state: &State) -> SessionSnapshot {
                 name: ws.name.clone(),
                 active_screen: ws.active_screen,
                 screens: ws.screens.iter().map(|screen| capture_screen(state, screen)).collect(),
+                color: ws.color.map(|c| format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b)),
             })
             .collect(),
     }
@@ -215,6 +218,7 @@ pub(crate) struct RestoreWorkspace<'a> {
     pub name: &'a str,
     pub screens: Vec<RestoreScreen<'a>>,
     pub active_screen: usize,
+    pub color: Option<Rgb>,
 }
 
 pub(crate) struct RestoreScreen<'a> {
@@ -251,6 +255,7 @@ pub(crate) fn workspaces(snapshot: &SessionSnapshot) -> (Vec<RestoreWorkspace<'_
         .map(|ws| RestoreWorkspace {
             name: &ws.name,
             active_screen: ws.active_screen,
+            color: ws.color.as_deref().and_then(|s| crate::server::parse_hex_color(s).ok()),
             screens: ws
                 .screens
                 .iter()
@@ -317,6 +322,7 @@ mod tests {
             workspaces: vec![WorkspaceSnapshot {
                 name: "work".into(),
                 active_screen: 0,
+                color: None,
                 screens: vec![ScreenSnapshot {
                     name: None,
                     active_pane_index: 1,

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -245,6 +245,13 @@ enum Command {
         workspace: WorkspaceId,
         name: String,
     },
+    /// `colour: Some(hex)` sets the workspace color; `colour: None` (an
+    /// explicit `null` or the key absent) clears it.
+    SetWorkspaceColor {
+        workspace: WorkspaceId,
+        #[serde(default)]
+        colour: Option<String>,
+    },
     ResizeSurface {
         surface: SurfaceId,
         cols: u16,
@@ -475,6 +482,7 @@ fn workspaces_json(state: &State) -> Value {
                 "id": ws.id,
                 "short_id": short_ids.get(&ws.id).cloned().unwrap_or_default(),
                 "name": ws.name,
+                "color": ws.color.map(|c| format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b)),
                 "active": i == state.active_workspace,
                 "screens": ws.screens.iter().enumerate().map(|(s, screen)| {
                     screen_json(state, screen, s == ws.active_screen, &short_ids)
@@ -514,7 +522,7 @@ fn require_browser(surface: &crate::Surface) -> anyhow::Result<()> {
     }
 }
 
-fn parse_hex_color(value: &str) -> anyhow::Result<Rgb> {
+pub(crate) fn parse_hex_color(value: &str) -> anyhow::Result<Rgb> {
     let bytes = value.as_bytes();
     if bytes.len() != 7 || bytes[0] != b'#' {
         anyhow::bail!("bad color {value:?} (want \"#rrggbb\")");
@@ -811,6 +819,16 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
         }
         Command::RenameWorkspace { workspace, name } => {
             if !mux.rename_workspace(workspace, name) {
+                anyhow::bail!("unknown workspace {workspace}");
+            }
+            Ok(json!({}))
+        }
+        Command::SetWorkspaceColor { workspace, colour } => {
+            let color = match colour {
+                Some(hex) => Some(parse_hex_color(&hex)?),
+                None => None,
+            };
+            if !mux.set_workspace_color(workspace, color) {
                 anyhow::bail!("unknown workspace {workspace}");
             }
             Ok(json!({}))

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -252,6 +252,14 @@ enum Command {
         #[serde(default)]
         colour: Option<String>,
     },
+    /// Emits a transient `flash` event to subscribers. `surface` is
+    /// advisory (not validated against the workspace) and just passed
+    /// through.
+    TriggerFlash {
+        workspace: WorkspaceId,
+        #[serde(default)]
+        surface: Option<SurfaceId>,
+    },
     ResizeSurface {
         surface: SurfaceId,
         cols: u16,
@@ -833,6 +841,12 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             }
             Ok(json!({}))
         }
+        Command::TriggerFlash { workspace, surface } => {
+            if !mux.trigger_flash(workspace, surface) {
+                anyhow::bail!("unknown workspace {workspace}");
+            }
+            Ok(json!({}))
+        }
         Command::ResizeSurface { surface, cols, rows } => {
             mux.resize_surface(surface, cols, rows)?;
             Ok(json!({}))
@@ -909,6 +923,11 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                             json!({"event": "title-changed", "surface": id})
                         }
                         MuxEvent::Bell(id) => json!({"event": "bell", "surface": id}),
+                        MuxEvent::Flash { workspace, surface } => json!({
+                            "event": "flash",
+                            "workspace": workspace,
+                            "surface": surface,
+                        }),
                         MuxEvent::Status(message) => {
                             json!({"event": "status", "message": message})
                         }

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -273,6 +273,16 @@ pub struct OmnibarState {
     pub select_all: bool,
 }
 
+/// How long a manual flash pulse stays visible.
+pub(crate) const FLASH_DURATION: Duration = Duration::from_millis(500);
+
+/// Whether a flash that started `elapsed` ago is still within its visible
+/// window. Takes the elapsed duration explicitly (rather than calling
+/// `Instant::now()` itself) so it's unit-testable without real sleeps.
+pub(crate) fn flash_active(elapsed: Duration) -> bool {
+    elapsed < FLASH_DURATION
+}
+
 pub struct Toast {
     pub text: String,
     deadline: Instant,
@@ -412,6 +422,10 @@ pub struct App {
     pub omnibar: Option<OmnibarState>,
     pub toast: Option<Toast>,
     pub(crate) shake_frames: u8,
+    /// Workspaces with an active manual flash pulse, keyed by when it
+    /// started. Checked (and lazily expired) in the sidebar render and
+    /// the event-loop poll timeout so the pulse disappears on its own.
+    pub(crate) flashing: HashMap<WorkspaceId, Instant>,
     pub selection: Option<Selection>,
     pub status_message: Option<String>,
     pub cell_pixels: (u16, u16),
@@ -658,6 +672,7 @@ pub fn run(session: Session, session_label: String) -> anyhow::Result<()> {
         omnibar: None,
         toast: None,
         shake_frames: 0,
+        flashing: HashMap::new(),
         selection: None,
         status_message: None,
         cell_pixels,
@@ -710,6 +725,7 @@ impl App {
             let timeout = if self.shake_frames > 0
                 || self.selection_auto_scroll_active()
                 || self.toast.is_some()
+                || self.has_active_flash()
             {
                 Duration::from_millis(30)
             } else {
@@ -726,6 +742,9 @@ impl App {
                         action = action.merge(RenderAction::Draw);
                     }
                     if self.expire_toast() {
+                        action = action.merge(RenderAction::Draw);
+                    }
+                    if self.expire_flashes() {
                         action = action.merge(RenderAction::Draw);
                     }
                     None
@@ -745,6 +764,9 @@ impl App {
                 break;
             }
             if self.expire_toast() {
+                action = action.merge(RenderAction::Draw);
+            }
+            if self.expire_flashes() {
                 action = action.merge(RenderAction::Draw);
             }
             match action {
@@ -936,6 +958,10 @@ impl App {
             AppEvent::Mux(MuxEvent::OscNotification { surface, title, body }) => {
                 let label = self.tree.tab_label(surface).unwrap_or_else(|| "cmux-mux".to_string());
                 crate::desktop_notify::send(&label, &title, &body);
+                Ok(RenderAction::Draw)
+            }
+            AppEvent::Mux(MuxEvent::Flash { workspace, .. }) => {
+                self.flashing.insert(workspace, Instant::now());
                 Ok(RenderAction::Draw)
             }
             AppEvent::Mux(_) => Ok(RenderAction::Draw),
@@ -2305,6 +2331,23 @@ impl App {
         }
     }
 
+    /// Whether any workspace currently has a flash pulse within its
+    /// visible window — used to keep the event-loop poll timeout short
+    /// enough that the pulse reliably disappears on its own.
+    fn has_active_flash(&self) -> bool {
+        let now = Instant::now();
+        self.flashing.values().any(|start| flash_active(now.duration_since(*start)))
+    }
+
+    /// Drops flash entries whose window has elapsed. Returns true if any
+    /// were dropped (i.e. a redraw is needed to visually clear them).
+    fn expire_flashes(&mut self) -> bool {
+        let now = Instant::now();
+        let before = self.flashing.len();
+        self.flashing.retain(|_, start| flash_active(now.duration_since(*start)));
+        self.flashing.len() != before
+    }
+
     /// Shift a pane's tab bar left/right. The renderer clamps to the
     /// valid range next frame.
     fn scroll_tabs(&mut self, pane: PaneId, delta: isize) {
@@ -2660,8 +2703,11 @@ fn browser_key_mapping(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::{
-        browser_content_size_for_rect, browser_hover_forward_allowed, pane_parts_for_rect,
+        browser_content_size_for_rect, browser_hover_forward_allowed, flash_active,
+        pane_parts_for_rect,
     };
     use crate::config::ScrollbarPosition;
     use mux_core::{BrowserStatus, Rect};
@@ -2701,5 +2747,17 @@ mod tests {
             false
         ));
         assert!(!browser_hover_forward_allowed(None, false));
+    }
+
+    #[test]
+    fn flash_active_within_window() {
+        assert!(flash_active(Duration::from_millis(0)));
+        assert!(flash_active(Duration::from_millis(499)));
+    }
+
+    #[test]
+    fn flash_active_expired_at_or_after_duration() {
+        assert!(!flash_active(Duration::from_millis(500)));
+        assert!(!flash_active(Duration::from_secs(2)));
     }
 }

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -188,6 +188,13 @@ const VERBS: &[VerbSpec] = &[
         stream: false,
     },
     VerbSpec {
+        name: "trigger-flash",
+        allowed: &["workspace", "surface"],
+        build: build_trigger_flash,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
         name: "resize-surface",
         allowed: &["surface", "cols", "rows"],
         build: build_resize_surface,
@@ -678,6 +685,13 @@ fn build_set_workspace_color(flags: &FlagMap) -> Result<Value, UsageError> {
     let colour = flags.required("colour")?;
     let colour = if colour.is_empty() { Value::Null } else { json!(colour) };
     Ok(json!({ "workspace": workspace, "colour": colour }))
+}
+
+fn build_trigger_flash(flags: &FlagMap) -> Result<Value, UsageError> {
+    let workspace = flags.required_u64("workspace")?;
+    let mut value = json!({ "workspace": workspace });
+    flags.insert_optional_u64(&mut value, "surface")?;
+    Ok(value)
 }
 
 fn build_resize_surface(flags: &FlagMap) -> Result<Value, UsageError> {

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -181,6 +181,13 @@ const VERBS: &[VerbSpec] = &[
         stream: false,
     },
     VerbSpec {
+        name: "set-workspace-color",
+        allowed: &["workspace", "colour"],
+        build: build_set_workspace_color,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
         name: "resize-surface",
         allowed: &["surface", "cols", "rows"],
         build: build_resize_surface,
@@ -662,6 +669,17 @@ fn build_rename_workspace(flags: &FlagMap) -> Result<Value, UsageError> {
     Ok(json!({ "workspace": flags.required_u64("workspace")?, "name": flags.required("name")? }))
 }
 
+/// `--colour` is required so an omitted flag never silently clears the
+/// workspace color (the wire command treats an absent/`null` `colour` as
+/// "clear"). An explicit empty value (`--colour ""`) is how you clear it;
+/// any non-empty value must be a `#rrggbb` hex string (validated server-side).
+fn build_set_workspace_color(flags: &FlagMap) -> Result<Value, UsageError> {
+    let workspace = flags.required_u64("workspace")?;
+    let colour = flags.required("colour")?;
+    let colour = if colour.is_empty() { Value::Null } else { json!(colour) };
+    Ok(json!({ "workspace": workspace, "colour": colour }))
+}
+
 fn build_resize_surface(flags: &FlagMap) -> Result<Value, UsageError> {
     Ok(json!({
         "surface": flags.required_u64("surface")?,
@@ -880,9 +898,10 @@ fn print_tree(data: &Value, out: &mut dyn Write) -> io::Result<()> {
         let workspace_id = id_field(workspace, "id");
         writeln!(
             out,
-            "workspace id={} name={} active={}",
+            "workspace id={} name={} color={} active={}",
             workspace_id,
             atom(workspace.get("name")),
+            atom(workspace.get("color")),
             bool_field(workspace, "active")
         )?;
         let Some(screens) = workspace.get("screens").and_then(Value::as_array) else {

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -752,7 +752,7 @@ fn load_raw_config() -> RawConfig {
 }
 
 /// `#rrggbb`, `#rgb`, or an xterm-256 index in a string.
-fn parse_color(s: &str) -> Option<Color> {
+pub(crate) fn parse_color(s: &str) -> Option<Color> {
     let s = s.trim();
     if let Some(hex) = s.strip_prefix('#') {
         return match hex.len() {

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -92,8 +92,8 @@ CLI VERBS
   new-browser-tab, new-workspace, new-screen, split, set-ratio,
   set-default-colors, close-surface, close-pane, close-screen,
   close-workspace, rename-pane, rename-surface, rename-screen,
-  rename-workspace, resize-surface, focus-pane, select-tab,
-  select-screen, select-workspace, move-tab, move-workspace,
+  rename-workspace, set-workspace-color, resize-surface, focus-pane,
+  select-tab, select-screen, select-workspace, move-tab, move-workspace,
   scroll-surface, subscribe, attach-surface, report-agent, list-agents,
   browser-reload
 

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -92,10 +92,10 @@ CLI VERBS
   new-browser-tab, new-workspace, new-screen, split, set-ratio,
   set-default-colors, close-surface, close-pane, close-screen,
   close-workspace, rename-pane, rename-surface, rename-screen,
-  rename-workspace, set-workspace-color, resize-surface, focus-pane,
-  select-tab, select-screen, select-workspace, move-tab, move-workspace,
-  scroll-surface, subscribe, attach-surface, report-agent, list-agents,
-  browser-reload
+  rename-workspace, set-workspace-color, trigger-flash, resize-surface,
+  focus-pane, select-tab, select-screen, select-workspace, move-tab,
+  move-workspace, scroll-surface, subscribe, attach-surface, report-agent,
+  list-agents, browser-reload
 
 CLAUDE CODE HOOK INTEGRATION
   cmux-mux claude install-hooks [--uninstall]

--- a/mux/crates/mux-tui/src/session/remote.rs
+++ b/mux/crates/mux-tui/src/session/remote.rs
@@ -360,6 +360,13 @@ impl RemoteSession {
                     self.emit(MuxEvent::Bell(id));
                 }
             }
+            Some("flash") => {
+                let Some(workspace) = value.get("workspace").and_then(|v| v.as_u64()) else {
+                    return;
+                };
+                let surface = value.get("surface").and_then(|v| v.as_u64());
+                self.emit(MuxEvent::Flash { workspace, surface });
+            }
             Some("status") => {
                 if let Some(message) = value.get("message").and_then(|v| v.as_str()) {
                     self.emit(MuxEvent::Status(message.to_string()));

--- a/mux/crates/mux-tui/src/session/tree.rs
+++ b/mux/crates/mux-tui/src/session/tree.rs
@@ -5,7 +5,10 @@ use mux_core::{
     assign_short_ids, AgentState, BrowserSource, Node, PaneId, ScreenId, SplitDir, State,
     SurfaceId, SurfaceKind, WorkspaceId,
 };
+use ratatui::style::Color;
 use serde_json::Value;
+
+use crate::config::parse_color;
 
 #[derive(Clone, Default)]
 pub struct TreeView {
@@ -18,6 +21,8 @@ pub struct WorkspaceView {
     pub id: WorkspaceId,
     pub short_id: String,
     pub name: String,
+    /// User-assigned sidebar rail color, if any.
+    pub color: Option<Color>,
     pub screens: Vec<ScreenView>,
     pub active_screen: usize,
 }
@@ -211,6 +216,7 @@ pub fn tree_from_state(state: &State) -> TreeView {
                 id: ws.id,
                 short_id: short_ids.get(&ws.id).cloned().unwrap_or_default(),
                 name: ws.name.clone(),
+                color: ws.color.map(|c| Color::Rgb(c.r, c.g, c.b)),
                 active_screen: ws.active_screen,
                 screens: ws
                     .screens
@@ -334,6 +340,7 @@ pub fn parse_tree(data: &Value) -> TreeView {
             id: ws.get("id").and_then(|v| v.as_u64()).unwrap_or(0),
             short_id: ws.get("short_id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
             name: ws.get("name").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+            color: ws.get("color").and_then(|v| v.as_str()).and_then(parse_color),
             screens: Vec::new(),
             active_screen: 0,
         };
@@ -350,4 +357,34 @@ pub fn parse_tree(data: &Value) -> TreeView {
         tree.workspaces.push(view);
     }
     tree
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_tree_reads_workspace_color_as_rgb() {
+        let data = json!({
+            "workspaces": [
+                {"id": 1, "name": "red", "color": "#ff0000", "active": true, "screens": []},
+                {"id": 2, "name": "none", "color": null, "active": false, "screens": []},
+            ]
+        });
+        let tree = parse_tree(&data);
+        assert_eq!(tree.workspaces[0].color, Some(Color::Rgb(0xff, 0x00, 0x00)));
+        assert_eq!(tree.workspaces[1].color, None);
+    }
+
+    #[test]
+    fn parse_tree_treats_missing_color_key_as_none() {
+        let data = json!({
+            "workspaces": [
+                {"id": 1, "name": "no-color-key", "active": true, "screens": []},
+            ]
+        });
+        let tree = parse_tree(&data);
+        assert_eq!(tree.workspaces[0].color, None);
+    }
 }

--- a/mux/crates/mux-tui/src/ui/sidebar.rs
+++ b/mux/crates/mux-tui/src/ui/sidebar.rs
@@ -26,6 +26,14 @@ fn agent_glyph_color(state: AgentState) -> Color {
     }
 }
 
+/// The sidebar rail glyph's color for a workspace, if it should be drawn
+/// at all. A user-assigned workspace color always wins (shown whether or
+/// not the workspace is active); otherwise the rail only shows, in the
+/// theme's color, when the workspace is active.
+fn rail_color(workspace_color: Option<Color>, active: bool, theme_rail: Color) -> Option<Color> {
+    workspace_color.or(if active { Some(theme_rail) } else { None })
+}
+
 pub fn draw(app: &mut App, frame: &mut Frame) {
     let area = frame.area();
     let width = app.sidebar_width;
@@ -77,14 +85,17 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
         if workspace_drag.is_some_and(|(id, _)| id == ws.id) {
             style = style.add_modifier(Modifier::DIM);
         }
-        // The active highlight paints the full rows, and the rail marks
-        // BOTH lines of the entry in the configured color.
+        // The active highlight paints the full rows. The rail marks BOTH
+        // lines of the entry: in the workspace's own color if it has one
+        // set (active or not), else in the theme color while active.
         if active {
             for x in 0..width - 1 {
                 buf[(x, y)].set_style(active_style);
                 buf[(x, y + 1)].set_style(active_style);
             }
-            let rail_style = active_style.fg(rail);
+        }
+        if let Some(color) = rail_color(ws.color, active, rail) {
+            let rail_style = (if active { active_style } else { base }).fg(color);
             buf[(0, y)].set_symbol("▎").set_style(rail_style);
             buf[(0, y + 1)].set_symbol("▎").set_style(rail_style);
         }
@@ -134,4 +145,27 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
     }
     hits.push((Rect { x: width - 1, y: 0, width: 1, height }, Hit::SidebarResize));
     app.hits.extend(hits);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const THEME_RAIL: Color = Color::Indexed(1);
+
+    #[test]
+    fn rail_color_prefers_workspace_color_whether_active_or_not() {
+        assert_eq!(rail_color(Some(Color::Red), false, THEME_RAIL), Some(Color::Red));
+        assert_eq!(rail_color(Some(Color::Red), true, THEME_RAIL), Some(Color::Red));
+    }
+
+    #[test]
+    fn rail_color_falls_back_to_theme_color_when_active_without_workspace_color() {
+        assert_eq!(rail_color(None, true, THEME_RAIL), Some(THEME_RAIL));
+    }
+
+    #[test]
+    fn rail_color_hidden_when_inactive_without_workspace_color() {
+        assert_eq!(rail_color(None, false, THEME_RAIL), None);
+    }
 }

--- a/mux/crates/mux-tui/src/ui/sidebar.rs
+++ b/mux/crates/mux-tui/src/ui/sidebar.rs
@@ -7,12 +7,14 @@
 //! status-bar row (the status bar starts after the sidebar). Rebuilds
 //! the click hit map as it draws.
 
+use std::time::Instant;
+
 use mux_core::{AgentState, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::Frame;
 
 use super::truncate;
-use crate::app::{App, Hit};
+use crate::app::{flash_active, App, Hit};
 
 /// Color for the sidebar's agent-state dot. `Working`/`Blocked` are the
 /// two states worth a glance (busy vs. needs you); `Idle`/`Done`/`Unknown`
@@ -34,6 +36,12 @@ fn rail_color(workspace_color: Option<Color>, active: bool, theme_rail: Color) -
     workspace_color.or(if active { Some(theme_rail) } else { None })
 }
 
+/// Bright, fixed pulse color for a manual flash — deliberately ignores
+/// the workspace's own color/active state so it reads as "look here"
+/// regardless of context. Layered on top of `rail_color`'s result, not a
+/// replacement for it.
+const FLASH_COLOR: Color = Color::White;
+
 pub fn draw(app: &mut App, frame: &mut Frame) {
     let area = frame.area();
     let width = app.sidebar_width;
@@ -46,6 +54,7 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
     let workspace_drag = app.workspace_drag();
     let buf = frame.buffer_mut();
 
+    let now = Instant::now();
     let base = Style::default();
     let dim = base.fg(Color::Indexed(242));
     let active_style = Style::default()
@@ -81,6 +90,8 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
             break;
         }
         let active = i == app.tree.active_workspace;
+        let flashing =
+            app.flashing.get(&ws.id).is_some_and(|start| flash_active(now.duration_since(*start)));
         let mut style = if active { active_style } else { base };
         if workspace_drag.is_some_and(|(id, _)| id == ws.id) {
             style = style.add_modifier(Modifier::DIM);
@@ -94,7 +105,9 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
                 buf[(x, y + 1)].set_style(active_style);
             }
         }
-        if let Some(color) = rail_color(ws.color, active, rail) {
+        let rail_pulse =
+            if flashing { Some(FLASH_COLOR) } else { rail_color(ws.color, active, rail) };
+        if let Some(color) = rail_pulse {
             let rail_style = (if active { active_style } else { base }).fg(color);
             buf[(0, y)].set_symbol("▎").set_style(rail_style);
             buf[(0, y + 1)].set_symbol("▎").set_style(rail_style);

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -173,6 +173,60 @@ fn report_agent_and_list_agents_round_trip() {
     assert_eq!(bad.status.code(), Some(1));
 }
 
+#[test]
+fn set_workspace_color_sets_and_clears() {
+    let server = HeadlessServer::start("workspace-color");
+
+    let list = cli(&server, &["--json", "list-workspaces"]);
+    assert_success(&list);
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    let workspace_id = value["workspaces"][0]["id"].as_u64().unwrap();
+    assert_eq!(value["workspaces"][0]["color"], serde_json::Value::Null);
+
+    let set = cli(
+        &server,
+        &["set-workspace-color", "--workspace", &workspace_id.to_string(), "--colour", "#ff8800"],
+    );
+    assert_success(&set);
+    assert!(set.stdout.is_empty(), "set-workspace-color should be quiet on success");
+
+    let list = cli(&server, &["--json", "list-workspaces"]);
+    assert_success(&list);
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(value["workspaces"][0]["color"].as_str(), Some("#ff8800"));
+
+    // Plain (non-JSON) output surfaces the color too.
+    let plain = cli(&server, &["list-workspaces"]);
+    assert_success(&plain);
+    let text = String::from_utf8(plain.stdout).unwrap();
+    assert!(
+        text.lines().next().unwrap().contains("color=\"#ff8800\""),
+        "expected color in plain output, got: {text}"
+    );
+
+    // An explicit empty value clears it.
+    let clear = cli(
+        &server,
+        &["set-workspace-color", "--workspace", &workspace_id.to_string(), "--colour", ""],
+    );
+    assert_success(&clear);
+    let list = cli(&server, &["--json", "list-workspaces"]);
+    assert_success(&list);
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    assert_eq!(value["workspaces"][0]["color"], serde_json::Value::Null);
+
+    // Omitting --colour entirely is a usage error, not a silent clear.
+    let missing = cli(&server, &["set-workspace-color", "--workspace", &workspace_id.to_string()]);
+    assert_eq!(missing.status.code(), Some(2));
+
+    // A malformed hex value is rejected by the server.
+    let bad = cli(
+        &server,
+        &["set-workspace-color", "--workspace", &workspace_id.to_string(), "--colour", "nope"],
+    );
+    assert_eq!(bad.status.code(), Some(1));
+}
+
 fn assert_subscribe_reports_tree_changed(server: &HeadlessServer) {
     let mut child = Command::new(bin())
         .args(["--socket"])

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -70,6 +70,8 @@ The generated CLI requires one of `--index` or `--delta` for `select-tab`, `sele
 | `rename-surface` | implemented | `--surface <id> --name <name>` | none | none |
 | `rename-screen` | implemented | `--screen <id> --name <name>` | none | none |
 | `rename-workspace` | implemented | `--workspace <id> --name <name>` | none | none |
+| `set-workspace-color` | implemented | `--workspace <id> --colour <hex>` | none | none |
+| `trigger-flash` | implemented | `--workspace <id>` | `--surface <id>` | none |
 | `resize-surface` | implemented | `--surface <id> --cols <n> --rows <n>` | none | none |
 | `focus-pane` | implemented | `--pane <id>` | none | none |
 | `select-tab` | implemented | one of `--index`, `--delta` | `--pane <id>` | none |

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -70,7 +70,7 @@ The generated CLI requires one of `--index` or `--delta` for `select-tab`, `sele
 | `rename-surface` | implemented | `--surface <id> --name <name>` | none | none |
 | `rename-screen` | implemented | `--screen <id> --name <name>` | none | none |
 | `rename-workspace` | implemented | `--workspace <id> --name <name>` | none | none |
-| `set-workspace-color` | implemented | `--workspace <id> --colour <hex>` | none | none |
+| `set-workspace-color` | implemented | `--workspace <id> --colour <hex-or-empty-string>` | none | none |
 | `trigger-flash` | implemented | `--workspace <id>` | `--surface <id>` | none |
 | `resize-surface` | implemented | `--surface <id> --cols <n> --rows <n>` | none | none |
 | `focus-pane` | implemented | `--pane <id>` | none | none |

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -1053,7 +1053,7 @@ Params:
 | Name | JSON type | Required/default | Constraints |
 | --- | --- | --- | --- |
 | `workspace` | `Id` | required | Must identify a live workspace |
-| `colour` | `ColorHex \| null` | required | Field should be present in the request; `null` clears the color, a `ColorHex` string sets it |
+| `colour` | `ColorHex \| null` | optional (default: `null`) | Absent or `null` clears the color, a `ColorHex` string sets it. The CLI always sends the key explicitly (see CLI mapping below), but the wire protocol itself does not require it. |
 
 Result:
 

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -1,6 +1,6 @@
 # Command Contract
 
-This file specifies the JSON command contract for the cmux-mux protocol. Implemented commands match protocol v5 in `mux/crates/mux-core/src/server.rs`. Proposed commands are future protocol v6 design.
+This file specifies the JSON command contract for the cmux-mux protocol. Implemented commands match protocol v6 in `mux/crates/mux-core/src/server.rs`. Proposed commands are future protocol v7 design.
 
 ## Notation
 

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -40,6 +40,7 @@ object{
   workspaces: array<object{
     id: Id,
     name: string,
+    color: ColorHex|null,
     active: boolean,
     screens: array<object{
       id: Id,
@@ -164,7 +165,7 @@ Example:
 
 ```json
 {"id":2,"cmd":"list-workspaces"}
-{"id":2,"ok":true,"data":{"workspaces":[{"id":4,"name":"1","active":true,"screens":[{"id":3,"name":null,"active":true,"active_pane":2,"layout":{"type":"leaf","pane":2},"panes":[{"id":2,"name":null,"active_tab":0,"tabs":[{"surface":1,"kind":"pty","browser_source":null,"name":null,"title":"","size":{"cols":80,"rows":24},"dead":false}]}]}]}]}}
+{"id":2,"ok":true,"data":{"workspaces":[{"id":4,"name":"1","color":null,"active":true,"screens":[{"id":3,"name":null,"active":true,"active_pane":2,"layout":{"type":"leaf","pane":2},"panes":[{"id":2,"name":null,"active_tab":0,"tabs":[{"surface":1,"kind":"pty","browser_source":null,"name":null,"title":"","size":{"cols":80,"rows":24},"dead":false}]}]}]}]}}
 ```
 
 ### send
@@ -1035,6 +1036,110 @@ Example:
 ```json
 {"id":20,"cmd":"rename-workspace","workspace":4,"name":"prod"}
 {"id":20,"ok":true,"data":{}}
+```
+
+### set-workspace-color
+
+| Field | Value |
+| --- | --- |
+| name | `set-workspace-color` |
+| status | implemented |
+| since | protocol 6 |
+
+Sets or clears a workspace's rail color. An explicit `ColorHex` in `colour` sets the workspace color to that value. `colour: null` clears it back to no color; an absent `colour` key has the same effect as `null` at the protocol level (serde default), but the CLI always sends the key explicitly and requires `--colour` so an omitted flag is a usage error rather than a silent clear (see `cli.md`).
+
+Params:
+
+| Name | JSON type | Required/default | Constraints |
+| --- | --- | --- | --- |
+| `workspace` | `Id` | required | Must identify a live workspace |
+| `colour` | `ColorHex \| null` | required | Field should be present in the request; `null` clears the color, a `ColorHex` string sets it |
+
+Result:
+
+```text
+object{}
+```
+
+Errors:
+
+| Error | Condition |
+| --- | --- |
+| `unknown workspace <id>` | Workspace id does not exist |
+| `bad color "<value>" (want "#rrggbb")` | `colour` is non-null and not exactly `#rrggbb` |
+| `bad request: ...` | Missing `workspace` or wrong JSON type |
+
+CLI mapping:
+
+| Item | Value |
+| --- | --- |
+| Verb | `set-workspace-color` |
+| Flags | `--workspace <id> --colour <hex-or-empty-string>` |
+| Plain stdout | no output |
+| JSON stdout | exact result object |
+| Exit codes | common |
+
+The CLI requires `--colour`; an empty string (`--colour ""`) sends `colour:null` to clear the color, and any non-empty value is sent through as-is for the server to validate.
+
+Example:
+
+```json
+{"id":29,"cmd":"set-workspace-color","workspace":4,"colour":"#ff8800"}
+{"id":29,"ok":true,"data":{}}
+```
+
+Clearing a color sends `colour:null` instead:
+
+```json
+{"id":30,"cmd":"set-workspace-color","workspace":4,"colour":null}
+{"id":30,"ok":true,"data":{}}
+```
+
+### trigger-flash
+
+| Field | Value |
+| --- | --- |
+| name | `trigger-flash` |
+| status | implemented |
+| since | protocol 6 |
+
+Emits a transient `flash` event to subscribers for a workspace, intended to draw attention to it (e.g. a sidebar pulse). `surface`, when present, is advisory only — it is passed straight through in the event and not validated against the workspace's own surfaces.
+
+Params:
+
+| Name | JSON type | Required/default | Constraints |
+| --- | --- | --- | --- |
+| `workspace` | `Id` | required | Must identify a live workspace |
+| `surface` | `Id` | default null | Advisory only; not validated against `workspace` |
+
+Result:
+
+```text
+object{}
+```
+
+Errors:
+
+| Error | Condition |
+| --- | --- |
+| `unknown workspace <id>` | Workspace id does not exist |
+| `bad request: ...` | Missing `workspace` or wrong JSON type |
+
+CLI mapping:
+
+| Item | Value |
+| --- | --- |
+| Verb | `trigger-flash` |
+| Flags | `--workspace <id> [--surface <id>]` |
+| Plain stdout | no output |
+| JSON stdout | exact result object |
+| Exit codes | common |
+
+Example:
+
+```json
+{"id":31,"cmd":"trigger-flash","workspace":4,"surface":1}
+{"id":31,"ok":true,"data":{}}
 ```
 
 ### resize-surface

--- a/mux/spec/events.md
+++ b/mux/spec/events.md
@@ -6,7 +6,7 @@ Implemented event lines can appear on two stream types:
 
 | Stream | How to start | Event names |
 | --- | --- | --- |
-| Subscribe stream | `subscribe` command | `tree-changed`, `surface-output`, `surface-resized`, `surface-exited`, `title-changed`, `bell`, `empty` |
+| Subscribe stream | `subscribe` command | `tree-changed`, `surface-output`, `surface-resized`, `surface-exited`, `title-changed`, `bell`, `flash`, `empty` |
 | Attach stream v5 | `attach-surface` command | `vt-state`, `output`, `detached` |
 | Attach stream v6 | `attach-surface` command | `vt-state`, `resized`, `output`, `detached` |
 
@@ -160,6 +160,31 @@ Example:
 
 ```json
 {"event":"bell","surface":1}
+```
+
+### flash
+
+| Field | Value |
+| --- | --- |
+| event | `flash` |
+| status | implemented |
+| since | protocol 6 |
+
+Payload:
+
+```text
+object{event:"flash",workspace:WorkspaceId,surface:Id|null}
+```
+
+Meaning: A manual flash was triggered for a workspace via the
+`trigger-flash` command, for frontends to render a transient visual
+pulse. `surface` is advisory context about which surface triggered it,
+if any -- not validated against the workspace.
+
+Example:
+
+```json
+{"event":"flash","workspace":4,"surface":9}
 ```
 
 ### empty


### PR DESCRIPTION
## Summary

Adds two small, independent features to cmux-mux, following the existing `rename-workspace`/`set-default-colors` code shape closely:

1. **Per-workspace colour** — `Workspace.color: Option<Rgb>`, a `set-workspace-color` command/CLI verb, persisted across restarts, surfaced in `list-workspaces --json`, rendered as the sidebar rail colour.
2. **Manual flash trigger** — a `trigger-flash` command/CLI verb, a new `MuxEvent::Flash` broadcast (including remote-session wire translation), and a self-clearing 500ms white pulse in the sidebar.

## Process

Built by a lead + 3 specialist agents (core data model, CLI+UI, flash), dispatched sequentially since they share `server.rs`/`mux.rs`. Each specialist's diff was reviewed and `cargo check`'d before the next started.

Reviewed independently three ways after the build: manual review, GLM-5.2 (via ClinePass), and Gemini (via Antigravity). All three agreed the implementation is correct — persistence round-trip, hex-parsing safety, flash self-clear logic, and convention adherence all checked out. One apparent bug (Gemini: possible panic in `Instant::duration_since` on backward clock movement) was empirically disproven with a standalone test — it saturates to `Duration::ZERO` rather than panicking. Three small doc gaps GLM-5.2 found (missing `flash` entry in `spec/events.md`, a `required`-vs-optional label mismatch, and a `cli.md`/`commands.md` notation inconsistency) were fixed.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace` — 161 tests, 0 failures, 0 warnings
- [x] `spec/cli.md`, `spec/commands.md`, `spec/events.md` all updated and cross-checked field-by-field against the implementation
- [ ] Human eyeball on the flash duration (500ms) and pulse colour (fixed white) — these are subjective UX calls the specialist made independently, worth a second look before merge

🤖 Generated with a pifactory cmux-mux fleet (lead + specialist agents, visible in real cmux-mux panes) — see the session for the full build/review trail.