### PR TITLE
feat(mux-tui): add Grok CLI agent hook integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ cargo build                      # builds everything via the zig-cc shim
 
 ## LLM harness hooks (under `mux/crates/mux-tui/src/`)
 
-The four binary subcommands `antigravity`, `codex`, `pi`, `aider` (and the existing `claude` on main) all install hooks by reading a config file (or writing a wrapper/extension), merging in our entries, and writing it back. They share parsing/writing helpers and a `--uninstall`/`--global` flag pair.
+The binary subcommands `antigravity`, `codex`, `grok`, `pi`, `aider` (and the existing `claude` on main) all install hooks by reading a config file (or writing a wrapper/extension), merging in our entries, and writing it back. They share parsing/writing helpers and a `--uninstall`/`--global` flag pair.
 
 **Editing one of these files?** Consider a refactor PR first — there's substantial duplication across them (load-or-default JSON, write-pretty, `--uninstall`/`--global` parse, the `CMUX-START`/`CMUX-END` block rewriter). A `hook_merge` module with `load_or_default<T>`, `save_pretty<T>`, `parse_flags(&[String]) -> (bool, bool)`, and `replace_marked_block(path, start, end, content)` would collapse ~200 lines of duplication.
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,13 @@ cmux aider install-hooks --uninstall
 ```
 *Note: For the local wrapper, ensure `.bin/` is prepended to your `$PATH` or call `./.bin/aider` directly.*
 
+#### 6. Grok CLI
+```bash
+cmux grok install-hooks            # installs workspace-level hooks in .grok/hooks.json
+cmux grok install-hooks --global   # installs global hooks in ~/.grok/hooks.json
+cmux grok install-hooks --uninstall
+```
+
 ## Documentation
 
 The full multiplexer docs live in [`mux/docs/`](./mux/docs/) — still accurate here since `mux/` was vendored

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ What's missing before this feels like `cmux` rather than a bare multiplexer:
    every lifecycle event (merged alongside any hooks already there, safely
    idempotent). It reports agent state over `report-agent`/`list-agents`
    (`crates/mux-tui/src/claude_hook.rs`) and records sessions to
-   `$XDG_STATE_HOME/cmux-mux/claude-sessions.json` for `cmux claude sessions`
+   `$XDG_STATE_HOME/cmux/claude-sessions.json` for `cmux claude sessions`
    / `cmux claude resume <session-id>`.
 3. ~~Agent-state notifications (OSC 9/99/777 → desktop notification)~~ — done.
    Every pane's raw output is watched for an OSC 9, OSC 777, or kitty-protocol
@@ -101,7 +101,7 @@ What's missing before this feels like `cmux` rather than a bare multiplexer:
 4. ~~Session persistence across daemon restarts~~ — done. Every session
    (headless or local TUI) debounce-writes a snapshot of its workspace/screen/
    pane layout — split shape+ratios, names, each tab's cwd, active selections —
-   to `$XDG_STATE_HOME/cmux-mux/sessions/<session>.json`
+   to `$XDG_STATE_HOME/cmux/sessions/<session>.json`
    (`crates/mux-core/src/persist.rs`), and replays it on next start with the
    same `--session` name. Closing every workspace deletes the file instead of
    leaving something to resurrect later. Deliberately not restored: a tab's

--- a/mux/bindings/conformance/fixtures.json
+++ b/mux/bindings/conformance/fixtures.json
@@ -7,7 +7,7 @@
         {
           "type": "command",
           "request": { "id": 1, "cmd": "identify" },
-          "expect": { "id": 1, "ok": true, "data": { "app": "cmux-mux", "protocol": 5 } },
+          "expect": { "id": 1, "ok": true, "data": { "app": "cmux", "protocol": 5 } },
           "match": "partial"
         }
       ]

--- a/mux/bindings/python/cmux_mux_client/client.py
+++ b/mux/bindings/python/cmux_mux_client/client.py
@@ -462,7 +462,7 @@ class MuxClient:
 
 def default_socket_path(session: str) -> str:
     base = os.environ.get("TMPDIR") or tempfile.gettempdir()
-    return os.path.join(base, f"cmux-mux-{os.getuid()}", f"{session}.sock")
+    return os.path.join(base, f"cmux-{os.getuid()}", f"{session}.sock")
 
 
 def _parse_tree(data: Dict[str, Any]) -> Tree:

--- a/mux/bindings/styles/python.md
+++ b/mux/bindings/styles/python.md
@@ -11,7 +11,7 @@ Requirements:
 - Method names are snake_case and map 1:1 to implemented command names.
 - Preserve server error strings in `CommandError`.
 - Distinguish command errors, connection errors, protocol errors, and timeouts.
-- Resolve the default socket as `$TMPDIR/cmux-mux-<uid>/<session>.sock`, with explicit socket path override.
+- Resolve the default socket as `$TMPDIR/cmux-<uid>/<session>.sock`, with explicit socket path override.
 - Use separate sockets for command requests, subscribe streams, and attach streams.
 - Provide `MuxClient.request(cmd, **params) -> dict` as the raw JSON response entry point.
 - Implement `subscribe()` as an iterator over event objects.

--- a/mux/crates/mux-core/src/platform.rs
+++ b/mux/crates/mux-core/src/platform.rs
@@ -110,16 +110,8 @@ pub mod transport {
 }
 
 /// Runtime socket/pidfile directory for the current user.
-///
-/// Kept as `cmux-mux-<uid>` (not renamed to match the `cmux` binary) so an
-/// already-running daemon's socket path doesn't move out from under any
-/// client that computes it independently. Same reasoning applies to every
-/// other path literal below (session snapshots, chrome-profile dirs) and to
-/// `claude_hook.rs`'s `claude-sessions.json` path and `remote_pty.rs`'s
-/// remote-side cache path — these are on-disk paths with existing data,
-/// not CLI-visible text, so the binary rename doesn't touch them.
 pub fn runtime_dir() -> PathBuf {
-    runtime_base_dir().join(format!("cmux-mux-{}", user_id_component()))
+    runtime_base_dir().join(format!("cmux-{}", user_id_component()))
 }
 
 /// Where a session's persisted tree snapshot lives, honoring the XDG
@@ -129,7 +121,7 @@ pub fn session_snapshot_path(session: &str) -> PathBuf {
     let base = env_path("XDG_STATE_HOME")
         .or_else(|| home_dir().map(|home| home.join(".local").join("state")))
         .unwrap_or_else(std::env::temp_dir);
-    base.join("cmux-mux").join("sessions").join(format!("{session}.json"))
+    base.join("cmux").join("sessions").join(format!("{session}.json"))
 }
 
 /// User config file path, honoring the XDG override order.
@@ -285,32 +277,32 @@ pub fn chrome_user_data_dir() -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
         home_dir().map(|home| {
-            home.join("Library").join("Application Support").join("cmux-mux").join("chrome-profile")
+            home.join("Library").join("Application Support").join("cmux").join("chrome-profile")
         })
     }
 
     #[cfg(target_os = "linux")]
     {
         env_path("XDG_DATA_HOME")
-            .map(|data_home| data_home.join("cmux-mux").join("chrome-profile"))
+            .map(|data_home| data_home.join("cmux").join("chrome-profile"))
             .or_else(|| {
                 home_dir().map(|home| {
-                    home.join(".local").join("share").join("cmux-mux").join("chrome-profile")
+                    home.join(".local").join("share").join("cmux").join("chrome-profile")
                 })
             })
     }
 
     #[cfg(windows)]
     {
-        env_path("LOCALAPPDATA").map(|dir| dir.join("cmux-mux").join("chrome-profile"))
+        env_path("LOCALAPPDATA").map(|dir| dir.join("cmux").join("chrome-profile"))
     }
 
     #[cfg(all(not(target_os = "macos"), not(target_os = "linux"), not(windows)))]
     {
-        env_path("XDG_DATA_HOME").map(|dir| dir.join("cmux-mux").join("chrome-profile")).or_else(
+        env_path("XDG_DATA_HOME").map(|dir| dir.join("cmux").join("chrome-profile")).or_else(
             || {
                 home_dir().map(|home| {
-                    home.join(".local").join("share").join("cmux-mux").join("chrome-profile")
+                    home.join(".local").join("share").join("cmux").join("chrome-profile")
                 })
             },
         )

--- a/mux/crates/mux-core/src/remote_pty.rs
+++ b/mux/crates/mux-core/src/remote_pty.rs
@@ -24,7 +24,7 @@
 //! is that closing it locally doesn't kill the remote session), and
 //! `pty.close` (actually kills it — not currently exposed by any verb; a
 //! stale remote session needs manual cleanup, e.g. deleting
-//! `~/.cache/cmux-mux/cmuxd-remote` and `~/.cmux/daemon/` on the remote).
+//! `~/.cache/cmux/cmuxd-remote` and `~/.cmux/daemon/` on the remote).
 //!
 //! `cmuxd-remote serve --stdio --persistent --slot <slot>` is what makes
 //! the remote shell outlive both an SSH disconnect and this local process
@@ -63,7 +63,7 @@ pub struct RemoteSpec {
     pub session_id: String,
     /// Local path to a `cmuxd-remote` binary built for the *remote*
     /// host's OS/arch. Uploaded (once, hash-checked) to
-    /// `~/.cache/cmux-mux/cmuxd-remote` on the remote if missing or
+    /// `~/.cache/cmux/cmuxd-remote` on the remote if missing or
     /// stale. Building this is deliberately not this module's job — it
     /// needs a Go toolchain and knowledge of where the vendored source
     /// lives, both of which belong to the frontend, not this library.
@@ -71,7 +71,7 @@ pub struct RemoteSpec {
 }
 
 pub fn generate_session_id() -> String {
-    format!("cmux-mux-{}", random_token())
+    format!("cmux-{}", random_token())
 }
 
 fn random_token() -> String {
@@ -110,9 +110,9 @@ pub fn open_remote_pty(spec: &RemoteSpec, size: PtySize) -> anyhow::Result<PtyPa
 /// unquoted, and every use of this path in an exec'd command string goes
 /// through [`shell_quote`] for safety against paths/slots with spaces or
 /// quotes, which would otherwise silently defeat tilde expansion.
-const REMOTE_BIN_PATH: &str = ".cache/cmux-mux/cmuxd-remote";
+const REMOTE_BIN_PATH: &str = ".cache/cmux/cmuxd-remote";
 
-/// Uploads `local_binary_path` to `$HOME/.cache/cmux-mux/cmuxd-remote` on
+/// Uploads `local_binary_path` to `$HOME/.cache/cmux/cmuxd-remote` on
 /// `host` unless a copy with the same SHA-256 is already there. Returns
 /// the remote path (relative to `$HOME`).
 fn ensure_uploaded(host: &str, local_binary_path: &std::path::Path) -> anyhow::Result<String> {

--- a/mux/crates/mux-tui/src/browser_input.rs
+++ b/mux/crates/mux-tui/src/browser_input.rs
@@ -70,7 +70,7 @@ pub enum BrowserInputKind {
 }
 
 /// Reads the desktop clipboard by shelling out to whichever clipboard tool
-/// is available, since cmux-mux (unlike the outer terminal) has no direct
+/// is available, since cmux (unlike the outer terminal) has no direct
 /// clipboard API of its own - it only ever *writes* the clipboard, via
 /// OSC52. Tries Wayland's `wl-paste` first, then X11's `xclip`; returns
 /// `None` (not an error) if neither is installed or the clipboard is

--- a/mux/crates/mux-tui/src/claude_hook.rs
+++ b/mux/crates/mux-tui/src/claude_hook.rs
@@ -125,7 +125,7 @@ fn send_request(cmd: &str, mut params: Value) -> Option<Value> {
 }
 
 // ---------- session store ----------
-// `$XDG_STATE_HOME/cmux-mux/claude-sessions.json`, most-recent-first,
+// `$XDG_STATE_HOME/cmux/claude-sessions.json`, most-recent-first,
 // deduplicated by session_id, capped at MAX_SESSIONS. Locked with flock
 // for the read-modify-write since multiple panes' hooks can fire
 // concurrently.
@@ -145,7 +145,7 @@ fn store_path() -> PathBuf {
         .map(PathBuf::from)
         .or_else(|| mux_core::platform::home_dir().map(|home| home.join(".local").join("state")))
         .unwrap_or_else(|| PathBuf::from("/tmp"));
-    base.join("cmux-mux").join("claude-sessions.json")
+    base.join("cmux").join("claude-sessions.json")
 }
 
 fn now_ms() -> u64 {
@@ -596,7 +596,7 @@ mod tests {
         // Regression test: reinstalling after the binary moved/was renamed
         // (a different absolute path, same `claude hook` command) must
         // replace the stale entry, not add a second one alongside it - this
-        // is exactly what happened live when cmux-mux was renamed to cmux
+        // is exactly what happened live when the binary was renamed to cmux
         // and the old absolute path stopped existing.
         let _guard = ENV_LOCK.lock().unwrap();
         let dir = temp_state_dir("install-stale-path");
@@ -604,7 +604,7 @@ mod tests {
         std::fs::create_dir_all(&claude_dir).unwrap();
         std::fs::write(
             claude_dir.join("settings.json"),
-            r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/old/deleted/path/cmux-mux claude hook"}]}]}}"#,
+            r#"{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/old/deleted/path/cmux claude hook"}]}]}}"#,
         )
         .unwrap();
         std::env::set_var("HOME", &dir);

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -19,7 +19,7 @@
 //!     "min_width": 7,
 //!     "solid_background": true,
 //!     "show_titles": false,
-//!     "agents": ["claude", "codex", "opencode", "pi"]
+//!     "agents": ["claude", "codex", "grok", "opencode", "pi"]
 //!   },
 //!   "sidebar": {
 //!     "width": 22,
@@ -236,7 +236,7 @@ impl Default for Tabs {
             min_width: 7,
             solid_background: true,
             show_titles: false,
-            agents: ["claude", "codex", "opencode", "pi"].map(String::from).to_vec(),
+            agents: ["claude", "codex", "grok", "opencode", "pi"].map(String::from).to_vec(),
         }
     }
 }

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -30,7 +30,7 @@
 //!     "cdp_url": "http://127.0.0.1:9222",
 //!     "discover": false,
 //!     "discover_ports": [9222],
-//!     "user_data_dir": "/Users/me/Library/Application Support/cmux-mux/chrome-profile",
+//!     "user_data_dir": "/Users/me/Library/Application Support/cmux/chrome-profile",
 //!     "ephemeral": false,
 //!     "max_capture_megapixels": 2.0,
 //!     "capture_scale": null

--- a/mux/crates/mux-tui/src/grok_hook.rs
+++ b/mux/crates/mux-tui/src/grok_hook.rs
@@ -176,6 +176,20 @@ fn run_install_skill(uninstall: bool, global: bool) -> i32 {
         if let Some(parent) = path.parent() {
             let _ = fs::create_dir_all(parent);
         }
+        // Refuse to overwrite a symlink: same rationale as claude_hook.rs
+        // (PR #18 / issue #10 hardening) and aider_hook.rs (PR #3) — fs::write
+        // on a symlink path overwrites the symlink target, not the symlink
+        // itself. An attacker-placed symlink in a user-writable target path
+        // could redirect the write to an arbitrary file.
+        if let Ok(meta) = fs::symlink_metadata(&path) {
+            if meta.file_type().is_symlink() {
+                eprintln!(
+                    "error: refusing to overwrite symlink at {}.                      Remove it manually if you want to install the skill.",
+                    path.display()
+                );
+                return 1;
+            }
+        }
         if let Err(e) = fs::write(&path, crate::skill_content::ORCHESTRATION_SKILL) {
             eprintln!("error writing {}: {e}", path.display());
             return 1;

--- a/mux/crates/mux-tui/src/grok_hook.rs
+++ b/mux/crates/mux-tui/src/grok_hook.rs
@@ -1,0 +1,209 @@
+use std::fs;
+use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
+
+use crate::hook_merge;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct GrokHook {
+    pub event: String,
+    pub command: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct GrokHooksConfig {
+    #[serde(default)]
+    pub hooks: Vec<GrokHook>,
+}
+
+fn config_path(global: bool) -> Option<PathBuf> {
+    if global {
+        mux_core::platform::home_dir().map(|h| h.join(".grok").join("hooks.json"))
+    } else {
+        Some(PathBuf::from(".grok").join("hooks.json"))
+    }
+}
+
+pub fn run(args: &[String]) -> i32 {
+    let mut uninstall = false;
+    let mut global = false;
+    
+    for arg in args.iter().skip(1) {
+        if arg == "--uninstall" {
+            uninstall = true;
+        } else if arg == "--global" {
+            global = true;
+        }
+    }
+
+    match args.first().map(String::as_str) {
+        Some("install-hooks") => run_install(uninstall, global),
+        Some("install-skill") => run_install_skill(uninstall, global),
+        _ => {
+            eprintln!("cmux: usage: cmux grok <install-hooks|install-skill> [--uninstall] [--global]");
+            2
+        }
+    }
+}
+
+fn run_install(uninstall: bool, global: bool) -> i32 {
+    let Some(path) = config_path(global) else {
+        eprintln!("error: could not resolve home directory for global hooks");
+        return 1;
+    };
+
+    if uninstall {
+        let mut config: GrokHooksConfig = match hook_merge::load_json(&path) {
+            Ok(c) => c,
+            Err(hook_merge::LoadError::NotFound) => {
+                println!("No Grok hooks file found at {}", path.display());
+                return 0;
+            }
+            Err(hook_merge::LoadError::Parse(e)) => {
+                eprintln!(
+                    "error: malformed Grok config at {}: {e}",
+                    path.display()
+                );
+                return 1;
+            }
+            Err(hook_merge::LoadError::Io(e)) => {
+                eprintln!("error reading {}: {e}", path.display());
+                return 1;
+            }
+        };
+        config.hooks.retain(|h| !h.command.contains("cmux report-agent"));
+
+        if let Err(e) = hook_merge::save_pretty(&path, &config) {
+            match e {
+                hook_merge::SaveError::Serialize(e) => {
+                    eprintln!("error: failed to serialize config: {e}");
+                    return 1;
+                }
+                hook_merge::SaveError::Io(e) => {
+                    eprintln!("error writing {}: {e}", path.display());
+                    return 1;
+                }
+            }
+        }
+        println!("Successfully removed cmux hooks from {}", path.display());
+        0
+    } else {
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let mut config = match hook_merge::load_or_default::<GrokHooksConfig>(&path) {
+            Ok(c) => c,
+            Err(hook_merge::LoadError::Parse(e)) => {
+                eprintln!(
+                    "error: malformed Grok config at {}: {e}",
+                    path.display()
+                );
+                return 1;
+            }
+            Err(hook_merge::LoadError::Io(e)) => {
+                eprintln!("error reading {}: {e}", path.display());
+                return 1;
+            }
+            Err(hook_merge::LoadError::NotFound) => GrokHooksConfig::default(),
+        };
+
+        // Remove any existing cmux hooks to avoid duplicates
+        config.hooks.retain(|h| !h.command.contains("cmux report-agent"));
+
+        // Add fresh ones
+        config.hooks.push(GrokHook {
+            event: "PreToolUse".to_string(),
+            command: "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state working --source grok".to_string(),
+        });
+        config.hooks.push(GrokHook {
+            event: "PostToolUse".to_string(),
+            command: "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state idle --source grok".to_string(),
+        });
+        config.hooks.push(GrokHook {
+            event: "Stop".to_string(),
+            command: "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state done --source grok".to_string(),
+        });
+
+        if let Err(e) = hook_merge::save_pretty(&path, &config) {
+            match e {
+                hook_merge::SaveError::Serialize(e) => {
+                    eprintln!("error: failed to serialize config: {e}");
+                    return 1;
+                }
+                hook_merge::SaveError::Io(e) => {
+                    eprintln!("error writing {}: {e}", path.display());
+                    return 1;
+                }
+            }
+        }
+        println!("Successfully installed cmux hooks into {}", path.display());
+        0
+    }
+}
+
+fn skill_path(global: bool) -> Option<PathBuf> {
+    if global {
+        mux_core::platform::home_dir().map(|h| h.join(".grok").join("skills").join("cmux-orchestration").join("SKILL.md"))
+    } else {
+        Some(PathBuf::from(".agents").join("skills").join("cmux-orchestration").join("SKILL.md"))
+    }
+}
+
+fn run_install_skill(uninstall: bool, global: bool) -> i32 {
+    let Some(path) = skill_path(global) else {
+        eprintln!("error: could not resolve home directory");
+        return 1;
+    };
+
+    if uninstall {
+        if path.exists() {
+            if let Err(e) = fs::remove_file(&path) {
+                eprintln!("error removing {}: {e}", path.display());
+                return 1;
+            }
+            if let Some(parent) = path.parent() {
+                let _ = fs::remove_dir(parent);
+                if let Some(grandparent) = parent.parent() {
+                    let _ = fs::remove_dir(grandparent);
+                }
+            }
+            println!("Successfully removed cmux skill from {}", path.display());
+        } else {
+            println!("No cmux skill found at {}", path.display());
+        }
+        0
+    } else {
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        if let Err(e) = fs::write(&path, crate::skill_content::ORCHESTRATION_SKILL) {
+            eprintln!("error writing {}: {e}", path.display());
+            return 1;
+        }
+        println!("Successfully installed cmux skill into {}", path.display());
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_grok_hooks_config_serialization() {
+        let mut config = GrokHooksConfig::default();
+        config.hooks.push(GrokHook {
+            event: "PreToolUse".to_string(),
+            command: "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state working --source grok".to_string(),
+        });
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: GrokHooksConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, parsed);
+    }
+
+    #[test]
+    fn test_run_unknown_subcommand() {
+        let code = run(&["invalid".to_string()]);
+        assert_eq!(code, 2);
+    }
+}

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -13,6 +13,7 @@ mod antigravity_hook;
 mod codex_hook;
 mod pi_hook;
 mod aider_hook;
+mod grok_hook;
 mod hook_merge;
 mod cli;
 mod config;
@@ -62,6 +63,7 @@ USAGE:
   cmux codex install-hooks        Codex CLI hook integration (see below)
   cmux pi install-hooks           Pi agent extension integration (see below)
   cmux aider install-hooks        Aider wrapper integration (see below)
+  cmux grok install-hooks         Grok CLI hook integration (see below)
   cmux ssh <host> [OPTS]   Open a remote workspace over SSH (see below)
 
 OPTIONS:
@@ -142,6 +144,14 @@ AIDER INTEGRATION
       Creates a wrapper script at .bin/aider (or ~/.local/bin/aider if --global)
       that wraps the real aider binary to report working/done state.
 
+GROK CLI INTEGRATION
+  cmux grok install-hooks [--uninstall] [--global]
+      Installs hooks into .grok/hooks.json (or ~/.grok/hooks.json if --global)
+      to automatically report state changes to cmux.
+  cmux grok install-skill [--uninstall] [--global]
+      Installs the orchestration skill to .agents/skills/cmux-orchestration/SKILL.md
+      (or ~/.grok/skills/cmux-orchestration/SKILL.md if --global).
+
 REMOTE (SSH) WORKSPACES
   cmux ssh <host> [--name <workspace-name>] [--session <mux-session>]
       Opens a workspace whose tab is a shell on <host> instead of local.
@@ -217,6 +227,9 @@ fn main() {
     }
     if raw_args.first().map(|arg| arg.as_str()) == Some("aider") {
         std::process::exit(aider_hook::run(&raw_args[1..]));
+    }
+    if raw_args.first().map(|arg| arg.as_str()) == Some("grok") {
+        std::process::exit(grok_hook::run(&raw_args[1..]));
     }
     if raw_args.first().map(|arg| arg.as_str()) == Some("ssh") {
         std::process::exit(ssh_bootstrap::run(&raw_args[1..]));

--- a/mux/crates/mux-tui/src/ssh_bootstrap.rs
+++ b/mux/crates/mux-tui/src/ssh_bootstrap.rs
@@ -175,7 +175,7 @@ fn cache_dir() -> anyhow::Result<PathBuf> {
         .map(PathBuf::from)
         .or_else(|| mux_core::platform::home_dir().map(|h| h.join(".cache")))
         .ok_or_else(|| anyhow::anyhow!("could not resolve a cache directory ($HOME unset?)"))?;
-    Ok(base.join("cmux-mux"))
+    Ok(base.join("cmux"))
 }
 
 // ---------- socket client ----------

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -249,7 +249,7 @@ fn install_skill_refuses_symlinks() {
     // is a symlink to a temp file with known content. Drop guard removes both.
     let guard = SymlinkSkillFixture::new();
 
-    // Invoke the REAL cmux-mux binary (integration test, not a unit call into
+    // Invoke the REAL cmux binary (integration test, not a unit call into
     // run_install_skill), so AC3's "remove the check and the test fails" holds.
     // `claude` MUST be arg[0] (main.rs dispatches it before --socket parsing),
     // so we cannot use the cli() helper; install-skill never used the socket
@@ -259,7 +259,7 @@ fn install_skill_refuses_symlinks() {
         .current_dir(&guard.project_dir)
         .env_remove("CMUX_MUX_SOCKET")
         .output()
-        .expect("failed to spawn cmux-mux claude install-skill");
+        .expect("failed to spawn cmux claude install-skill");
 
     // Assertion 1 — exit code is non-zero (the refusal path returns 1;
     // claude_hook.rs:474).
@@ -343,7 +343,7 @@ fn trigger_flash_returns_success() {
 
     // 3. Unknown workspace id -> server-side `anyhow::bail!("unknown workspace {workspace}")`
     //    (server.rs line 863), surfaced by `print_response` (cli.rs lines 550–555)
-    //    as exit code 1 and a bare (no `cmux-mux:` prefix) stderr line
+    //    as exit code 1 and a bare (no `cmux:` prefix) stderr line
     //    `unknown workspace 99999`.
     let out = cli(&server, &["trigger-flash", "--workspace", "99999"]);
     assert_eq!(out.status.code(), Some(1), "unknown workspace should fail with exit 1");
@@ -357,7 +357,7 @@ fn trigger_flash_returns_success() {
     // 4. Missing --workspace flag entirely -> client-side usage error from
     //    `build_trigger_flash` (cli.rs lines 696–701) -> `flags.required_u64("workspace")`
     //    (cli.rs lines 798–804) -> `UsageError("--workspace is required")` (line 799),
-    //    which `run_command` prints as `cmux-mux: --workspace is required` (line 408)
+    //    which `run_command` prints as `cmux: --workspace is required` (line 408)
     //    and returns exit code 2. This is the same usage-error contract the
     //    template asserts for `set-workspace-color`'s missing `--colour` case
     //    (lines 377–378: `assert_eq!(missing.status.code(), Some(2));`).
@@ -501,7 +501,7 @@ fn bin() -> &'static str {
 
 /// Fixture for the install-skill symlink-refusal test.
 ///
-/// Owns a temp "project" dir acting as CWD for `cmux-mux claude install-skill`
+/// Owns a temp "project" dir acting as CWD for `cmux claude install-skill`
 /// (whose non-global `skill_path` is `.claude/skills/cmux-orchestration/SKILL.md`,
 /// relative to CWD — see claude_hook.rs:427-432). Inside it we place:
 ///   <project>/.claude/skills/cmux-orchestration/SKILL.md -> <project>/target.txt
@@ -509,7 +509,7 @@ fn bin() -> &'static str {
 /// On drop we remove the symlink, the target file, and the whole project dir,
 /// even if the test panicked — mirroring HeadlessServer::drop (tests/cli.rs:45-52).
 struct SymlinkSkillFixture {
-    /// Temp dir used as `current_dir` for the cmux-mux subprocess.
+    /// Temp dir used as `current_dir` for the cmux subprocess.
     project_dir: PathBuf,
     /// Absolute path of the symlink itself (the path install-skill targets).
     symlink_path: PathBuf,

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -301,6 +301,72 @@ fn install_skill_refuses_symlinks() {
     // file, and the temp project dir — even if any assertion above panicked.
 }
 
+// Regression test for the symlink_metadata guard added to
+// grok_hook::run_install_skill (PR #24 follow-up). Sibling to the Claude
+// test above (PR #18 / issue #10) — the grok non-global skill path is
+// `.agents/skills/cmux-orchestration/SKILL.md` (see grok_hook.rs:147-149),
+// so the fixture is built with `top = ".agents"`. Exercises the same
+// attack vector on the new grok install path: an attacker-placed symlink
+// must NOT silently redirect fs::write at the target file.
+#[test]
+fn install_skill_refuses_symlinks_grok() {
+    // AC1 setup: a temp project dir whose .agents/skills/cmux-orchestration/SKILL.md
+    // is a symlink to a temp file with known content. Drop guard removes both.
+    let guard = SymlinkSkillFixture::new_for(".agents", "install-skill-symlink-grok");
+
+    // Invoke the REAL cmux binary (integration test, not a unit call into
+    // run_install_skill), so removing the check makes this test fail.
+    // `grok` MUST be arg[0] (main.rs dispatches it before --socket parsing);
+    // install-skill never uses the socket anyway. current_dir pins
+    // skill_path(false)'s CWD-relative target.
+    let output = Command::new(bin())
+        .args(["grok", "install-skill"])
+        .current_dir(&guard.project_dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .expect("failed to spawn cmux grok install-skill");
+
+    // Assertion 1 — exit code is non-zero (the refusal path returns 1;
+    // grok_hook.rs::run_install_skill install branch).
+    assert!(
+        !output.status.success(),
+        "grok install-skill must refuse a symlink target, got status {:?}\n\
+         stdout:\n{}\n\
+         stderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    // Assertion 2 — combined stdout+stderr mentions "symlink"
+    // (case-insensitive), so the user learns *why* it failed
+    // (the eprintln in grok_hook::run_install_skill).
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        combined.to_lowercase().contains("symlink"),
+        "error output must mention \"symlink\", got: {combined:?}"
+    );
+
+    // Assertion 3 — the symlink target file is byte-for-byte unchanged,
+    // proving the refusal happened *before* fs::write (which would
+    // otherwise follow the symlink and clobber the target — the exact
+    // attack vector).
+    let read_back = fs::read(&guard.target_path)
+        .expect("symlink target file must still exist after refusal");
+    assert_eq!(
+        read_back,
+        guard.original_content.as_bytes(),
+        "refusal must not have written through the symlink to its target"
+    );
+
+    // guard goes out of scope here: Drop removes the symlink, the target
+    // file, and the temp project dir — even if any assertion above panicked.
+}
+
 #[test]
 fn trigger_flash_returns_success() {
     let server = HeadlessServer::start("trigger-flash");
@@ -521,21 +587,31 @@ struct SymlinkSkillFixture {
 }
 
 impl SymlinkSkillFixture {
+    /// Default fixture for the Claude install-skill path (`.claude/...`).
     fn new() -> Self {
+        Self::new_for(".claude", "install-skill-symlink")
+    }
+
+    /// Build a fixture for an install-skill variant whose non-global path is
+    /// `<top>/skills/cmux-orchestration/SKILL.md` relative to CWD (e.g.
+    /// `.claude` for claude, `.agents` for grok — see grok_hook.rs:147-149).
+    /// `tag` keeps the temp dir name unique per variant so parallel test
+    /// runs never collide.
+    fn new_for(top: &str, tag: &str) -> Self {
         const KNOWN_CONTENT: &str =
             "#!/bin/sh\necho this is a precious file that must survive install-skill\n";
 
-        let project_dir = unique_temp_dir("install-skill-symlink");
+        let project_dir = unique_temp_dir(tag);
         fs::create_dir_all(&project_dir).expect("mkdir project_dir");
 
         // The exact non-global path install-skill will write to.
         let symlink_path: PathBuf = project_dir
-            .join(".claude")
+            .join(top)
             .join("skills")
             .join("cmux-orchestration")
             .join("SKILL.md");
         fs::create_dir_all(symlink_path.parent().expect("symlink_path has parent"))
-            .expect("mkdir .claude/skills/cmux-orchestration");
+            .expect("mkdir skills/cmux-orchestration");
 
         // The real file the symlink redirects to. Putting it inside the same
         // temp project dir keeps cleanup to one remove_dir_all on drop.

--- a/mux/docs/browser-panes.md
+++ b/mux/docs/browser-panes.md
@@ -45,7 +45,7 @@ Browser panes share one browser runtime per mux session. Closing a browser tab c
 
 Launched Chrome uses a persistent cmux profile unless `browser.ephemeral` is true. `browser.user_data_dir` overrides the persistent profile path. When ephemeral mode is true, Chrome uses a temporary profile that is deleted on shutdown and ignores `browser.user_data_dir`.
 
-The default launched profile is `~/Library/Application Support/cmux-mux/chrome-profile` on macOS. On non-macOS targets it is `$XDG_DATA_HOME/cmux-mux/chrome-profile` when `XDG_DATA_HOME` is set, then `~/.local/share/cmux-mux/chrome-profile`.
+The default launched profile is `~/Library/Application Support/cmux/chrome-profile` on macOS. On non-macOS targets it is `$XDG_DATA_HOME/cmux/chrome-profile` when `XDG_DATA_HOME` is set, then `~/.local/share/cmux/chrome-profile`.
 
 ## Limitations
 

--- a/mux/docs/configuration.md
+++ b/mux/docs/configuration.md
@@ -53,7 +53,7 @@ Live sidebar dragging also leaves at least 40 columns for pane content.
 
 When `browser.ephemeral` is true, it takes precedence over `browser.user_data_dir`: launched Chrome uses a fresh temporary profile, and the configured directory is not deleted.
 
-The default launched profile is `~/Library/Application Support/cmux-mux/chrome-profile` on macOS. On non-macOS targets it is `$XDG_DATA_HOME/cmux-mux/chrome-profile` when `XDG_DATA_HOME` is set, then `~/.local/share/cmux-mux/chrome-profile`.
+The default launched profile is `~/Library/Application Support/cmux/chrome-profile` on macOS. On non-macOS targets it is `$XDG_DATA_HOME/cmux/chrome-profile` when `XDG_DATA_HOME` is set, then `~/.local/share/cmux/chrome-profile`.
 
 ## Scrollbar
 
@@ -131,7 +131,7 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
     "cdp_url": "http://127.0.0.1:9222",
     "discover": true,
     "discover_ports": [9222, 9223],
-    "user_data_dir": "/Users/me/Library/Application Support/cmux-mux/chrome-profile",
+    "user_data_dir": "/Users/me/Library/Application Support/cmux/chrome-profile",
     "ephemeral": false
   },
   "scrollbar": {

--- a/mux/docs/configuration.md
+++ b/mux/docs/configuration.md
@@ -27,7 +27,7 @@ Selection colors are resolved in this order: explicit `mux.json`, Ghostty config
 | `tabs.min_width` | integer | `7` | Minimum tab label width, clamped to 3 through 40 |
 | `tabs.solid_background` | boolean | `true` | Renders tab chips with solid backgrounds |
 | `tabs.show_titles` | boolean | `false` | Shows full process titles after tab numbers |
-| `tabs.agents` | string array | `["claude","codex","opencode","pi"]` | Agent names surfaced in tab labels when `show_titles` is false |
+| `tabs.agents` | string array | `["claude","codex","grok","opencode","pi"]` | Agent names surfaced in tab labels when `show_titles` is false |
 
 Tabs are numbered by default. A recognized agent program can appear after the number. A user-assigned tab name replaces the generated label.
 
@@ -120,7 +120,7 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
     "min_width": 9,
     "solid_background": true,
     "show_titles": false,
-    "agents": ["claude", "codex", "opencode", "pi"]
+    "agents": ["claude", "codex", "grok", "opencode", "pi"]
   },
   "sidebar": {
     "width": 24,

--- a/mux/docs/getting-started.md
+++ b/mux/docs/getting-started.md
@@ -46,14 +46,14 @@ Detach from an attached TUI with prefix `d`. With default keys, that is `Ctrl-b 
 The default socket path is:
 
 ```text
-$TMPDIR/cmux-mux-<uid>/<session>.sock
+$TMPDIR/cmux-<uid>/<session>.sock
 ```
 
