### PR TITLE
fix(mux-tui): socket watchdog for SIGKILL cleanup (#27)

### DIFF
--- a/contrib/cmux-socket-watchdog.service
+++ b/contrib/cmux-socket-watchdog.service
@@ -1,0 +1,28 @@
+# Optional systemd --user unit for environments that prefer a supervised
+# companion over the in-process `cmux socket-watchdog` spawn (issue #27).
+#
+# The headless daemon already auto-spawns a detached watchdog on start, so
+# most users do not need this unit. Install it only if you want systemd to
+# own the watchdog lifecycle (Restart=on-failure, logout cleanup via the
+# user manager).
+#
+# Example (per session):
+#   systemctl --user import-environment
+#   systemctl --user set-environment CMUX_WATCH_PID=12345 CMUX_WATCH_SOCKET=/run/user/$UID/cmux-$UID/main.sock
+#   systemctl --user start cmux-socket-watchdog@main.service
+#
+# Or rely on the daemon's built-in spawn and leave this file as documentation.
+
+[Unit]
+Description=cmux socket watchdog for %i
+Documentation=https://github.com/mathewclarkau/cmux-linux/issues/27
+
+[Service]
+Type=simple
+# Expect CMUX_WATCH_PID and CMUX_WATCH_SOCKET in the environment.
+ExecStart=/usr/bin/env cmux socket-watchdog --pid ${CMUX_WATCH_PID} --socket ${CMUX_WATCH_SOCKET}
+Restart=on-failure
+RestartSec=1
+
+[Install]
+WantedBy=default.target

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -23,6 +23,7 @@ mod keys;
 mod pi_hook;
 mod session;
 mod skill_content;
+mod socket_watchdog;
 mod ssh_bootstrap;
 mod ui;
 
@@ -234,6 +235,9 @@ fn main() {
     if raw_args.first().map(|arg| arg.as_str()) == Some("ssh") {
         std::process::exit(ssh_bootstrap::run(&raw_args[1..]));
     }
+    if raw_args.first().map(|arg| arg.as_str()) == Some("socket-watchdog") {
+        std::process::exit(socket_watchdog::run(&raw_args[1..]));
+    }
     if cli::is_cli_invocation(&raw_args) {
         std::process::exit(cli::run(&raw_args, USAGE));
     }
@@ -275,6 +279,9 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     mux.restore_session();
     mux.enable_persistence();
     mux_core::server::serve(mux.clone(), Some(socket_path.clone()))?;
+    // Issue #27: detached companion that unlinks .sock/.pid if we die via
+    // SIGKILL (handlers/atexit never run). Harmless no-op on graceful exit.
+    socket_watchdog::spawn(std::process::id(), &socket_path);
 
     let result = if args.headless {
         run_headless(&mux, &socket_path)

--- a/mux/crates/mux-tui/src/socket_watchdog.rs
+++ b/mux/crates/mux-tui/src/socket_watchdog.rs
@@ -1,0 +1,172 @@
+//! External companion that removes a session's `.sock` / `.pid` after the
+//! daemon dies — including the SIGKILL case where signal handlers and
+//! `atexit` never run (issue #27).
+//!
+//! The daemon spawns `cmux socket-watchdog --pid <daemon> --socket <path>`
+//! as a detached child right after binding. The watchdog polls until the
+//! target PID is gone (or is no longer a cmux process — PID-reuse guard),
+//! then unlinks both files and exits. On graceful shutdown the daemon
+//! already unlinks; the watchdog's second unlink is a no-op.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use mux_core::server::{is_cmux_process, is_process_alive, pid_path};
+
+const POLL_MS: u64 = 200;
+/// Upper bound matching issue #27 acceptance (≤5s). Used only in tests /
+/// docs; the loop itself has no timeout while the daemon lives.
+#[allow(dead_code)]
+pub const MAX_CLEANUP_SECS: u64 = 5;
+
+/// Spawn a detached watchdog watching `daemon_pid` + `socket_path`.
+/// Failures are swallowed: a missing watchdog only means SIGKILL leaves
+/// stale files (the pre-#27 behaviour), never blocks daemon start.
+pub fn spawn(daemon_pid: u32, socket_path: &Path) {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let socket = socket_path.display().to_string();
+    let pid_s = daemon_pid.to_string();
+    let _ = Command::new(exe)
+        .args(["socket-watchdog", "--pid", &pid_s, "--socket", &socket])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+}
+
+/// Entry point for `cmux socket-watchdog ...`. Returns a process exit code.
+pub fn run(args: &[String]) -> i32 {
+    let mut pid: Option<u32> = None;
+    let mut socket: Option<PathBuf> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--pid" => {
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    eprintln!("cmux socket-watchdog: --pid needs a value");
+                    return 2;
+                };
+                match v.parse::<u32>() {
+                    Ok(p) if p > 1 => pid = Some(p),
+                    _ => {
+                        eprintln!("cmux socket-watchdog: invalid --pid {v}");
+                        return 2;
+                    }
+                }
+            }
+            "--socket" => {
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    eprintln!("cmux socket-watchdog: --socket needs a value");
+                    return 2;
+                };
+                socket = Some(PathBuf::from(v));
+            }
+            "-h" | "--help" => {
+                print_usage();
+                return 0;
+            }
+            other => {
+                eprintln!("cmux socket-watchdog: unknown argument {other}");
+                print_usage();
+                return 2;
+            }
+        }
+        i += 1;
+    }
+
+    let Some(pid) = pid else {
+        eprintln!("cmux socket-watchdog: --pid is required");
+        return 2;
+    };
+    let Some(socket) = socket else {
+        eprintln!("cmux socket-watchdog: --socket is required");
+        return 2;
+    };
+
+    watch_until_dead(pid, &socket);
+    cleanup_files(&socket);
+    0
+}
+
+fn print_usage() {
+    eprint!(
+        "\
+cmux socket-watchdog — remove a session socket after the daemon dies
+
+USAGE:
+  cmux socket-watchdog --pid <daemon-pid> --socket <path>
+
+Not intended for interactive use; the daemon spawns this automatically.
+"
+    );
+}
+
+/// Block until `pid` is dead or no longer a cmux process (PID reuse).
+fn watch_until_dead(pid: u32, _socket: &Path) {
+    loop {
+        if !is_process_alive(pid) {
+            break;
+        }
+        // PID reused by something that is not cmux → treat as dead so we
+        // don't hold the socket forever for the wrong owner.
+        if !is_cmux_process(pid) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(POLL_MS));
+    }
+}
+
+fn cleanup_files(socket: &Path) {
+    let _ = std::fs::remove_file(socket);
+    let _ = std::fs::remove_file(pid_path(socket));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use std::time::Instant;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn watchdog_unlinks_after_target_dies() {
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-wd-test-{}-{}",
+            std::process::id(),
+            Instant::now().elapsed().as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let socket = dir.join("sess.sock");
+        let pid_file = dir.join("sess.pid");
+        // Dummy files the watchdog should remove.
+        fs::write(&socket, b"").unwrap();
+        // Spawn a short-lived process to watch.
+        let mut child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        let pid = child.id();
+        fs::write(&pid_file, format!("{pid}\n")).unwrap();
+
+        // Run the watch loop in-process against a process we kill.
+        let sock = socket.clone();
+        let handle = std::thread::spawn(move || {
+            watch_until_dead(pid, &sock);
+            cleanup_files(&sock);
+        });
+
+        std::thread::sleep(Duration::from_millis(100));
+        let _ = child.kill();
+        let _ = child.wait();
+
+        handle.join().expect("watchdog thread");
+
+        assert!(!socket.exists(), "socket should be unlinked");
+        assert!(!pid_file.exists(), "pid file should be unlinked");
+        let _ = fs::remove_dir_all(&dir);
+    }
+}

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -852,29 +852,12 @@ fn serve_recovers_from_stale_socket() {
     let socket = dir.join("recover.sock");
     let pid_file = dir.join("recover.pid");
 
-    // Spawn a daemon and SIGKILL it without cleanup
-    let mut child = Command::new(bin())
-        .args(["--headless", "--socket"])
-        .arg(&socket)
-        .env("XDG_RUNTIME_DIR", &dir)
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
-
-    let deadline = Instant::now() + Duration::from_secs(15);
-    while Instant::now() < deadline {
-        if socket.exists() && pid_file.exists() {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(25));
-    }
-
-    let _ = child.kill();
-    let _ = child.wait();
-
-    // Verify stale socket still exists on disk
+    // Synthetic stale pair (dead PID). We no longer rely on SIGKILL leaving
+    // files behind — the socket-watchdog (#27) cleans those up within ≤5s.
+    fs::write(&socket, b"").unwrap();
+    fs::write(&pid_file, "999999\n").unwrap();
     assert!(socket.exists());
+    assert!(pid_file.exists());
 
     // Start a new daemon on the same socket path — should clear stale socket and bind
     let mut child2 = Command::new(bin())
@@ -903,5 +886,56 @@ fn serve_recovers_from_stale_socket() {
 
     let _ = child2.kill();
     let _ = child2.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Issue #27 acceptance: `kill -9` on a headless daemon leaves zero
+/// leftover `.sock`/`.pid` files within ≤5s without operator action.
+#[test]
+fn sigkill_watchdog_removes_socket_and_pid_within_5s() {
+    let dir = unique_temp_dir("sigkill-wd");
+    fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("wd-sess.sock");
+    let pid_file = dir.join("wd-sess.pid");
+
+    let mut child = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if socket.exists() && pid_file.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(socket.exists(), "daemon should create socket");
+    assert!(pid_file.exists(), "daemon should create pid file");
+
+    // SIGKILL bypasses handlers/atexit — only the external watchdog cleans up.
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let cleanup_deadline = Instant::now() + Duration::from_secs(5);
+    let mut cleaned = false;
+    while Instant::now() < cleanup_deadline {
+        if !socket.exists() && !pid_file.exists() {
+            cleaned = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        cleaned,
+        "watchdog should unlink socket+pid within 5s after SIGKILL (socket={}, pid={})",
+        socket.exists(),
+        pid_file.exists()
+    );
+
     let _ = fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary

Closes #27.

SIGTERM/SIGINT already clean the session socket via handlers; **SIGKILL cannot**. This PR auto-spawns a detached companion after the control socket binds:

```
cmux socket-watchdog --pid <daemon> --socket <path>
```

The watchdog polls (~200ms) until the target PID is dead (or no longer a cmux process — PID-reuse guard), then unlinks `.sock` + `.pid` and exits. Graceful shutdown still cleans up itself; the watchdog's second unlink is a no-op.

Also ships an optional `contrib/cmux-socket-watchdog.service` systemd user unit for environments that prefer supervised lifecycle (the built-in spawn covers the default path without systemd).

## Acceptance (from #27)

- [x] `kill -9` on `cmux --headless` leaves zero leftover `.sock`/`.pid` within ≤5s (`sigkill_watchdog_removes_socket_and_pid_within_5s`)
- [x] Compatible with existing `kill-session` / `kill-stale` tests
- [x] Watchdog exits after cleanup (no long-lived orphan after the daemon is gone)

## Test plan

- [x] `cargo test -p mux-tui -- socket_watchdog`
- [x] `cargo test -p mux-tui --test cli -- sigkill_watchdog`
- [x] `cargo test -p mux-tui --test cli -- serve_recovers`
- [x] `cargo test -p mux-tui --test cli -- kill_session`
- [ ] Manual: `cmux --headless --session t27 &`; `kill -9 $!`; confirm socket gone within 5s