### PR TITLE
fix(mux-tui): paste clipboard images into PTY panes (#30)

### DIFF
--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -1658,6 +1658,17 @@ impl App {
             self.forward_browser_key(key);
             return;
         }
+        // Issue #30: Claude Code (and similar agents) try to read the OS
+        // clipboard on Ctrl+V for images, but that often fails inside a
+        // nested multiplexer. If the clipboard holds an image, materialize
+        // it and paste `@/path.png` so agents can attach the file.
+        if is_paste_image_chord(key) {
+            if let Some(payload) = crate::clipboard::image_paste_payload() {
+                self.paste(&payload);
+                return;
+            }
+            // No image → fall through so text Ctrl+V / agent handlers run.
+        }
         let Some(input) = keys::key_input_from(key) else { return };
         let Some(surface) = self.active_surface_handle() else { return };
         self.encode_buf.clear();
@@ -1747,6 +1758,17 @@ impl App {
             });
             return;
         }
+        // Host terminal paste of an image often yields empty text. Try the
+        // system clipboard image path before no-op'ing (issue #30).
+        let text = if text.is_empty() {
+            if let Some(payload) = crate::clipboard::image_paste_payload() {
+                payload
+            } else {
+                return;
+            }
+        } else {
+            text.to_string()
+        };
         let Some(bracketed) = surface.with_terminal(|t| t.mode(2004, false)) else {
             return;
         };
@@ -2664,6 +2686,20 @@ fn browser_modifiers(modifiers: KeyModifiers) -> u32 {
         out |= 8;
     }
     out
