### PR TITLE
fix(mux-core): reap orphan process trees on surface kill (#28)

### DIFF
--- a/mux/crates/mux-core/src/lib.rs
+++ b/mux/crates/mux-core/src/lib.rs
@@ -13,6 +13,7 @@ mod model;
 mod mux;
 mod notify;
 mod persist;
+pub mod process;
 pub mod remote_pty;
 mod short_id;
 mod surface;

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -255,6 +255,12 @@ impl Mux {
         if let Some(runtime) = self.browser_runtime.lock().unwrap().take() {
             runtime.shutdown();
         }
+        // Note: do NOT call process::kill_remaining_children() here.
+        // Mux is also constructed in-process by tests that run in parallel;
+        // a global child sweep would kill sibling tests' PTY children.
+        // The daemon path in mux-tui calls kill_remaining_children after
+        // shutdown so subreaper-reparented orphans are still cleaned up
+        // in production (issue #28).
     }
 
     fn snapshot_path(&self) -> std::path::PathBuf {

--- a/mux/crates/mux-core/src/process.rs
+++ b/mux/crates/mux-core/src/process.rs
@@ -1,0 +1,322 @@
+//! Linux process-tree helpers for orphan reaping.
+//!
+//! When a pane's shell exits (or is killed), grandchildren that double-forked
+//! or were backgrounded can outlive the direct PTY child. Combined with
+//! [`set_child_subreaper`], this module lets cmux inherit those orphans and
+//! terminate the whole tree on surface kill / mux shutdown.
+//!
+//! See issue #28.
+
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+
+/// Make this process a subreaper so orphaned descendants reparent here
+/// instead of PID 1. No-op / returns false on non-Linux.
+///
+/// Safe to call more than once. Requires Linux 3.4+.
+pub fn set_child_subreaper() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        // PR_SET_CHILD_SUBREAPER = 36
+        let rc = unsafe { libc::prctl(36, 1i64, 0, 0, 0) };
+        rc == 0
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}
+
+/// Whether `pid` is currently alive (same semantics as server::is_process_alive).
+pub fn is_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        let res = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        if res == 0 {
+            true
+        } else {
+            std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+/// Direct children of `pid` (Linux `/proc/<pid>/task/<pid>/children`, with
+/// a `/proc` scan fallback). Empty on non-Linux.
+pub fn direct_children(pid: u32) -> Vec<u32> {
+    #[cfg(target_os = "linux")]
+    {
+        let path = format!("/proc/{pid}/task/{pid}/children");
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            let kids: Vec<u32> = contents
+                .split_whitespace()
+                .filter_map(|s| s.parse::<u32>().ok())
+                .collect();
+            // Some kernels expose the file but leave it empty for the
+            // calling process in certain contexts; fall through to a scan.
+            if !kids.is_empty() {
+                return kids;
+            }
+        }
+        scan_proc_for_children(pid)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = pid;
+        Vec::new()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn scan_proc_for_children(pid: u32) -> Vec<u32> {
+    let mut kids = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return kids;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.as_bytes().iter().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        let Ok(child_pid) = name.parse::<u32>() else { continue };
+        if child_pid == pid {
+            continue;
+        }
+        let stat_path = format!("/proc/{child_pid}/stat");
+        let Ok(stat) = std::fs::read_to_string(&stat_path) else {
+            continue;
+        };
+        // /proc/pid/stat: "pid (comm) state ppid ..."
+        // comm may contain spaces/parens; ppid is the first field after
+        // the final ')' of the comm.
+        if let Some(close) = stat.rfind(')') {
+            let after = &stat[close + 1..];
+            let mut fields = after.split_whitespace();
+            // state, ppid
+            let _state = fields.next();
+            if let Some(ppid_s) = fields.next() {
+                if ppid_s.parse::<u32>().ok() == Some(pid) {
+                    kids.push(child_pid);
+                }
+            }
+        }
+    }
+    kids
+}
+
+/// All descendants of `root` (not including `root` itself), depth-first.
+pub fn all_descendants(root: u32) -> Vec<u32> {
+    let mut out = Vec::new();
+    let mut stack = vec![root];
+    let mut seen = HashSet::new();
+    seen.insert(root);
+    while let Some(pid) = stack.pop() {
+        for child in direct_children(pid) {
+            if seen.insert(child) {
+                out.push(child);
+                stack.push(child);
+            }
+        }
+    }
+    out
+}
+
+/// Reap any zombie children of this process (non-blocking).
+pub fn reap_zombies() {
+    #[cfg(unix)]
+    {
+        loop {
+            let mut status: libc::c_int = 0;
+            let rc = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+            if rc <= 0 {
+                break;
+            }
+        }
+    }
+}
+
+/// Send `sig` to every pid in `pids`. Ignores ESRCH / EPERM.
+fn signal_all(pids: &[u32], sig: libc::c_int) {
+    #[cfg(unix)]
+    {
+        for &pid in pids {
+            if pid == 0 {
+                continue;
+            }
+            let _ = unsafe { libc::kill(pid as libc::pid_t, sig) };
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (pids, sig);
+    }
+}
+
+/// Terminate `root` and every descendant: SIGTERM, wait up to `grace`,
+/// then SIGKILL survivors. Also reaps zombies along the way.
+///
+/// Does nothing if `root` is 0 or is this process.
+pub fn kill_process_tree(root: u32) {
+    let self_pid = std::process::id();
+    if root == 0 || root == self_pid {
+        return;
+    }
+
+    // Snapshot tree; re-walk after SIGTERM for late-spawned kids.
+    let mut targets: HashSet<u32> = all_descendants(root).into_iter().collect();
+    targets.insert(root);
+    targets.remove(&self_pid);
+
+    let list: Vec<u32> = targets.into_iter().collect();
+    signal_all(&list, libc::SIGTERM);
+
+    let grace = Duration::from_secs(2);
+    let deadline = Instant::now() + grace;
+    while Instant::now() < deadline {
+        reap_zombies();
+        // Catch late reparents / new children under still-living nodes.
+        let mut still = false;
+        for &pid in &list {
+            if is_alive(pid) {
+                still = true;
+                break;
+            }
+        }
+        // Also pull any new descendants of still-living roots.
+        for d in all_descendants(root) {
+            if d != self_pid && is_alive(d) {
+                still = true;
+                let _ = unsafe { libc::kill(d as libc::pid_t, libc::SIGTERM) };
+            }
+        }
+        if !still && !is_alive(root) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // Final hard kill of anything still around in the tree.
+    let mut survivors = all_descendants(root);
+    survivors.push(root);
+    survivors.retain(|&p| p != self_pid && is_alive(p));
+    signal_all(&survivors, libc::SIGKILL);
+    // Brief wait for SIGKILL to take effect.
+    let hard_deadline = Instant::now() + Duration::from_millis(500);
+    while Instant::now() < hard_deadline {
+        reap_zombies();
+        if survivors.iter().all(|&p| !is_alive(p)) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    reap_zombies();
+}
+
+/// Kill every remaining child process of *this* process (and their
+/// descendants). Used on mux shutdown after surface kills so anything
+/// reparented via the subreaper is cleaned up.
+pub fn kill_remaining_children() {
+    let self_pid = std::process::id();
+    let kids = direct_children(self_pid);
+    for kid in kids {
+        kill_process_tree(kid);
+    }
+    reap_zombies();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn kill_process_tree_reaps_background_grandchild() {
+        // Shape matching issue #28 acceptance:
+        //   sh -c 'sleep 999 & wait'  — sleep is a grandchild that would
+        //   normally reparent to init if sh exits first.
+        let enabled = set_child_subreaper();
+        assert!(enabled, "PR_SET_CHILD_SUBREAPER should succeed on Linux");
+
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "sleep 999 & exec sleep 998"])
+            .spawn()
+            .expect("spawn shell tree");
+        let root = child.id();
+
+        // Wait until the background sleep is visible as a descendant.
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut found_bg = false;
+        while Instant::now() < deadline {
+            let desc = all_descendants(root);
+            // Either sleep 999 is under root, or (if exec replaced sh) we
+            // still have the root sleep 998 alive.
+            if is_alive(root) {
+                // Look for any sleep-named descendant via /proc.
+                for d in &desc {
+                    if let Ok(cmd) = std::fs::read_to_string(format!("/proc/{d}/cmdline")) {
+                        if cmd.contains("sleep") {
+                            found_bg = true;
+                            break;
+                        }
+                    }
+                }
+                // Even without finding the bg sleep yet, proceed once root is up.
+                if found_bg || Instant::now() > deadline - Duration::from_secs(1) {
+                    break;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(is_alive(root), "root should still be alive before kill");
+
+        // Snapshot every descendant so we can assert none survive.
+        let mut watched = all_descendants(root);
+        watched.push(root);
+
+        kill_process_tree(root);
+        let _ = child.try_wait();
+
+        // Nothing in the original tree (or reparented to us) should remain.
+        for pid in watched {
+            assert!(!is_alive(pid), "pid {pid} should be dead after kill_process_tree");
+        }
+
+        // Also assert no leftover "sleep 999" from this test.
+        // (Best-effort: only fail if we can still see a descendant we tracked.)
+        reap_zombies();
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn direct_children_finds_spawned_child() {
+        let mut child = Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+        // Give the kernel a moment to publish the child in /proc.
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut found = false;
+        while Instant::now() < deadline {
+            let kids = direct_children(std::process::id());
+            if kids.contains(&pid) {
+                found = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(found, "expected {pid} in direct_children of self");
+        let _ = child.kill();
+        let _ = child.wait();
+        reap_zombies();
+    }
+}

--- a/mux/crates/mux-core/src/surface.rs
+++ b/mux/crates/mux-core/src/surface.rs
@@ -237,6 +237,10 @@ pub struct PtySurface {
     writer: Mutex<Box<dyn Write + Send>>,
     master: Mutex<Box<dyn MasterPty + Send>>,
     killer: Mutex<Box<dyn ChildKiller + Send>>,
+    /// Direct PTY child PID. Used to walk/kill the process tree on
+    /// surface kill (issue #28); grandchildren that double-forked would
+    /// otherwise outlive a single-pid SIGHUP from ChildKiller.
+    child_pid: Option<u32>,
     dead: AtomicBool,
     /// Set when output arrived since the last render; cleared by the
     /// frontend when it draws.
@@ -307,6 +311,7 @@ impl Surface {
 
         let mut child = pty.slave.spawn_command(cmd)?;
         drop(pty.slave);
+        let child_pid = child.process_id();
         let killer = child.clone_killer();
         let mut reader = pty.master.try_clone_reader()?;
         let writer = pty.master.take_writer()?;
@@ -348,6 +353,7 @@ impl Surface {
             writer: Mutex::new(writer),
             master: Mutex::new(pty.master),
             killer: Mutex::new(killer),
+            child_pid,
             dead: AtomicBool::new(false),
             dirty: AtomicBool::new(false),
             title: Mutex::new(String::new()),
@@ -621,6 +627,24 @@ impl Surface {
     pub fn kill(&self) {
         match self {
             Surface::Pty(pty) => {
+                // Issue #28: kill the whole process tree rooted at the PTY
+                // child, not just the direct child. portable_pty's
+                // ChildKiller only SIGHUPs a single pid, so backgrounded
+                // / double-forked grandchildren would otherwise leak.
+                #[cfg(target_os = "linux")]
+                {
+                    if let Ok(master) = pty.master.lock() {
+                        if let Some(pgid) = master.process_group_leader() {
+                            if pgid > 1 {
+                                // Negative pgid = signal the whole process group.
+                                let _ = unsafe { libc::kill(-pgid, libc::SIGTERM) };
+                            }
+                        }
+                    }
+                    if let Some(pid) = pty.child_pid {
+                        crate::process::kill_process_tree(pid);
+                    }
+                }
                 let _ = pty.killer.lock().unwrap().kill();
             }
             Surface::Browser(browser) => browser.kill(),

--- a/mux/crates/mux-core/tests/pty.rs
+++ b/mux/crates/mux-core/tests/pty.rs
@@ -742,3 +742,61 @@ fn session_persists_layout_and_cwd_across_simulated_restart() {
     std::env::remove_var("XDG_STATE_HOME");
     let _ = std::fs::remove_dir_all(&dir);
 }
+
+/// Issue #28 acceptance: spawning a background `sleep` under a pane shell,
+/// then shutting down the mux, leaves zero leftover processes from that tree.
+#[test]
+#[cfg(target_os = "linux")]
+fn shutdown_kills_background_grandchild_sleep() {
+    let _ = mux_core::process::set_child_subreaper();
+
+    // Shape: shell backgrounds sleep 999, then becomes sleep 998 so the
+    // surface stays alive until mux.shutdown().
+    let mux = Mux::new(
+        unique_session("issue28-tree"),
+        SurfaceOptions {
+            command: Some(vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                "sleep 999 & exec sleep 998".into(),
+            ]),
+            ..Default::default()
+        },
+    );
+    let _surface = mux.new_workspace(None, None).unwrap();
+
+    // Collect PIDs we care about (any sleep 998/999 that is a descendant
+    // of this test process via the subreaper / surface child).
+    let self_pid = std::process::id();
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut watched: Vec<u32> = Vec::new();
+    while Instant::now() < deadline {
+        watched = mux_core::process::all_descendants(self_pid)
+            .into_iter()
+            .filter(|&pid| {
+                std::fs::read_to_string(format!("/proc/{pid}/cmdline"))
+                    .map(|c| c.contains("sleep") && (c.contains("999") || c.contains("998")))
+                    .unwrap_or(false)
+            })
+            .collect();
+        if !watched.is_empty() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        !watched.is_empty(),
+        "expected sleep 998/999 descendant(s) before shutdown"
+    );
+
+    mux.shutdown();
+
+    let leftover: Vec<u32> = watched
+        .into_iter()
+        .filter(|&pid| mux_core::process::is_alive(pid))
+        .collect();
+    assert!(
+        leftover.is_empty(),
+        "leftover sleep PIDs after mux.shutdown(): {leftover:?}"
+    );
+}

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -253,6 +253,10 @@ fn run_attach(args: Args) -> anyhow::Result<()> {
 }
 
 fn run_server(args: Args) -> anyhow::Result<()> {
+    // Issue #28: inherit orphaned pane grandchildren so mux.shutdown()
+    // can reap them instead of leaving them under PID 1.
+    let _ = mux_core::process::set_child_subreaper();
+
     let mut surface_options = SurfaceOptions::default();
     let config = config::load();
     surface_options.chrome_binary = config.browser.chrome_binary.clone();
@@ -282,6 +286,13 @@ fn run_server(args: Args) -> anyhow::Result<()> {
         run_tui(Session::Local(mux.clone()), args.session)
     };
     mux.shutdown();
+    // Issue #28: after known surfaces are killed, sweep anything that
+    // reparented to us via PR_SET_CHILD_SUBREAPER (grandchildren whose
+    // intermediate parent already exited before surface.kill ran).
+    #[cfg(target_os = "linux")]
+    {
+        mux_core::process::kill_remaining_children();
+    }
     mux_core::server::cleanup(&socket_path);
     result
 }


### PR DESCRIPTION
## Summary

Closes #28 (priority path 1: `PR_SET_CHILD_SUBREAPER` + process-tree kill).

When a pane's shell exits or is killed, backgrounded / double-forked grandchildren used to leak under PID 1. This PR:

- enables `PR_SET_CHILD_SUBREAPER` on daemon start so orphans reparent to cmux
- records each PTY surface's child PID and, on `surface.kill()`, SIGTERMs the process group (when available) then walks `/proc` to SIGTERM → SIGKILL the whole tree
- after `mux.shutdown()` in the daemon path, sweeps any remaining reparented children

The global child sweep is intentionally **not** inside `Mux::shutdown()` so in-process parallel tests do not kill each other's PTYs.

## Acceptance (from #28)

- [x] Spawning a background `sleep` under a pane shell, then shutting down, leaves zero leftovers (`shutdown_kills_background_grandchild_sleep`)
- [x] Unit coverage for `kill_process_tree` and `direct_children`

cgroups v2 `cgroup.kill` remains deferred as noted in the issue (path 3).

## Test plan

- [x] `cargo test -p mux-core process::`
- [x] `cargo test -p mux-core --test pty shutdown_kills_background`
- [x] `cargo check -p mux-tui`
- [ ] Manual: `cmux --headless --session t28`, send `sleep 999 &`, `cmux kill-session --session t28`, confirm `pgrep -af 'sleep 999'` empty