### PR TITLE
re-sync(upstream @ d19f59aa2): PATH fix + upstream tracking (#29)

### DIFF
--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -4,7 +4,7 @@ This repository repurposes pieces of [manaflow-ai/cmux](https://github.com/manaf
 for Linux. The upstream `cmux` app itself is macOS-only (Swift/AppKit) and is not
 included here. What's included:
 
-- `mux/` — vendored verbatim (build artifacts excluded) from
+- `mux/` — vendored from
   `manaflow-ai/cmux@adc48877acd03a000da1660006713ac9f81ed611`, subdirectory `mux/`.
   This is the project's own cross-platform Rust + Zig terminal-multiplexer backend
   (`cmux` / `mux-tui`), already OS-agnostic upstream. It is not a git submodule
@@ -18,12 +18,14 @@ included here. What's included:
   `manaflow-ai/ghostty` remote); local modifications live as patch files in
   `patches/`, applied by `scripts/bootstrap.sh` after `submodule update`. See
   `patches/*.patch` for what each one does and why.
-- `daemon/remote/` — vendored verbatim from the same
+- `daemon/remote/` — vendored from the same
   `manaflow-ai/cmux@adc48877acd03a000da1660006713ac9f81ed611`, subdirectory
-  `daemon/remote/`. This is `cmuxd-remote`, upstream's own Go daemon for durable
-  remote PTYs over SSH — already cross-compiles cleanly for `linux/{amd64,arm64}`.
-  Used unmodified; `mux-core/src/remote_pty.rs` and `mux-tui/src/ssh_bootstrap.rs`
-  are new Rust code that builds it, uploads it, and speaks its NDJSON RPC protocol.
+  `daemon/remote/`, plus selective re-sync cherry-picks documented below and in
+  [`UPSTREAM.md`](./UPSTREAM.md). This is `cmuxd-remote`, upstream's own Go daemon
+  for durable remote PTYs over SSH — already cross-compiles cleanly for
+  `linux/{amd64,arm64}`. `mux-core/src/remote_pty.rs` and
+  `mux-tui/src/ssh_bootstrap.rs` are new Rust code that builds it, uploads it,
+  and speaks its NDJSON RPC protocol.
 
 ## Licensing
 
@@ -35,6 +37,30 @@ included here. What's included:
   repository-wide grant, so the GPL-3.0-or-later terms govern these vendored
   copies unless/until Manaflow states otherwise.
 - `ghostty` (the submodule) is MIT-licensed; see `ghostty/LICENSE`.
+
+## Anchor history
+
+Append-only. Do not rewrite prior rows when re-syncing.
+
+| Date | Event | Upstream SHA | Integrated | Skipped | Deferred | Notes |
+|------|-------|--------------|------------|---------|----------|-------|
+| 2026-07 (initial) | Vendor `mux/` + `daemon/remote/` | `adc48877acd03a000da1660006713ac9f81ed611` | — | — | — | Original Linux-port anchor |
+| 2026-07-23 | Classification + batch 1 PATH fix (#29) | Classified against `7652d3b1cf24b86188d8d04efe60dd6d317b39d1`; integrated `d19f59aa2` | 1 | 14 | 13 | Full table in `UPSTREAM.md`. `mux/` still at anchor + port commits; `daemon/remote/` = anchor + PATH cherry-pick |
+
+**Current code anchors**
+
+| Tree | Base vendor SHA | Plus |
+|------|-----------------|------|
+| `mux/` | `adc48877a` | Linux-port commits only (hooks, sessions CLI, etc.) |
+| `daemon/remote/` | `adc48877a` | Cherry-pick `d19f59aa2` (remote PTY PATH) |
+| `ghostty/` submodule | `a78fe53ef` | `patches/*.patch` via bootstrap |
+
+## Re-sync cadence
+
+Monthly (or sooner if a known-fixed upstream bug bites us): follow the procedure
+in [`UPSTREAM.md`](./UPSTREAM.md). Goal: keep the classification table honest so
+contributors can see at a glance whether a release is "up to date with upstream
+@ X" or deliberately behind.
 
 ## What was NOT touched
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This repo instead builds on `mux/`, upstream's own cross-platform Rust + Zig bac
 (`cmux` / `mux-tui`), which already reimplements the same session → workspace →
 screen → pane → surface model over a JSON-Lines Unix-socket control protocol. See
 [`PROVENANCE.md`](./PROVENANCE.md) for exactly what was vendored from where, and
-under what license.
+[`UPSTREAM.md`](./UPSTREAM.md) for release↔upstream mapping and the re-sync
+procedure.
 
 This is an unofficial, community-maintained port and is not affiliated with,
 endorsed by, or supported by Manaflow, Inc. Upstream `cmux` is dual-licensed

--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -1,0 +1,137 @@
+# Upstream tracking
+
+How `mathewclarkau/cmux-linux` relates to
+[`manaflow-ai/cmux`](https://github.com/manaflow-ai/cmux), and how to re-sync.
+
+See also [`PROVENANCE.md`](./PROVENANCE.md) for the original vendor anchors and
+licensing. This file is the living **drift ledger** (issue #29).
+
+## Release ↔ upstream map
+
+| Our release | Merged-from upstream | Upstream HEAD at integration | Notes |
+|-------------|----------------------|------------------------------|-------|
+| v0.1.0 | (initial vendor) | `adc48877a` | Anchor for `mux/` + `daemon/remote/` |
+| v0.4.0 | (n/a — port-only) | `7652d3b1c` (observed, not integrated) | First large port divergence: session CLI, agent hooks, Linux lifecycle |
+| *next after #29 batch 1* | `d19f59aa2` (PATH fix only) | `7652d3b1c` | See [Integration log](#integration-log) |
+
+Update this table on every release that either integrates upstream commits or
+deliberately ships further port-only work while upstream advances.
+
+## What we deliberately do NOT carry
+
+| Area | Why skipped |
+|------|-------------|
+| Swift / AppKit / macOS app | Linux port surface is `mux/` + `daemon/remote/` + Ghostty VT only |
+| iOS recovery, macOS notifications | Platform-specific |
+| Upstream MSRV 1.88 / edition 2024 (`760e343d0`) | We pin **Rust 1.75.0** in CI (`pr-build.yml`); adopting requires a coordinated toolchain bump PR |
+| `npx`/`uvx` publish pipelines, Freestyle cloud slots | Distribution / cloud product paths, not the Linux TUI core |
+| Sidebar plugin manager (`a19223059`, `a1c5295dd`) | Large feature; evaluate after MSRV / protocol alignment |
+| Full protocol-6 + window-manager socket surface | Needs careful merge against our hooks + session CLI; batch later |
+
+## Re-sync procedure
+
+Run this on a cadence (monthly is fine; sooner if a remote-PTY or mux bug is
+known fixed upstream). Owner: whoever is on rotation.
+
+### 1. Fetch and inventory
+
+```bash
+# Side clone (do not put this inside the cmux-linux worktree)
+git clone --filter=blob:none https://github.com/manaflow-ai/cmux.git /tmp/cmux-upstream
+cd /tmp/cmux-upstream
+ANCHOR=$(grep -oE 'manaflow-ai/cmux@[0-9a-f]{7,}' \
+  /path/to/cmux-linux/PROVENANCE.md | head -1 | cut -d@ -f2)
+# Prefer the latest "Integrated through" SHA from PROVENANCE.md Anchor history.
+git fetch origin "$ANCHOR" HEAD
+git log --oneline "${ANCHOR}..HEAD" -- mux/ daemon/remote/
+```
+
+### 2. Classify each commit
+
+For every commit that touches `mux/` or `daemon/remote/`, label it:
+
+| Label | Meaning | Action |
+|-------|---------|--------|
+| **(a) integrate** | Linux-port-relevant, applies cleanly or with small edits | Cherry-pick / port into a `re-sync(upstream @ <sha>)` PR |
+| **(b) skip** | macOS-only, product packaging, or superseded by our port | Document in the tally; do not code |
+| **(c) defer** | Relevant but conflicts with our hooks / MSRV / protocol work | Call out; schedule a later batch |
+
+### 3. Integrate in batches
+
+- One PR per batch. Commit message pattern:
+
+  ```
+  re-sync(upstream @ <shortsha>): <one-line summary of what landed>
+
+  Integrated: <list>
+  Skipped: <count + reason summary>
+  Deferred: <count + reason summary>
+  ```
+
+- Prefer cherry-picks of focused Go/`daemon/remote` fixes first (smaller
+  conflict surface). Large `mux/` rewrites (MSRV, plugins, rebrand) need their
+  own planning PR.
+
+### 4. Update docs in the same PR
+
+1. Append a row to [Release ↔ upstream map](#release--upstream-map) if this
+   batch will ship in a named release; otherwise update the integration log.
+2. Append to **Anchor history** in `PROVENANCE.md` (never overwrite prior rows).
+3. Bump the "Integrated through" / "Classified against" SHAs.
+4. Release notes for the next tag should include:
+
+   ```
+   Upstream: integrated <range or list>; classified against manaflow-ai/cmux@<sha>
+   ```
+
+### 5. Do not re-sync Ghostty here
+
+`ghostty/` tracks `manaflow-ai/ghostty` on its own pin + `patches/`. Re-syncing
+the submodule pointer is a separate change from `mux/` / `daemon/remote/`.
+
+## Classification snapshot (against `7652d3b1c`, 2026-07-23)
+
+28 commits touch `mux/` or `daemon/remote/` between anchor `adc48877a` and
+upstream HEAD `7652d3b1c`. Full tally at classification time:
+
+| SHA | Subject | Class | Notes |
+|-----|---------|-------|-------|
+| `e157d80bb` | read-screen reports rendered viewport | **defer** | Useful; merge after our read-screen callers reviewed |
+| `b197d2353` | client SDKs TS/Rust/Go/Java + e2e | **skip** | SDK publish surface; optional later |
+| `835c46d9b` | PTY-free surfaces for structural tests | **defer** | Good for CI; needs careful port |
+| `bd0b24b74` | persistent Freestyle sshd cloud slot | **skip** | Cloud product |
+| `7a2d486b2` | bindings: unify SDK identity on cmux | **skip** | Bindings rename churn |
+| `bb2d8c070` | protocol-6 commands + tests | **defer** | Protocol expansion batch |
+| `f41794c68` | window-manager ops on control socket | **defer** | Depends on protocol-6 direction |
+| `fce37f1cb` | purge agent/notification tables on close | **defer** | Relevant lifecycle fix |
+| `f452ddbd5` | ping, reload-config, window-title, scroll-changed | **defer** | Useful verbs; batch with protocol work |
+| `a44618f64` | SDK publish workflows | **skip** | CI product |
+| `0302b40ea` | sdk 0.1.2 npm publish | **skip** | Packaging |
+| `be3535344` | npx/uvx cmux distribution | **skip** | Packaging |
+| `df264cbfc` | publish cmux-mux artifacts linux/darwin | **skip** | We have our own release.yml |
+| `760e343d0` | edition 2024, MSRV 1.88, latest deps | **skip** | Conflicts with Rust 1.75 pin |
+| `155d344e3` | tmux/zellij-familiar keybindings | **defer** | UX; evaluate vs our key table |
+| `a19223059` | pluggable sidebar | **skip** | Large feature |
+| `a1c5295dd` | plugin manager from git | **skip** | Depends on sidebar plugins |
+| `d675f0a0e` | rebrand mux → cmux-tui | **skip** | We already renamed independently |
+| `c914b23a2` | ssh PTY input loss / reorder fix | **defer** | High value; large patch, needs dedicated batch |
+| `f38b30371` | light-theme-aware chrome | **defer** | Nice-to-have TUI polish |
+| `97872bc79` | windows-gnu CI + remove mux/target | **skip** | Windows CI; we never commit target |
+| `2eeac82c6` | resize-pane remote tmux mirror | **skip** | Mostly Swift; Go relay hunks optional later |
+| `b250ada01` | reap persistent SSH daemon on workspace close | **defer** | Lifecycle; depends on persistent-slot work |
+| `3c1a6c2f6` | workspace group CLI deletion safe by default | **skip** | macOS/workspace-group product |
+| `9a06a6988` | shield persistent remote PTY children | **defer** | Large remote-daemon refactor; foundation for later remote fixes |
+| `d19f59aa2` | Fix remote PTY PATH inherited from cmuxd | **integrate** | Batch 1 (this PR) |
+| `9f0613e23` | tear a PTY session down once | **defer** | Needs `9a06a6988` structure first |
+| `38b8ca796` | respawn-pane in Go relay __tmux-compat | **defer** | SSH teammate panes; after relay baseline |
+
+**Tally (2026-07-23):** integrated **1** · skipped **14** · deferred **13**.
+
+## Integration log
+
+### Batch 1 — `re-sync(upstream @ d19f59aa2)` (issue #29)
+
+- **Integrated:** `d19f59aa2` — remote PTY PATH always includes standard executable directories (`/usr/bin`, `/bin`, …) so a restricted daemon PATH does not strand interactive shells.
+- **Skipped / deferred:** see table above (27 remaining of the 28-commit window).
+- **Code anchor for `daemon/remote/` PATH helper:** still rooted at original vendor `adc48877a`, plus this cherry-picked fix.
+- **`mux/` code anchor:** unchanged at `adc48877a` (+ our port commits).

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -89,6 +89,7 @@ const (
 	defaultPTYInputChunkBytes        = 16 * 1024
 	defaultWebSocketWriteTimeout     = 10 * time.Second
 	defaultWebSocketSessionIdleTTL   = 24 * time.Hour
+	standardExecutablePath           = "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 )
 
 type wsPTYOutgoingFrame struct {
@@ -522,6 +523,7 @@ func defaultWebSocketPTYEnv(shellPath string) []string {
 		}
 	}
 
+	set("PATH", pathWithStandardExecutableDirectories(env["PATH"]))
 	set("TERM", "xterm-256color")
 	setIfMissing("COLORTERM", "truecolor")
 	setIfMissing("TERM_PROGRAM", "ghostty")
@@ -543,6 +545,22 @@ func defaultWebSocketPTYEnv(shellPath string) []string {
 		out = append(out, key+"="+env[key])
 	}
 	return out
+}
+
+func pathWithStandardExecutableDirectories(inheritedPath string) string {
+	entries := filepath.SplitList(inheritedPath)
+	present := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		present[entry] = struct{}{}
+	}
+	for _, standardDirectory := range filepath.SplitList(standardExecutablePath) {
+		if _, ok := present[standardDirectory]; ok {
+			continue
+		}
+		entries = append(entries, standardDirectory)
+		present[standardDirectory] = struct{}{}
+	}
+	return strings.Join(entries, string(os.PathListSeparator))
 }
 
 func envMapWithOrder(values []string) (map[string]string, []string) {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -836,6 +836,52 @@ func TestWebSocketPTYScrollbackDoesNotRetainOversizedChunks(t *testing.T) {
 	}
 }
 
+func TestDefaultWebSocketPTYEnvAddsStandardExecutableDirectories(t *testing.T) {
+	tests := []struct {
+		name          string
+		inheritedPath string
+	}{
+		{name: "restricted daemon PATH", inheritedPath: "/opt/cmux/bin"},
+		{name: "empty daemon PATH", inheritedPath: ""},
+		{name: "partially complete daemon PATH", inheritedPath: "/opt/cmux/bin:/usr/bin"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("PATH", test.inheritedPath)
+
+			env, _ := envMapWithOrder(defaultWebSocketPTYEnv("/bin/sh"))
+			pathEntries := strings.Split(env["PATH"], string(os.PathListSeparator))
+			inheritedPrefix := test.inheritedPath + string(os.PathListSeparator)
+			if test.inheritedPath != "" && env["PATH"] != test.inheritedPath && !strings.HasPrefix(env["PATH"], inheritedPrefix) {
+				t.Fatalf("PATH should preserve inherited entries first, got %q", env["PATH"])
+			}
+			for _, standardDirectory := range []string{
+				"/usr/local/bin",
+				"/usr/bin",
+				"/bin",
+				"/usr/local/sbin",
+				"/usr/sbin",
+				"/sbin",
+			} {
+				if count := countStrings(pathEntries, standardDirectory); count != 1 {
+					t.Errorf("PATH %q contains standard directory %q %d times, want once", env["PATH"], standardDirectory, count)
+				}
+			}
+		})
+	}
+}
+
+func countStrings(values []string, target string) int {
+	count := 0
+	for _, value := range values {
+		if value == target {
+			count++
+		}
+	}
+	return count
+}
+
 func TestWebSocketPTYSeedsUTF8LocaleAndTerminalEnv(t *testing.T) {
 	leasePath := filepath.Join(t.TempDir(), "lease.json")
 	server, _ := newTestWebSocketPTYServer(t, leasePath)


### PR DESCRIPTION
## Summary

Addresses #29 (first batch — process + one safe code integration).

### Docs (drift management)

- New [`UPSTREAM.md`](./UPSTREAM.md): release↔upstream table, “what we do NOT carry”, re-sync procedure, full classification of **28** upstream commits touching `mux/` / `daemon/remote/` since anchor `adc48877a` (against HEAD `7652d3b1c`).
- [`PROVENANCE.md`](./PROVENANCE.md): append-only **Anchor history** + current code anchors (never overwrites the original vendor SHA).
- README links to both.

**Tally at classification:** integrated **1** · skipped **14** · deferred **13**.

### Code (batch 1)

Cherry-pick of upstream `d19f59aa2` — remote PTY env always includes standard executable directories so a restricted `cmuxd-remote` PATH does not strand interactive shells. Unit test included; `go test` passes.

### Explicitly not in this PR

- MSRV 1.88 / edition 2024 (`760e343d0`) — conflicts with our Rust 1.75 pin
- Large remote-daemon refactors (persistent PTY shielding, input seq_ack) — deferred dedicated batches
- Sidebar plugins, protocol-6 expansion, packaging/npx pipelines — skip or defer per table

## Test plan

- [x] `go test ./cmd/cmuxd-remote/ -run TestDefaultWebSocketPTYEnvAddsStandardExecutableDirectories` (in `daemon/remote/`)
- [x] Classification inventory against `manaflow-ai/cmux@7652d3b1c`
- [ ] Reviewer: skim `UPSTREAM.md` table for mis-labels