### PR TITLE
feat(mux-tui): add session enumeration and cleanup CLI verbs

### DIFF
--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -41,6 +41,72 @@ pub fn default_socket_path(session: &str) -> PathBuf {
     platform::runtime_dir().join(format!("{session}.sock"))
 }
 
+/// PID file path corresponding to a socket path.
+pub fn pid_path(socket_path: &Path) -> PathBuf {
+    socket_path.with_extension("pid")
+}
+
+/// Check if a process ID is currently alive.
+pub fn is_process_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        let res = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if res == 0 {
+            true
+        } else {
+            std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+/// Check if a process ID is alive AND is a cmux process.
+pub fn is_cmux_process(pid: u32) -> bool {
+    if !is_process_alive(pid) {
+        return false;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let cmdline_path = format!("/proc/{pid}/cmdline");
+        if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path) {
+            cmdline.contains("cmux")
+        } else {
+            false
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        true
+    }
+}
+
+/// Check if a session socket path is live (connectable AND process is alive if pidfile present).
+pub fn is_session_socket_live(socket_path: &Path) -> bool {
+    if !socket_path.exists() {
+        return false;
+    }
+    if transport::connect(socket_path).is_err() {
+        return false;
+    }
+    let pid_p = pid_path(socket_path);
+    if pid_p.exists() {
+        if let Ok(content) = std::fs::read_to_string(&pid_p) {
+            if let Ok(pid) = content.trim().parse::<u32>() {
+                if !is_cmux_process(pid) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
 #[derive(Deserialize)]
 struct Request {
     id: Option<Value>,
@@ -361,18 +427,23 @@ pub fn serve(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
         std::fs::create_dir_all(dir)?;
         platform::restrict_directory(dir)?;
     }
+    let pid_p = pid_path(&path);
     // Refuse to clobber a live socket; remove a stale one.
-    if path.exists() {
-        match transport::connect(&path) {
-            Ok(_) => anyhow::bail!(
+    if path.exists() || pid_p.exists() {
+        if is_session_socket_live(&path) {
+            anyhow::bail!(
                 "session socket {} is already in use (another instance running?)",
                 path.display()
-            ),
-            Err(_) => std::fs::remove_file(&path)?,
+            );
         }
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&pid_p);
     }
     let listener = transport::listen(&path)?;
     platform::restrict_file(&path)?;
+
+    std::fs::write(&pid_p, format!("{}\n", std::process::id()))?;
+    platform::restrict_file(&pid_p)?;
 
     std::thread::Builder::new().name("mux-server".into()).spawn(move || loop {
         let Ok(stream) = listener.accept() else { continue };
@@ -732,7 +803,15 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             let surface = mux.new_workspace(name, cols.zip(rows))?;
             Ok(json!({ "surface": surface.id }))
         }
-        Command::NewRemoteWorkspace { host, slot, session_id, local_binary_path, name, cols, rows } => {
+        Command::NewRemoteWorkspace {
+            host,
+            slot,
+            session_id,
+            local_binary_path,
+            name,
+            cols,
+            rows,
+        } => {
             let spec = crate::remote_pty::RemoteSpec {
                 host,
                 slot,
@@ -1043,7 +1122,8 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
     }
 }
 
-/// Remove the socket file (call on clean shutdown).
+/// Remove the socket file and pid file (call on clean shutdown).
 pub fn cleanup(path: &Path) {
     let _ = std::fs::remove_file(path);
+    let _ = std::fs::remove_file(pid_path(path));
 }

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -288,6 +288,27 @@ const VERBS: &[VerbSpec] = &[
         print: print_empty,
         stream: false,
     },
+    VerbSpec {
+        name: "list-sessions",
+        allowed: &[],
+        build: build_no_args,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "kill-session",
+        allowed: &["session"],
+        build: build_kill_session,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "kill-stale",
+        allowed: &[],
+        build: build_no_args,
+        print: print_empty,
+        stream: false,
+    },
 ];
 
 pub fn is_cli_invocation(args: &[String]) -> bool {
@@ -398,6 +419,12 @@ fn verb_by_name(name: &str) -> Option<&'static VerbSpec> {
 }
 
 fn run_command(args: CliArgs) -> i32 {
+    match args.verb.name {
+        "list-sessions" => return run_list_sessions(&args.global, &args.flags),
+        "kill-session" => return run_kill_session(&args.global, &args.flags),
+        "kill-stale" => return run_kill_stale(&args.global, &args.flags),
+        _ => {}
+    }
     let request = match (args.verb.build)(&args.flags) {
         Ok(mut value) => {
             value["cmd"] = json!(args.verb.name);
@@ -761,6 +788,175 @@ fn build_list_agents(flags: &FlagMap) -> Result<Value, UsageError> {
     flags.insert_optional_u64(&mut value, "surface")?;
     flags.insert_optional_string(&mut value, "state");
     Ok(value)
+}
+
+fn build_kill_session(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_string(&mut value, "session");
+    Ok(value)
+}
+
+fn get_runtime_dir(global: &GlobalArgs) -> PathBuf {
+    global
+        .socket
+        .as_ref()
+        .and_then(|s| s.parent().map(|p| p.to_path_buf()))
+        .unwrap_or_else(mux_core::platform::runtime_dir)
+}
+
+fn read_pid_file(path: &std::path::Path) -> Option<u32> {
+    if let Ok(content) = std::fs::read_to_string(path) {
+        content.trim().parse::<u32>().ok()
+    } else {
+        None
+    }
+}
+
+fn run_list_sessions(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
+    let dir = get_runtime_dir(global);
+    let mut session_names = std::collections::BTreeSet::new();
+
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                if ext == "sock" || ext == "pid" {
+                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        session_names.insert(stem.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    struct SessionInfo {
+        session: String,
+        pid: Option<u32>,
+        status: &'static str,
+    }
+
+    let mut sessions = Vec::new();
+    for name in session_names {
+        let sock_path = dir.join(format!("{name}.sock"));
+        let pid_p = dir.join(format!("{name}.pid"));
+        let pid = read_pid_file(&pid_p);
+        let is_live = mux_core::server::is_session_socket_live(&sock_path);
+        let status = if is_live { "live" } else { "stale" };
+        sessions.push(SessionInfo { session: name, pid, status });
+    }
+
+    if global.json {
+        let json_list: Vec<Value> = sessions
+            .iter()
+            .map(|s| {
+                json!({
+                    "session": s.session,
+                    "name": s.session,
+                    "pid": s.pid,
+                    "status": s.status,
+                })
+            })
+            .collect();
+        let payload = json!({ "sessions": json_list });
+        if serde_json::to_writer(io::stdout(), &payload).is_ok() {
+            println!();
+            0
+        } else {
+            3
+        }
+    } else {
+        for s in &sessions {
+            let pid_str = s.pid.map(|p| p.to_string()).unwrap_or_else(|| "-".to_string());
+            println!("{} {} {}", s.session, pid_str, s.status);
+        }
+        0
+    }
+}
+
+fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
+    let target_session = flags.optional("session").or_else(|| global.session.clone());
+    let Some(session_name) = target_session else {
+        eprintln!("cmux: --session is required");
+        return 2;
+    };
+
+    let dir = get_runtime_dir(global);
+    let sock_path = dir.join(format!("{session_name}.sock"));
+    let pid_p = dir.join(format!("{session_name}.pid"));
+
+    if !sock_path.exists() && !pid_p.exists() {
+        eprintln!("cmux: session {session_name:?} not found");
+        return 1;
+    }
+
+    if let Some(pid) = read_pid_file(&pid_p) {
+        if mux_core::server::is_cmux_process(pid) {
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+            let deadline = std::time::Instant::now() + Duration::from_secs(2);
+            while std::time::Instant::now() < deadline {
+                if !mux_core::server::is_process_alive(pid) {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            if mux_core::server::is_process_alive(pid) {
+                unsafe {
+                    libc::kill(pid as libc::pid_t, libc::SIGKILL);
+                }
+                let deadline2 = std::time::Instant::now() + Duration::from_secs(1);
+                while std::time::Instant::now() < deadline2 {
+                    if !mux_core::server::is_process_alive(pid) {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+    }
+
+    let _ = std::fs::remove_file(&sock_path);
+    let _ = std::fs::remove_file(&pid_p);
+
+    if global.json {
+        println!("{}", json!({ "ok": true }));
+    }
+    0
+}
+
+fn run_kill_stale(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
+    let dir = get_runtime_dir(global);
+    let mut session_names = std::collections::BTreeSet::new();
+
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+                if ext == "sock" || ext == "pid" {
+                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                        session_names.insert(stem.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    let mut cleaned = 0;
+    for name in session_names {
+        let sock_path = dir.join(format!("{name}.sock"));
+        let pid_p = dir.join(format!("{name}.pid"));
+        if !mux_core::server::is_session_socket_live(&sock_path) {
+            let _ = std::fs::remove_file(&sock_path);
+            let _ = std::fs::remove_file(&pid_p);
+            cleaned += 1;
+        }
+    }
+
+    if global.json {
+        println!("{}", json!({ "ok": true, "cleaned": cleaned }));
+    }
+    0
 }
 
 fn selector_request(flags: &FlagMap) -> Result<Value, UsageError> {

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -6,25 +6,25 @@
 //! `cmux attach` connects the same TUI to an existing (usually
 //! headless) session over that socket, which is how detach/reattach works.
 
+mod aider_hook;
+mod antigravity_hook;
 mod app;
 mod browser_input;
 mod claude_hook;
-mod antigravity_hook;
-mod codex_hook;
-mod pi_hook;
-mod aider_hook;
-mod grok_hook;
-mod hook_merge;
 mod cli;
+mod codex_hook;
 mod config;
 mod desktop_notify;
 mod git_info;
+mod grok_hook;
+mod hook_merge;
 mod host_colors;
 mod keys;
+mod pi_hook;
 mod session;
+mod skill_content;
 mod ssh_bootstrap;
 mod ui;
-mod skill_content;
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -98,7 +98,7 @@ CLI VERBS
   rename-workspace, set-workspace-color, trigger-flash, resize-surface,
   focus-pane, select-tab, select-screen, select-workspace, move-tab,
   move-workspace, scroll-surface, subscribe, attach-surface, report-agent,
-  list-agents, browser-reload
+  list-agents, browser-reload, list-sessions, kill-session, kill-stale
 
 CLAUDE CODE HOOK INTEGRATION
   cmux claude install-hooks [--uninstall]

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -152,13 +152,25 @@ fn report_agent_and_list_agents_round_trip() {
     // A socket report cannot downgrade an existing hook report.
     let downgrade = cli(
         &server,
-        &["report-agent", "--surface", &surface.to_string(), "--state", "idle", "--source", "socket"],
+        &[
+            "report-agent",
+            "--surface",
+            &surface.to_string(),
+            "--state",
+            "idle",
+            "--source",
+            "socket",
+        ],
     );
     assert_success(&downgrade);
     let list = cli(&server, &["--json", "list-agents", "--state", "working"]);
     assert_success(&list);
     let value: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
-    assert_eq!(value["agents"].as_array().unwrap().len(), 1, "hook report should still be in effect");
+    assert_eq!(
+        value["agents"].as_array().unwrap().len(),
+        1,
+        "hook report should still be in effect"
+    );
 
     // Plain (non-JSON) output is one line per agent.
     let plain = cli(&server, &["list-agents"]);
@@ -169,7 +181,15 @@ fn report_agent_and_list_agents_round_trip() {
     // Bad state/source are rejected.
     let bad = cli(
         &server,
-        &["report-agent", "--surface", &surface.to_string(), "--state", "nonsense", "--source", "hook"],
+        &[
+            "report-agent",
+            "--surface",
+            &surface.to_string(),
+            "--state",
+            "nonsense",
+            "--source",
+            "hook",
+        ],
     );
     assert_eq!(bad.status.code(), Some(1));
 }
@@ -289,8 +309,8 @@ fn install_skill_refuses_symlinks() {
     // Assertion 2 — the symlink target file is byte-for-byte unchanged,
     // proving the refusal happened *before* fs::write (which would otherwise
     // follow the symlink and clobber the target — the exact attack vector).
-    let read_back = fs::read(&guard.target_path)
-        .expect("symlink target file must still exist after refusal");
+    let read_back =
+        fs::read(&guard.target_path).expect("symlink target file must still exist after refusal");
     assert_eq!(
         read_back,
         guard.original_content.as_bytes(),
@@ -355,8 +375,8 @@ fn install_skill_refuses_symlinks_grok() {
     // proving the refusal happened *before* fs::write (which would
     // otherwise follow the symlink and clobber the target — the exact
     // attack vector).
-    let read_back = fs::read(&guard.target_path)
-        .expect("symlink target file must still exist after refusal");
+    let read_back =
+        fs::read(&guard.target_path).expect("symlink target file must still exist after refusal");
     assert_eq!(
         read_back,
         guard.original_content.as_bytes(),
@@ -402,7 +422,13 @@ fn trigger_flash_returns_success() {
     //    by new-workspace is fine.
     let out = cli(
         &server,
-        &["trigger-flash", "--workspace", &workspace_id.to_string(), "--surface", &surface.to_string()],
+        &[
+            "trigger-flash",
+            "--workspace",
+            &workspace_id.to_string(),
+            "--surface",
+            &surface.to_string(),
+        ],
     );
     assert_success(&out);
     assert!(out.stdout.is_empty(), "trigger-flash should be quiet on success");
@@ -605,11 +631,8 @@ impl SymlinkSkillFixture {
         fs::create_dir_all(&project_dir).expect("mkdir project_dir");
 
         // The exact non-global path install-skill will write to.
-        let symlink_path: PathBuf = project_dir
-            .join(top)
-            .join("skills")
-            .join("cmux-orchestration")
-            .join("SKILL.md");
+        let symlink_path: PathBuf =
+            project_dir.join(top).join("skills").join("cmux-orchestration").join("SKILL.md");
         fs::create_dir_all(symlink_path.parent().expect("symlink_path has parent"))
             .expect("mkdir skills/cmux-orchestration");
 
@@ -627,23 +650,12 @@ impl SymlinkSkillFixture {
         // the check fs::write would follow it and clobber target_path. This
         // guards against a misconfigured fixture silently making the test
         // pass for the wrong reason (a missing symlink ⇒ error before check).
-        assert!(
-            symlink_path.exists(),
-            "fixture broken: symlink does not resolve to a real file"
-        );
+        assert!(symlink_path.exists(), "fixture broken: symlink does not resolve to a real file");
         let meta = fs::symlink_metadata(&symlink_path)
             .expect("symlink_metadata on the freshly created symlink");
-        assert!(
-            meta.file_type().is_symlink(),
-            "fixture broken: SKILL.md is not a symlink"
-        );
+        assert!(meta.file_type().is_symlink(), "fixture broken: SKILL.md is not a symlink");
 
-        Self {
-            project_dir,
-            symlink_path,
-            target_path,
-            original_content,
-        }
+        Self { project_dir, symlink_path, target_path, original_content }
     }
 }
 
@@ -655,4 +667,241 @@ impl Drop for SymlinkSkillFixture {
         let _ = fs::remove_file(&self.target_path);
         let _ = fs::remove_dir_all(&self.project_dir);
     }
+}
+
+#[test]
+fn list_sessions_lists_active_headless_session() {
+    let dir = unique_temp_dir("list-sess");
+    fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("test-list.sock");
+    let mut child = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let pid_file = dir.join("test-list.pid");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if socket.exists() && pid_file.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(socket.exists(), "socket must exist");
+    assert!(pid_file.exists(), "pid file must exist");
+
+    let output = Command::new(bin())
+        .args(["--socket"])
+        .arg(&socket)
+        .arg("list-sessions")
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test-list"), "output should list session test-list, got: {stdout}");
+    assert!(stdout.contains("live"), "output should show live status, got: {stdout}");
+
+    let json_output = Command::new(bin())
+        .args(["--socket"])
+        .arg(&socket)
+        .args(["--json", "list-sessions"])
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&json_output);
+    let value: serde_json::Value = serde_json::from_slice(&json_output.stdout).unwrap();
+    let sessions = value["sessions"].as_array().expect("sessions array");
+    assert!(
+        sessions.iter().any(|s| s["session"] == "test-list" && s["status"] == "live"),
+        "expected test-list with status live in json, got {value}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn kill_session_terminates_daemon_and_cleans_files() {
+    let dir = unique_temp_dir("kill-sess");
+    fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("target-sess.sock");
+    let mut child = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let pid_file = dir.join("target-sess.pid");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if socket.exists() && pid_file.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(socket.exists());
+    assert!(pid_file.exists());
+
+    let output = Command::new(bin())
+        .args(["--socket"])
+        .arg(&socket)
+        .args(["kill-session", "--session", "target-sess"])
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&output);
+
+    // Verify process is killed.
+    let status = child.wait().unwrap();
+    assert!(
+        status.success() || status.code().is_none(),
+        "process should exit cleanly on SIGTERM or be killed"
+    );
+    assert!(!socket.exists(), "socket should be removed");
+    assert!(!pid_file.exists(), "pid file should be removed");
+
+    // Verify killing non-existent session returns exit 1.
+    let missing = Command::new(bin())
+        .args(["--socket"])
+        .arg(&socket)
+        .args(["kill-session", "--session", "nonexistent"])
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_eq!(missing.status.code(), Some(1));
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn kill_stale_removes_stale_pair_and_leaves_live_untouched() {
+    let dir = unique_temp_dir("kill-stale");
+    fs::create_dir_all(&dir).unwrap();
+    let live_socket = dir.join("live-sess.sock");
+    let mut child = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&live_socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let live_pid = dir.join("live-sess.pid");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if live_socket.exists() && live_pid.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    // Create fake stale files (nonexistent PID 999999)
+    let stale_socket = dir.join("stale-sess.sock");
+    let stale_pid = dir.join("stale-sess.pid");
+    fs::write(&stale_socket, "fake").unwrap();
+    fs::write(&stale_pid, "999999\n").unwrap();
+
+    let output = Command::new(bin())
+        .args(["--socket"])
+        .arg(&live_socket)
+        .args(["kill-stale"])
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&output);
+
+    assert!(!stale_socket.exists(), "stale socket should be removed");
+    assert!(!stale_pid.exists(), "stale pid file should be removed");
+    assert!(live_socket.exists(), "live socket should be untouched");
+    assert!(live_pid.exists(), "live pid file should be untouched");
+
+    // Idempotent test: run again when no stale sessions remain.
+    let output2 = Command::new(bin())
+        .args(["--socket"])
+        .arg(&live_socket)
+        .args(["kill-stale"])
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&output2);
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn serve_recovers_from_stale_socket() {
+    let dir = unique_temp_dir("recover-stale");
+    fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("recover.sock");
+    let pid_file = dir.join("recover.pid");
+
+    // Spawn a daemon and SIGKILL it without cleanup
+    let mut child = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if socket.exists() && pid_file.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+
+    // Verify stale socket still exists on disk
+    assert!(socket.exists());
+
+    // Start a new daemon on the same socket path — should clear stale socket and bind
+    let mut child2 = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut rebound = false;
+    while Instant::now() < deadline {
+        if socket.exists() && pid_file.exists() {
+            if let Ok(pid_str) = fs::read_to_string(&pid_file) {
+                if pid_str.trim() == child2.id().to_string() {
+                    rebound = true;
+                    break;
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(rebound, "new daemon should overwrite stale pid file with its own pid");
+
+    let _ = child2.kill();
+    let _ = child2.wait();
+    let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary

Closes #25 — `cmux --headless` daemons no longer leave permanently-stale
sockets behind on `SIGKILL`/crash, and the CLI gains built-in primitives to
inspect and clean up session state instead of requiring a hand-rolled
`pkill -f` workaround.

- **`list-sessions`** (human + `--json`): enumerates session sockets in the
  runtime dir, reporting name/pid/live-or-stale status.
- **`kill-session --session <name>`**: SIGTERM, brief poll, SIGKILL fallback
  if still alive, then removes the socket + pid files. Verifies
  `/proc/<pid>/cmdline` actually contains `"cmux"` before signaling —
  guards against PID reuse after a reboot/wraparound.
- **`kill-stale`**: bulk-sweeps any session whose socket isn't connectable
  or whose owning PID isn't alive; idempotent; leaves live sessions
  untouched.
- **`mux-core::server`**: tracks a sibling `<session>.pid` file next to the
  control socket; `serve()`'s startup liveness check now considers both
  socket connectability and PID identity before treating an existing
  socket as stale-and-safe-to-clobber vs. live-and-must-bail;
  `cleanup()` removes both files on graceful shutdown.

## Process note on how this PR was produced

This was built by an Agy (gemini-3.6-flash-high) worker in an isolated
worktree, orchestrated by Claude Code. Two things worth being transparent
about:

1. **Verifier fallback to Claude.** The mission called for an independent
   Agy review of the diff. That worker hit an account-wide Agy quota
   lockout on its first turn; a retry on gemini-3.5-flash-high hit the
   identical lockout immediately (same shared quota pool, not a per-model
   limit — three unrelated Agy sessions for a different project were
   running concurrently on the same account). Per explicit direction, the
   independent verification pass was instead carried out directly by
   Claude: a completely separate `git worktree` + fresh submodule
   init + bootstrap + build, the full test suite, and adversarial manual
   testing beyond the automated tests (crafted stale socket/pid pairs,
   confirmed a live daemon is never clobbered by a second bind attempt,
   confirmed `kill-session`/`kill-stale` idempotency and PID-reuse
   guarding). Verdict: **PASS, no findings** — but flagging plainly that
   this is not the independent-model review originally planned.
2. **Pre-existing test flake, not a regression.** `cargo test -p mux-tui
   --test cli` shows `cli_verbs_cover_command_output_errors_and_streams`
   failing in this build environment. This is unrelated to this change:
   the test spawns a raw PTY `zsh`, and this particular sandbox's `$HOME`
   has no `.zshrc`, so zsh's first-run `zsh-newuser-install` wizard
   intercepts the test's `printf` command before it can complete. Verified
   twice independently (once via `git stash` of this diff against the
   builder's own build, once via the verifier's from-scratch build) that
   the identical failure occurs on unmodified `main` too. All other tests
   pass: 67/67 unit tests, 10/11 CLI tests, `cargo check -p mux-tui` clean,
   the four changed files are individually `cargo fmt`-clean.

## Deferred scope (explicitly out of bounds for this PR — suggest filing as follow-up issues rather than blocking this one)

1. **SIGKILL-triggered instant socket removal.** Not possible without an
   external watchdog process or systemd user unit, since `SIGKILL` bypasses
   signal handlers and `atexit` entirely. The startup liveness sweep in
   `serve()` and the standalone `kill-stale` verb substitute for this: the
   stale socket/pid pair gets cleaned up the next time anything looks at
   it, rather than the instant the daemon dies.
2. **Generic orphan child-process-tree reaping.** `mux.shutdown()` already
   signals direct surface children on a graceful exit. Reaping deeply
   nested or double-forked descendants (e.g. an agent process that itself
   forked, as described in the issue) across arbitrary PID namespaces is
   out of scope here and deferred to a future cgroups-based
   process-isolation epic.

## Test plan

- [x] `cargo check -p mux-tui` — clean
- [x] `cargo test -p mux-tui --bin cmux` — 67 passed, 0 failed
- [x] `cargo test -p mux-tui --test cli` — 10 passed, 1 failed (pre-existing
      environmental flake, see above; not a regression)
- [x] `cargo fmt -- --check` on the 4 changed files — no diff
- [x] Manual adversarial testing: nonexistent-session kill (clean error,
      exit 1), empty/idempotent `kill-stale`, stale-pid-pair cleanup
      leaving live sessions untouched, live-daemon-not-clobbered-by-second-bind
- [x] Confirmed the live `sis-aug-2026-20260723-012705` session and its
      runtime socket were untouched throughout development/verification

🤖 Generated with a Claude Code + Agy (gemini-3.6-flash-high) orchestration.