-The usual default is `$XDG_RUNTIME_DIR/cmux-mux-<uid>/main.sock` when `XDG_RUNTIME_DIR` is set, then `$TMPDIR/cmux-mux-<uid>/main.sock`, then `/tmp/cmux-mux-<uid>/main.sock`. `--session <name>` changes the final file name. `--socket <path>` bypasses the session-derived path. Server-started child processes receive `CMUX_MUX_SOCKET` with the socket path.
+The usual default is `$XDG_RUNTIME_DIR/cmux-<uid>/main.sock` when `XDG_RUNTIME_DIR` is set, then `$TMPDIR/cmux-<uid>/main.sock`, then `/tmp/cmux-<uid>/main.sock`. `--session <name>` changes the final file name. `--socket <path>` bypasses the session-derived path. Server-started child processes receive `CMUX_MUX_SOCKET` with the socket path.
 
 ## Session persistence
 
-Every session (headless or local TUI) writes a snapshot of its workspace/screen/pane layout — split shape and ratios, names, and each tab's cwd — to `$XDG_STATE_HOME/cmux-mux/sessions/<session>.json` (falling back to `~/.local/state/...`), debounced a few hundred ms after each structural change and again on clean shutdown. Starting a session with the same `--session` name again (a real daemon restart, or just restarting the local TUI) replays that snapshot: same panes, same directories. Closing every workspace deletes the file rather than leaving a stale one to resurrect later.
+Every session (headless or local TUI) writes a snapshot of its workspace/screen/pane layout — split shape and ratios, names, and each tab's cwd — to `$XDG_STATE_HOME/cmux/sessions/<session>.json` (falling back to `~/.local/state/...`), debounced a few hundred ms after each structural change and again on clean shutdown. Starting a session with the same `--session` name again (a real daemon restart, or just restarting the local TUI) replays that snapshot: same panes, same directories. Closing every workspace deletes the file rather than leaving a stale one to resurrect later.
 
 Not restored: a tab's *command*. Every restored tab is the default shell, `cd`'d into its recorded directory (visibly, briefly, before a `clear`) — if something specific was running there (a dev server, `claude --resume ...`), you'll need to relaunch it. See `mux-core/src/persist.rs` for why, and `Mux::restore_session`/`Mux::enable_persistence` for the implementation.
 