+}
+
+/// Ctrl+V or Alt+V — chords Claude Code uses for image paste on Linux/Windows.
+fn is_paste_image_chord(key: &KeyEvent) -> bool {
+    if key.kind != KeyEventKind::Press {
+        return false;
+    }
+    if !matches!(key.code, KeyCode::Char('v') | KeyCode::Char('V')) {
+        return false;
+    }
+    let mods = key.modifiers;
+    // Ctrl+V (Linux / most terminals) or Alt+V (Claude's Windows hint).
+    (mods.contains(KeyModifiers::CONTROL) && !mods.contains(KeyModifiers::ALT))
+        || (mods.contains(KeyModifiers::ALT) && !mods.contains(KeyModifiers::CONTROL))
 }
 
 fn browser_only_action(action: Action) -> bool {

--- a/mux/crates/mux-tui/src/browser_input.rs
+++ b/mux/crates/mux-tui/src/browser_input.rs
@@ -69,29 +69,9 @@ pub enum BrowserInputKind {
     PasteFromSystemClipboard,
 }
 
-/// Reads the desktop clipboard by shelling out to whichever clipboard tool
-/// is available, since cmux (unlike the outer terminal) has no direct
-/// clipboard API of its own - it only ever *writes* the clipboard, via
-/// OSC52. Tries Wayland's `wl-paste` first, then X11's `xclip`; returns
-/// `None` (not an error) if neither is installed or the clipboard is
-/// empty/unreadable, so callers can no-op cleanly.
+/// Text clipboard read (shared with PTY image-paste in `clipboard`).
 fn read_system_clipboard() -> Option<String> {
-    let from_wl_paste = std::process::Command::new("wl-paste")
-        .arg("--no-newline")
-        .output()
-        .ok()
-        .filter(|out| out.status.success())
-        .map(|out| out.stdout);
-    let from_xclip = from_wl_paste.or_else(|| {
-        std::process::Command::new("xclip")
-            .args(["-selection", "clipboard", "-o"])
-            .output()
-            .ok()
-            .filter(|out| out.status.success())
-            .map(|out| out.stdout)
-    });
-    let text = String::from_utf8(from_xclip?).ok()?;
-    (!text.is_empty()).then_some(text)
+    crate::clipboard::read_text()
 }
 
 impl BrowserInputKind {

--- a/mux/crates/mux-tui/src/clipboard.rs
+++ b/mux/crates/mux-tui/src/clipboard.rs
@@ -1,0 +1,125 @@
+//! System clipboard helpers for the TUI.
+//!
+//! cmux only *writes* the host clipboard via OSC 52. Reads shell out to
+//! `wl-paste` (Wayland) or `xclip` (X11) so we can paste into browser panes
+//! and inject clipboard images into PTY panes (issue #30 — Claude Code's
+//! own clipboard read often fails inside nested terminal multiplexers).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Read text from the desktop clipboard. Returns `None` if no tool is
+/// available or the clipboard is empty/unreadable.
+pub fn read_text() -> Option<String> {
+    let bytes = read_clipboard_bytes(&["wl-paste", "--no-newline"], &["xclip", "-selection", "clipboard", "-o"])?;
+    let text = String::from_utf8(bytes).ok()?;
+    (!text.is_empty()).then_some(text)
+}
+
+/// Read a PNG image from the desktop clipboard, if one is present.
+pub fn read_image_png() -> Option<Vec<u8>> {
+    // Prefer explicit image MIME types so we don't pull text as "image".
+    if let Some(bytes) = read_clipboard_bytes(
+        &["wl-paste", "--type", "image/png"],
+        &["xclip", "-selection", "clipboard", "-t", "image/png", "-o"],
+    ) {
+        if looks_like_png(&bytes) {
+            return Some(bytes);
+        }
+    }
+    // Some compositors only expose image/jpeg or omit type filters.
+    if let Some(bytes) = read_clipboard_bytes(
+        &["wl-paste", "--type", "image/jpeg"],
+        &["xclip", "-selection", "clipboard", "-t", "image/jpeg", "-o"],
+    ) {
+        if !bytes.is_empty() {
+            return Some(bytes);
+        }
+    }
+    None
+}
+
+/// Write `png` bytes to a unique temp file under the runtime dir and return
+/// its absolute path. Caller is responsible for eventually cleaning up
+/// (OS temp cleanup is fine for short-lived paste files).
+pub fn write_paste_image(png_or_image: &[u8]) -> Option<PathBuf> {
+    let dir = paste_dir()?;
+    std::fs::create_dir_all(&dir).ok()?;
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_nanos();
+    let ext = if looks_like_png(png_or_image) { "png" } else { "img" };
+    let path = dir.join(format!("paste-{}-{}.{}", std::process::id(), nanos, ext));
+    std::fs::write(&path, png_or_image).ok()?;
+    Some(path)
+}
+
+/// If the clipboard holds an image, materialize it and return a paste
+/// payload Claude Code / agents understand: `@/abs/path.png`.
+/// Returns `None` when no image is available (caller should fall through
+/// to normal Ctrl+V / text paste).
+pub fn image_paste_payload() -> Option<String> {
+    let bytes = read_image_png()?;
+    let path = write_paste_image(&bytes)?;
+    Some(format!("@{}", path.display()))
+}
+
+fn paste_dir() -> Option<PathBuf> {
+    if let Ok(runtime) = std::env::var("XDG_RUNTIME_DIR") {
+        if !runtime.is_empty() {
+            return Some(Path::new(&runtime).join("cmux").join("pastes"));
+        }
+    }
+    Some(std::env::temp_dir().join("cmux-pastes"))
+}
+
+fn looks_like_png(bytes: &[u8]) -> bool {
+    bytes.len() >= 8 && bytes.starts_with(b"\x89PNG\r\n\x1a\n")
+}
+
+/// Try `wl_args` first (argv[0] = binary), then `x_args`.
+fn read_clipboard_bytes(wl_args: &[&str], x_args: &[&str]) -> Option<Vec<u8>> {
+    let from_wl = run_capture(wl_args);
+    from_wl.or_else(|| run_capture(x_args))
+}
+
+fn run_capture(args: &[&str]) -> Option<Vec<u8>> {
+    if args.is_empty() {
+        return None;
+    }
+    let output = Command::new(args[0]).args(&args[1..]).output().ok()?;
+    if !output.status.success() || output.stdout.is_empty() {
+        return None;
+    }
+    Some(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn looks_like_png_detects_signature() {
+        let mut bytes = b"\x89PNG\r\n\x1a\n".to_vec();
+        bytes.extend_from_slice(&[0u8; 16]);
+        assert!(looks_like_png(&bytes));
+        assert!(!looks_like_png(b"not a png"));
+        assert!(!looks_like_png(b""));
+    }
+
+    #[test]
+    fn write_paste_image_roundtrips() {
+        let mut bytes = b"\x89PNG\r\n\x1a\n".to_vec();
+        bytes.extend_from_slice(b"fake-png-body");
+        let path = write_paste_image(&bytes).expect("write");
+        assert!(path.exists());
+        assert_eq!(std::fs::read(&path).unwrap(), bytes);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn image_paste_payload_none_when_no_image_tool_or_empty() {
+        // Without a real image on the clipboard this returns None; we only
+        // assert it does not panic.
+        let _ = image_paste_payload();
+    }
+}

--- a/mux/crates/mux-tui/src/clipboard.rs
+++ b/mux/crates/mux-tui/src/clipboard.rs
@@ -47,7 +47,11 @@ pub fn write_paste_image(png_or_image: &[u8]) -> Option<PathBuf> {
     let dir = paste_dir()?;
     std::fs::create_dir_all(&dir).ok()?;
     let nanos = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_nanos();
-    let ext = if looks_like_png(png_or_image) { "png" } else { "img" };
+    // Use a real image extension: agents (Claude Code) detect attachments by
+    // file extension, so a `.img` file would not be recognised as an image.
+    // The only non-PNG source is the `image/jpeg` clipboard branch, so any
+    // non-PNG payload here is JPEG.
+    let ext = if looks_like_png(png_or_image) { "png" } else { "jpg" };
     let path = dir.join(format!("paste-{}-{}.{}", std::process::id(), nanos, ext));
     std::fs::write(&path, png_or_image).ok()?;
     Some(path)

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -12,6 +12,7 @@ mod app;
 mod browser_input;
 mod claude_hook;
 mod cli;
+mod clipboard;
 mod codex_hook;
 mod config;
 mod desktop_notify;


### PR DESCRIPTION
## Summary

Closes #30.

Claude Code reports *\"No image found in clipboard. Use ctrl+v to paste images\"* when Ctrl+V is pressed inside a cmux pane, even though the same screenshot pastes fine in other apps. Nested multiplexers commonly break the app’s direct clipboard image read (same class of problem as tmux).

**Fix:** on Ctrl+V / Alt+V for PTY panes (and on empty host paste events), cmux:

1. Reads `image/png` (then `image/jpeg`) via `wl-paste` / `xclip`
2. Writes it under `$XDG_RUNTIME_DIR/cmux/pastes/`
3. Bracketed-pastes `@/absolute/path.png` into the pane so agents can attach the file

If no image is on the clipboard, behaviour is unchanged (key is forwarded / text paste as before). Browser panes keep their existing system-clipboard text paste path (now shared via `clipboard` module).

## Requirements

- `wl-clipboard` (`wl-paste`) and/or `xclip` installed — same tools browser paste already needed

## Test plan

- [x] `cargo test -p mux-tui -- clipboard`
- [x] `cargo check -p mux-tui`
- [ ] Manual: copy a screenshot, focus a Claude Code pane, Ctrl+V → `@/run/user/.../cmux/pastes/paste-*.png` appears / image attaches
- [ ] Manual: Ctrl+V with only text on clipboard still pastes text via Claude / shell as before