@@ -89,14 +89,14 @@ Two consequences:
   ordinary local tab on restore, with a status message noting it.
 
 There's no verb to actually end a remote session (only detach it) — a stale one
-needs manual cleanup on the remote host (`rm -rf ~/.cmux/daemon ~/.cache/cmux-mux`
+needs manual cleanup on the remote host (`rm -rf ~/.cmux/daemon ~/.cache/cmux`
 there, or `kill` its `cmuxd-remote serve --persistent-server` process).
 
 ## Platforms and XDG
 
 cmux supports macOS and Linux; Windows support via ConPTY is planned for phase 2. The TUI config path resolves `CMUX_MUX_CONFIG`, then `$XDG_CONFIG_HOME/cmux/mux.json`, then `~/.config/cmux/mux.json`.
 
-Launched Chrome profile paths are platform-specific. On macOS the default is `~/Library/Application Support/cmux-mux/chrome-profile`. On Linux and other non-macOS targets, `XDG_DATA_HOME` is used when set, then `~/.local/share/cmux-mux/chrome-profile`.
+Launched Chrome profile paths are platform-specific. On macOS the default is `~/Library/Application Support/cmux/chrome-profile`. On Linux and other non-macOS targets, `XDG_DATA_HOME` is used when set, then `~/.local/share/cmux/chrome-profile`.
 
 ## Development flow
 

--- a/mux/docs/protocol.md
+++ b/mux/docs/protocol.md
@@ -7,7 +7,7 @@ For shell use, prefer `cmux <verb>`; it wraps the same socket commands and prese
 Default socket path:
 
 ```text
-$TMPDIR/cmux-mux-<uid>/<session>.sock
+$TMPDIR/cmux-<uid>/<session>.sock
 ```
 
 `identify` reports the protocol version:
@@ -188,7 +188,7 @@ The bundled TUI forwards this to the host desktop via `notify-send`. There is no
 `new-remote-workspace` creates a workspace whose tab is a `cmuxd-remote` session over SSH instead of a local shell (see `getting-started.md`'s "Remote (SSH) workspaces" and `remote_pty.rs`'s module doc for the transport). Building/caching the daemon binary for the remote's OS/arch is the caller's job — the bundled `cmux ssh <host>` CLI command does it and is the intended way to use this, not calling the socket command directly:
 
 ```json
-{"id":60,"cmd":"new-remote-workspace","host":"myhost","slot":"cmux","session_id":"cmux-...","local_binary_path":"/home/me/.cache/cmux-mux/cmuxd-remote-linux-amd64","name":"work"}
+{"id":60,"cmd":"new-remote-workspace","host":"myhost","slot":"cmux","session_id":"cmux-...","local_binary_path":"/home/me/.cache/cmux/cmuxd-remote-linux-amd64","name":"work"}
 {"id":60,"ok":true,"data":{"surface":7}}
 ```
 

--- a/mux/scripts/measure-frames.py
+++ b/mux/scripts/measure-frames.py
@@ -13,7 +13,7 @@ import time
 
 
 def default_socket() -> str:
-    return os.path.join(tempfile.gettempdir(), f"cmux-mux-{os.getuid()}", "main.sock")
+    return os.path.join(tempfile.gettempdir(), f"cmux-{os.getuid()}", "main.sock")
 
 
 class Rpc:

--- a/mux/scripts/smoke-attach.py
+++ b/mux/scripts/smoke-attach.py
@@ -29,7 +29,7 @@ MARKER = f"reattach-marker-{os.getpid()}"
 
 def fallback_socket_path():
     base = os.environ.get("XDG_RUNTIME_DIR") or os.environ.get("TMPDIR") or "/tmp"
-    return os.path.join(base, f"cmux-mux-{os.getuid()}", f"{SESSION}.sock")
+    return os.path.join(base, f"cmux-{os.getuid()}", f"{SESSION}.sock")
 
 
 def wait_for_control_socket(server, seconds=15):

--- a/mux/scripts/smoke-tui.py
+++ b/mux/scripts/smoke-tui.py
@@ -7,7 +7,7 @@ CONTROL_SOCKET_RE = re.compile(r"control socket at (.+)$")
 
 def fallback_socket_path():
     base = os.environ.get("XDG_RUNTIME_DIR") or os.environ.get("TMPDIR") or "/tmp"
-    return os.path.join(base, f"cmux-mux-{os.getuid()}", f"{SESSION}.sock")
+    return os.path.join(base, f"cmux-{os.getuid()}", f"{SESSION}.sock")
 
 def wait_for_control_socket(server, seconds=15):
     deadline = time.time() + seconds

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -12,7 +12,7 @@ The CLI resolves the target session in this order:
 | --- | --- |
 | 1 | `--socket <path>` |
 | 2 | `CMUX_MUX_SOCKET` |
-| 3 | `--session <name>` using `$TMPDIR/cmux-mux-<uid>/<session>.sock` |
+| 3 | `--session <name>` using `$TMPDIR/cmux-<uid>/<session>.sock` |
 | 4 | default session `main` using the default socket path |
 
 `--session` and `--socket` are global flags and may appear before or after the verb.

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -2096,7 +2096,7 @@ CLI mapping:
 Example:
 
 ```json
-{"id":60,"cmd":"new-remote-workspace","host":"myhost","slot":"cmux","session_id":"cmux-...","local_binary_path":"/home/me/.cache/cmux-mux/cmuxd-remote-linux-amd64","name":"work"}
+{"id":60,"cmd":"new-remote-workspace","host":"myhost","slot":"cmux","session_id":"cmux-...","local_binary_path":"/home/me/.cache/cmux/cmuxd-remote-linux-amd64","name":"work"}
 {"id":60,"ok":true,"data":{"surface":7}}
 ```
 

--- a/mux/spec/transports.md
+++ b/mux/spec/transports.md
@@ -14,10 +14,10 @@ The command schema is transport-independent. Protocol v5 implements a Unix domai
 The default socket path for a session is:
 
 ```text
-$TMPDIR/cmux-mux-<uid>/<session>.sock
+$TMPDIR/cmux-<uid>/<session>.sock
 ```
 
-The implementation uses Rust `std::env::temp_dir()` for `$TMPDIR`, appends `cmux-mux-<uid>`, and then appends `<session>.sock`. The TUI exports the resolved path to child surfaces as `CMUX_MUX_SOCKET`.
+The implementation uses Rust `std::env::temp_dir()` for `$TMPDIR`, appends `cmux-<uid>`, and then appends `<session>.sock`. The TUI exports the resolved path to child surfaces as `CMUX_MUX_SOCKET`.
 
 The `cmux` process accepts `--session <name>` to select the default socket name and `--socket <path>` to override the path.
 


### PR DESCRIPTION
## Overview
Adds Grok CLI agent harness support to `cmux-linux`, matching the existing agent harness integration patterns (Antigravity, Codex, Pi, Aider, Claude Code).

## Key Changes
- **`grok_hook` module (`mux/crates/mux-tui/src/grok_hook.rs`)**:
  - Implements `cmux grok install-hooks [--uninstall] [--global]` to write/manage `.grok/hooks.json` (or `~/.grok/hooks.json` if `--global`).
  - Configures lifecycle event hooks (`PreToolUse`, `PostToolUse`, `Stop`) to report agent status via `cmux report-agent --surface "$CMUX_MUX_SURFACE" --state <working|idle|done> --source grok`.
  - Implements `cmux grok install-skill [--uninstall] [--global]` to manage `.agents/skills/cmux-orchestration/SKILL.md` (or `~/.grok/skills/cmux-orchestration/SKILL.md`).
  - Follows security best practices: propagates JSON parse errors, avoids silent `unwrap_or_default` overwrites, and cleans up empty parent directories on uninstall.

- **Mux TUI CLI Integration (`mux/crates/mux-tui/src/main.rs`)**:
  - Registered `grok_hook` module and subcommand handler `cmux grok`.
  - Updated CLI usage documentation text.

- **Agent Configuration (`mux/crates/mux-tui/src/config.rs`)**:
  - Added `"grok"` to the default recognized agents array for tab label formatting.

- **Documentation**:
  - Updated `README.md`, `mux/docs/configuration.md`, and `AGENTS.md`.

## Testing & Verification
- Validated build using `./scripts/bootstrap.sh` (pinned Zig 0.15.2 + Rust 1.75.0).
- Ran unit & integration tests (`cargo test -p mux-tui`); all 67 unittests and 6 CLI integration tests passed cleanly.