### PR TITLE
fix(attach): --apply-local-config overlays local mux config over server config

### DIFF
--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -69,6 +69,13 @@ pub struct Mux {
     browser_runtime: Mutex<Option<Arc<BrowserRuntime>>>,
     cell_pixels: Mutex<(u16, u16)>,
     default_colors: Mutex<DefaultColors>,
+    /// Resolved presentation chrome (theme/tabs/sidebar/keys) the server
+    /// process loaded, exposed to thin-client attaches via the
+    /// `get-resolved-config` verb so a local `Overlay` can layer on top
+    /// of the *server* config rather than the laptop's own config. Set
+    /// from `mux-tui`'s `run_server` after `config::load()`. `None` until
+    /// the server registers it (e.g. a `mux-core`-only host with no TUI).
+    resolved_chrome: Mutex<Option<serde_json::Value>>,
     /// Set only by `enable_persistence()`. Gates every snapshot write,
     /// including the one on `shutdown()` — without this, every ephemeral
     /// `Mux` a test or one-shot CLI invocation creates would write a
@@ -96,6 +103,7 @@ impl Mux {
             browser_runtime: Mutex::new(None),
             cell_pixels: Mutex::new((8, 16)),
             default_colors: Mutex::new(DefaultColors::default()),
+            resolved_chrome: Mutex::new(None),
             persistence_enabled: std::sync::atomic::AtomicBool::new(false),
             session,
         })
@@ -503,6 +511,21 @@ impl Mux {
             surface.set_default_colors(colors);
             self.emit(MuxEvent::SurfaceOutput(surface.id));
         }
+    }
+
+    /// The resolved presentation chrome this server process loaded, if it
+    /// has registered one. Returned to thin-client attaches by the
+    /// `get-resolved-config` control-socket verb so a local `Overlay` can
+    /// layer on top of the *server* config.
+    pub fn resolved_chrome(&self) -> Option<serde_json::Value> {
+        self.resolved_chrome.lock().unwrap().clone()
+    }
+
+    /// Register the resolved presentation chrome (theme/tabs/sidebar/keys)
+    /// for this server, exposed via `get-resolved-config`. Called from the
+    /// TUI's server entry point after `config::load()`.
+    pub fn set_resolved_chrome(&self, value: serde_json::Value) {
+        *self.resolved_chrome.lock().unwrap() = Some(value);
     }
 
     /// Resize a surface and broadcast the final clamped size when it

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -249,6 +249,13 @@ enum Command {
         #[serde(default)]
         rows: Option<u16>,
     },
+    /// Return the server's resolved presentation chrome (theme/tabs/
+    /// sidebar/keys) so a thin-client `cmux attach --apply-local-config`
+    /// can layer its local `Overlay` on top of the server config rather
+    /// than replacing it with the laptop's own config (issue #40,
+    /// blocker 1). See `mux-tui`'s `Config::resolved_chrome_value`/
+    /// `Config::from_server_chrome` for the round-trip shape.
+    GetResolvedConfig,
     /// New screen in a workspace (default: the active one).
     NewScreen {
         #[serde(default)]
@@ -671,6 +678,9 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             "pid": std::process::id(),
         })),
         Command::ListWorkspaces => Ok(mux.with_state(workspaces_json)),
+        Command::GetResolvedConfig => {
+            Ok(mux.resolved_chrome().unwrap_or_else(|| json!({})))
+        }
         Command::Send { surface, text, bytes, send_cr } => {
             let surface = get_surface(mux, surface)?;
             require_pty(&surface)?;

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -570,8 +570,11 @@ fn pane_parts_for_rect(
     (bar, omnibar, content, track)
 }
 
-pub fn run(session: Session, session_label: String) -> anyhow::Result<()> {
-    let config = crate::config::load();
+pub fn run(session: Session, session_label: String, overlay: Option<crate::config::Overlay>) -> anyhow::Result<()> {
+    let mut config = crate::config::load();
+    if let Some(o) = overlay {
+        o.apply(&mut config);
+    }
     // First workspace before the terminal switches modes, so a spawn
     // failure prints a normal error. Spawn at the size the first pane
     // will actually render at (a post-spawn resize makes shells like zsh

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -570,8 +570,35 @@ fn pane_parts_for_rect(
     (bar, omnibar, content, track)
 }
 
+/// Fetch the server's resolved presentation chrome for a thin-client
+/// attach and rebuild a base `Config` from it (issue #40 blocker 1).
+/// Returns `None` for a local session, or when the remote does not
+/// expose a `get-resolved-config` verb / the fetch fails, so the caller
+/// can fall back to the laptop's local `config::load()`. Browser and
+/// scrollbar are not in the server payload; they stay at `Config`'s
+/// defaults here and the server keeps the truth for them.
+fn server_base_config(session: &Session) -> Option<crate::config::Config> {
+    let remote = match session {
+        Session::Remote(remote) => remote,
+        Session::Local(_) => return None,
+    };
+    let data = remote.request(serde_json::json!({ "cmd": "get-resolved-config" })).ok()?;
+    Some(crate::config::Config::from_server_chrome(&data))
+}
+
 pub fn run(session: Session, session_label: String, overlay: Option<crate::config::Overlay>) -> anyhow::Result<()> {
-    let mut config = crate::config::load();
+    // For a thin-client attach (issue #40 blocker 1) the local `Overlay`
+    // must layer on top of the *server's* resolved config, not the
+    // laptop's own `config::load()`. So a remote attach fetches the
+    // server's resolved chrome via the `get-resolved-config` verb and
+    // rebuilds a base `Config` from it; only if that fetch fails does it
+    // fall back to the laptop's local config so the attach still degrades
+    // rather than dying. A local (in-process) session still loads its own
+    // `config::load()`, exactly as before.
+    let mut config = match server_base_config(&session) {
+        Some(base) => base,
+        None => crate::config::load(),
+    };
     if let Some(o) = overlay {
         o.apply(&mut config);
     }

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -55,6 +55,19 @@ const VERBS: &[VerbSpec] = &[
         stream: false,
     },
     VerbSpec {
+        // Issue #40: returns the server's resolved presentation chrome
+        // (theme/tabs/sidebar/keys) for a thin-client attach to layer its
+        // local `Overlay` on top of. Read-only; `cmux attach
+        // --apply-local-config` invokes the same verb internally, and
+        // `cmux attach --print-resolved-config` shows the merged
+        // (server + local overlay) chrome for inspection.
+        name: "get-resolved-config",
+        allowed: &[],
+        build: build_no_args,
+        print: print_get_resolved_config,
+        stream: false,
+    },
+    VerbSpec {
         name: "send",
         allowed: &["surface", "text", "bytes", "send-cr"],
         build: build_send,
@@ -1087,6 +1100,16 @@ fn print_agents(data: &Value, out: &mut dyn Write) -> io::Result<()> {
         )?;
     }
     Ok(())
+}
+
+/// Human stdout for `cmux get-resolved-config`: pretty-print the
+/// server's resolved chrome as JSON (matches the shape that
+/// `Config::resolved_chrome_value` produces and `cmux attach
+/// --print-resolved-config` prints for the merged view). `--json`
+/// mode prints the same object compact via `print_response`.
+fn print_get_resolved_config(data: &Value, out: &mut dyn Write) -> io::Result<()> {
+    let pretty = serde_json::to_string_pretty(data).unwrap_or_else(|_| "{}".to_string());
+    writeln!(out, "{pretty}")
 }
 
 fn print_identify(data: &Value, out: &mut dyn Write) -> io::Result<()> {

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -62,7 +62,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mux_core::platform;
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
-use serde_json::Value;
+use serde_json::{json, Value};
 
 /// For a field typed `Option<Option<T>>`: makes an explicit `null` in the
 /// input deserialize to `Some(None)` rather than the `None` an absent key
@@ -523,6 +523,78 @@ impl Keys {
             }
         }
     }
+
+    /// Serialise the resolved bindings back into the raw `keys` map shape
+    /// (`"prefix"`, `"alt_shortcuts"`, one entry per action config key
+    /// mapped to a chord string or array) so that
+    /// `Config::resolved_chrome_value` can send the server's keys to a
+    /// thin client, which re-applies them via `Keys::apply` and reproduces
+    /// the same resolved state (issue #40 blocker 1). Every action that
+    /// still has a chord is emitted so the round-trip is whole, not just
+    /// the non-default ones.
+    pub fn to_raw_map(&self) -> HashMap<String, Value> {
+        let mut map: HashMap<String, Value> = HashMap::new();
+        let has_alt = self.bindings.iter().any(|(c, _)| c.mods.contains(KeyModifiers::ALT));
+        map.insert("alt_shortcuts".to_string(), Value::Bool(has_alt));
+        map.insert("prefix".to_string(), Value::String(chord_to_string(self.prefix)));
+        let mut by_action: HashMap<&str, Vec<Value>> = HashMap::new();
+        for (chord, action) in &self.bindings {
+            by_action
+                .entry(action.config_key())
+                .or_default()
+                .push(Value::String(chord_to_string(*chord)));
+        }
+        for (name, chords) in by_action {
+            map.insert(name.to_string(), Value::Array(chords));
+        }
+        map
+    }
+}
+
+/// Inverse of `parse_chord`: render a resolved `Chord` back as the chord
+/// string (`ctrl+b`, `alt+t`, `tab`, `B`, ...). Shift is implied by an
+/// uppercase/symbol char, so for `Char` we emit only ctrl/alt, matching
+/// how `parse_chord` interprets single characters (its shift branch only
+/// fires for non-char codes).
+fn chord_to_string(chord: Chord) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    if chord.mods.contains(KeyModifiers::CONTROL) {
+        parts.push("ctrl");
+    }
+    if chord.mods.contains(KeyModifiers::ALT) {
+        parts.push("alt");
+    }
+    let is_char = matches!(chord.code, KeyCode::Char(_));
+    if chord.mods.contains(KeyModifiers::SHIFT) && !is_char {
+        parts.push("shift");
+    }
+    let code = match chord.code {
+        KeyCode::Tab => "tab",
+        KeyCode::BackTab => "backtab",
+        KeyCode::Enter => "enter",
+        KeyCode::Esc => "escape",
+        KeyCode::Left => "left",
+        KeyCode::Right => "right",
+        KeyCode::Up => "up",
+        KeyCode::Down => "down",
+        KeyCode::PageUp => "pageup",
+        KeyCode::PageDown => "pagedown",
+        KeyCode::Home => "home",
+        KeyCode::End => "end",
+        KeyCode::Char(c) => {
+            let joined = parts.join("+");
+            let mut buf = [0u8; 4];
+            let ch = c.encode_utf8(&mut buf);
+            return if joined.is_empty() { ch.to_string() } else { format!("{joined}+{ch}") };
+        }
+        other => return format!("{}{:?}", parts.join("+"), other),
+    };
+    let mut s = parts.join("+");
+    if !s.is_empty() {
+        s.push('+');
+    }
+    s.push_str(code);
+    s
 }
 
 fn key_values(value: &Value) -> Vec<&str> {
@@ -622,6 +694,85 @@ pub struct Config {
     pub browser: Browser,
     pub scrollbar: Scrollbar,
     pub keys: Keys,
+}
+
+impl Config {
+    /// Serialise the resolved chrome (theme/tabs/sidebar/keys) into the
+    /// same raw JSON shape that `RawConfig`/the `apply_*_raw` helpers
+    /// consume, so a thin-client attach can round-trip it back through
+    /// `Config::from_server_chrome` (issue #40 blocker 1). Browser and
+    /// scrollbar are server-side truth and intentionally omitted.
+    pub fn resolved_chrome_value(&self) -> Value {
+        let theme = json!({
+            "selection_background": color_to_value(&self.theme.selection_bg),
+            "selection_foreground": self.theme.selection_fg.as_ref().and_then(color_to_value),
+            "sidebar_rail": color_to_value(&self.theme.sidebar_rail),
+            "sidebar_active_bg": color_to_value(&self.theme.sidebar_active_bg),
+            "tab_rail": color_to_value(&self.theme.tab_rail),
+            "tab_bg": color_to_value(&self.theme.tab_bg),
+            "tab_active_bg": self.theme.tab_active_bg.as_ref().and_then(color_to_value),
+            "border_active": color_to_value(&self.theme.border_active),
+            "border_inactive": color_to_value(&self.theme.border_inactive),
+        });
+        let tabs = json!({
+            "min_width": self.tabs.min_width,
+            "solid_background": self.tabs.solid_background,
+            "show_titles": self.tabs.show_titles,
+            "agents": self.tabs.agents,
+        });
+        let sidebar = json!({
+            "width": self.sidebar.width,
+            "max_width": self.sidebar.max_width,
+        });
+        let keys = serde_json::to_value(self.keys.to_raw_map()).unwrap_or_else(|_| json!({}));
+        json!({ "theme": theme, "tabs": tabs, "sidebar": sidebar, "keys": keys })
+    }
+
+    /// Rebuild a `Config` from a server's `resolved_chrome_value` payload:
+    /// start from `Config::default()` and re-apply each present chrome
+    /// section through the same `apply_*_raw` helpers `load()` uses, so
+    /// the round-trip is byte-identical to the server's resolution. Used
+    /// as the base for a thin-client attach, then the local `Overlay` is
+    /// layered on top. Browser/scrollbar stay at defaults: the server
+    /// keeps the truth for them and the attach client does not spawn
+    /// browsers locally.
+    pub fn from_server_chrome(value: &Value) -> Config {
+        let mut config = Config::default();
+        if let Some(theme) = value.get("theme").filter(|v| !v.is_null()) {
+            if let Ok(raw) = serde_json::from_value::<RawTheme>(theme.clone()) {
+                apply_theme_raw(&mut config, &raw);
+            }
+        }
+        if let Some(tabs) = value.get("tabs").filter(|v| !v.is_null()) {
+            if let Ok(raw) = serde_json::from_value::<RawTabs>(tabs.clone()) {
+                apply_tabs_raw(&mut config, &raw);
+            }
+        }
+        if let Some(sidebar) = value.get("sidebar").filter(|v| !v.is_null()) {
+            if let Ok(raw) = serde_json::from_value::<RawSidebar>(sidebar.clone()) {
+                apply_sidebar_raw(&mut config, &raw);
+            }
+        }
+        if let Some(keys) = value.get("keys").filter(|v| v.is_object()) {
+            if let Ok(raw) = serde_json::from_value::<HashMap<String, Value>>(keys.clone()) {
+                config.keys.apply(&raw);
+            }
+        }
+        config
+    }
+}
+
+/// Serialise a resolved `Color` back into the raw config shape that
+/// `ColorValue`/`parse_color` accept: `#rrggbb` for true-colour, a bare
+/// number for an xterm-256 index. Named/reset colours have no portable
+/// raw form and yield `None` (which renders as `null` and is ignored on
+/// the client), matching the overlay's permissive overlay semantics.
+fn color_to_value(color: &Color) -> Option<Value> {
+    match color {
+        Color::Rgb(r, g, b) => Some(Value::String(format!("#{r:02x}{g:02x}{b:02x}"))),
+        Color::Indexed(i) => Some(Value::Number((*i).into())),
+        _ => None,
+    }
 }
 
 /// Apply a raw theme table onto a resolved config: every present colour

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -56,7 +56,7 @@
 //! default.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use mux_core::platform;
@@ -624,6 +624,71 @@ pub struct Config {
     pub keys: Keys,
 }
 
+/// Apply a raw theme table onto a resolved config: every present colour
+/// overrides the seeded/default value. Shared by `load()` (server config)
+/// and `Overlay::apply` (client overlay), so the two never drift.
+fn apply_theme_raw(config: &mut Config, t: &RawTheme) {
+    if let Some(c) = t.selection_background.as_ref().and_then(ColorValue::to_color) {
+        config.theme.selection_bg = c;
+    }
+    match t.selection_foreground.as_ref() {
+        None => {}
+        Some(None) => config.theme.selection_fg = None,
+        Some(Some(c)) => {
+            if let Some(color) = c.to_color() {
+                config.theme.selection_fg = Some(color);
+            }
+        }
+    }
+    if let Some(c) = t.sidebar_rail.as_ref().and_then(ColorValue::to_color) {
+        config.theme.sidebar_rail = c;
+    }
+    if let Some(c) = t.sidebar_active_bg.as_ref().and_then(ColorValue::to_color) {
+        config.theme.sidebar_active_bg = c;
+    }
+    if let Some(c) = t.tab_rail.as_ref().and_then(ColorValue::to_color) {
+        config.theme.tab_rail = c;
+    }
+    if let Some(c) = t.tab_bg.as_ref().and_then(ColorValue::to_color) {
+        config.theme.tab_bg = c;
+    }
+    if let Some(c) = t.tab_active_bg.as_ref().and_then(ColorValue::to_color) {
+        config.theme.tab_active_bg = Some(c);
+    }
+    if let Some(c) = t.border_active.as_ref().and_then(ColorValue::to_color) {
+        config.theme.border_active = c;
+    }
+    if let Some(c) = t.border_inactive.as_ref().and_then(ColorValue::to_color) {
+        config.theme.border_inactive = c;
+    }
+}
+
+/// Apply raw tab overrides onto a resolved config.
+fn apply_tabs_raw(config: &mut Config, t: &RawTabs) {
+    if let Some(w) = t.min_width {
+        config.tabs.min_width = w.clamp(3, 40);
+    }
+    if let Some(b) = t.solid_background {
+        config.tabs.solid_background = b;
+    }
+    if let Some(b) = t.show_titles {
+        config.tabs.show_titles = b;
+    }
+    if let Some(agents) = t.agents.clone() {
+        config.tabs.agents = agents.into_iter().map(|a| a.to_lowercase()).collect();
+    }
+}
+
+/// Apply raw sidebar overrides onto a resolved config.
+fn apply_sidebar_raw(config: &mut Config, s: &RawSidebar) {
+    if let Some(w) = s.width {
+        config.sidebar.width = w.clamp(10, 60);
+    }
+    if let Some(w) = s.max_width {
+        config.sidebar.max_width = w;
+    }
+}
+
 /// Load the config: defaults, overlaid with the user's Ghostty selection
 /// colors, overlaid with `mux.json`.
 pub fn load() -> Config {
@@ -648,58 +713,10 @@ pub fn load() -> Config {
         ThemeValue::Table(t) => Some(t.clone()),
     };
     if let Some(t) = raw_theme {
-        if let Some(c) = t.selection_background.as_ref().and_then(ColorValue::to_color) {
-            config.theme.selection_bg = c;
-        }
-        match t.selection_foreground.as_ref() {
-            None => {}
-            Some(None) => config.theme.selection_fg = None,
-            Some(Some(c)) => {
-                if let Some(color) = c.to_color() {
-                    config.theme.selection_fg = Some(color);
-                }
-            }
-        }
-        if let Some(c) = t.sidebar_rail.as_ref().and_then(ColorValue::to_color) {
-            config.theme.sidebar_rail = c;
-        }
-        if let Some(c) = t.sidebar_active_bg.as_ref().and_then(ColorValue::to_color) {
-            config.theme.sidebar_active_bg = c;
-        }
-        if let Some(c) = t.tab_rail.as_ref().and_then(ColorValue::to_color) {
-            config.theme.tab_rail = c;
-        }
-        if let Some(c) = t.tab_bg.as_ref().and_then(ColorValue::to_color) {
-            config.theme.tab_bg = c;
-        }
-        if let Some(c) = t.tab_active_bg.as_ref().and_then(ColorValue::to_color) {
-            config.theme.tab_active_bg = Some(c);
-        }
-        if let Some(c) = t.border_active.as_ref().and_then(ColorValue::to_color) {
-            config.theme.border_active = c;
-        }
-        if let Some(c) = t.border_inactive.as_ref().and_then(ColorValue::to_color) {
-            config.theme.border_inactive = c;
-        }
+        apply_theme_raw(&mut config, &t);
     }
-    if let Some(w) = raw.tabs.min_width {
-        config.tabs.min_width = w.clamp(3, 40);
-    }
-    if let Some(b) = raw.tabs.solid_background {
-        config.tabs.solid_background = b;
-    }
-    if let Some(b) = raw.tabs.show_titles {
-        config.tabs.show_titles = b;
-    }
-    if let Some(agents) = raw.tabs.agents {
-        config.tabs.agents = agents.into_iter().map(|a| a.to_lowercase()).collect();
-    }
-    if let Some(w) = raw.sidebar.width {
-        config.sidebar.width = w.clamp(10, 60);
-    }
-    if let Some(w) = raw.sidebar.max_width {
-        config.sidebar.max_width = w;
-    }
+    apply_tabs_raw(&mut config, &raw.tabs);
+    apply_sidebar_raw(&mut config, &raw.sidebar);
     config.browser.chrome_binary = raw.browser.chrome_binary.filter(|s| !s.trim().is_empty());
     config.browser.cdp_url = raw.browser.cdp_url.filter(|s| !s.trim().is_empty());
     if let Some(discover) = raw.browser.discover {
@@ -735,6 +752,156 @@ pub fn load() -> Config {
     }
     config.keys.apply(&raw.keys);
     config
+}
+
+// --- Local config overlay (issue #40) ---
+//
+// The overlay is the *client* side of an attach: a typed subset of the
+// server config (theme/tabs/sidebar/keys only) that the laptop layers on
+// top of the server-side session so colours and key bindings travel with
+// the operator. Browser panes, scrollbar, and the session name are
+// server-side truth and must NOT be overridable here, so `RawOverlay`
+// carries `#[serde(deny_unknown_fields)]` to reject them at parse time
+// (AC7) instead of silently ignoring them.
+
+/// Raw deserialization shape for a local overlay file. Only the chrome
+/// fields the client is allowed to override; anything else (browser,
+// session, scrollbar) is rejected by `deny_unknown_fields`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)] // overlay: reject server-only chrome fields
+struct RawOverlay {
+    #[serde(default)]
+    theme: Option<ThemeValue>,
+    #[serde(default)]
+    tabs: Option<RawTabs>,
+    #[serde(default)]
+    sidebar: Option<RawSidebar>,
+    #[serde(default)]
+    keys: Option<HashMap<String, Value>>,
+}
+
+/// Typed client overlay: a subset of `Config` (theme/tabs/sidebar/keys)
+/// applied on top of the server-side config during `cmux attach`. The
+/// browser, scrollbar, and session name stay server-side truth.
+#[derive(Debug, Default)]
+pub struct Overlay {
+    theme: Option<ThemeValue>,
+    tabs: Option<RawTabs>,
+    sidebar: Option<RawSidebar>,
+    keys: Option<HashMap<String, Value>>,
+}
+
+impl Overlay {
+    fn from_raw(raw: RawOverlay) -> Self {
+        Overlay {
+            theme: raw.theme,
+            tabs: raw.tabs,
+            sidebar: raw.sidebar,
+            keys: raw.keys,
+        }
+    }
+
+    /// Resolve a string/table theme the same way `load()` does, then layer
+    /// the present chrome fields onto `config`. Browser and scrollbar are
+    /// intentionally untouched: the server keeps the truth for the tree.
+    pub fn apply(&self, config: &mut Config) {
+        if let Some(tv) = &self.theme {
+            let resolved = match tv {
+                ThemeValue::String(name) => {
+                    if name == "none" {
+                        None
+                    } else {
+                        load_preset(name)
+                    }
+                }
+                ThemeValue::Table(t) => Some(t.clone()),
+            };
+            if let Some(t) = resolved {
+                apply_theme_raw(config, &t);
+            }
+        }
+        if let Some(t) = &self.tabs {
+            apply_tabs_raw(config, t);
+        }
+        if let Some(s) = &self.sidebar {
+            apply_sidebar_raw(config, s);
+        }
+        if let Some(k) = &self.keys {
+            config.keys.apply(k);
+        }
+    }
+
+    /// How many top-level chrome keys this overlay overrides, for the
+    /// `cmux: applying local config from <path> (overrides N keys)` log
+    /// line. Counts a section once if it is present at all.
+    pub fn override_count(&self) -> usize {
+        let mut n = 0;
+        if self.theme.is_some() {
+            n += 1;
+        }
+        if self.tabs.is_some() {
+            n += 1;
+        }
+        if self.sidebar.is_some() {
+            n += 1;
+        }
+        if self.keys.is_some() {
+            n += 1;
+        }
+        n
+    }
+}
+
+/// Resolve which local overlay file would apply for an attach, without
+/// reading it. Resolution order (AC2): explicit `--config <path>` ->
+/// `$CMUX_LOCAL_CONFIG` -> `~/.config/cmux/mux.local.toml` ->
+/// `~/.config/cmux/mux.json` -> `None` (server-side config wins). The
+/// explicit and env cases are returned as-is even when the file does not
+/// exist, so the caller can log the missing path rather than silently
+/// falling back to the server config.
+pub fn local_config_path(explicit: Option<&Path>) -> Option<PathBuf> {
+    if let Some(path) = explicit {
+        return Some(path.to_path_buf());
+    }
+    if let Some(path) = std::env::var_os("CMUX_LOCAL_CONFIG") {
+        return Some(PathBuf::from(path));
+    }
+    let dir = platform::config_dir()?;
+    let local_toml = dir.join("mux.local.toml");
+    if local_toml.exists() {
+        return Some(local_toml);
+    }
+    let json = dir.join("mux.json");
+    if json.exists() {
+        return Some(json);
+    }
+    None
+}
+
+/// Read and parse a local overlay file into an `Overlay`. Returns `None`
+/// (with a stderr note, mirroring `load_raw_config`) when the file is
+/// missing or fails to parse, so the attach path degrades to the
+/// server-side config instead of taking the TUI down.
+pub fn load_overlay_file(path: &Path) -> Option<Overlay> {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return None;
+    };
+    let parsed = if is_toml_path(path) {
+        toml::from_str::<RawOverlay>(&text).map_err(|e| e.to_string())
+    } else if is_json_path(path) {
+        serde_json::from_str::<RawOverlay>(&text).map_err(|e| e.to_string())
+    } else if looks_like_json(&text) {
+        serde_json::from_str::<RawOverlay>(&text).map_err(|e| e.to_string())
+    } else {
+        toml::from_str::<RawOverlay>(&text).map_err(|e| e.to_string())
+    };
+    match parsed {
+        Ok(raw) => Some(Overlay::from_raw(raw)),
+        Err(e) => {
+            eprintln!("cmux: ignoring invalid local config {}: {e}", path.display());
+            None
+        }
+    }
 }
 
 /// Load a preset by name from the bundled themes directory.
@@ -1527,5 +1694,103 @@ sidebar_rail = 55
 
         assert_eq!(config.theme.sidebar_rail, Color::Rgb(0x87, 0xdc, 0xbf));
         assert_eq!(config.theme.border_inactive, Color::Indexed(238));
+    }
+
+    // --- Local config overlay (issue #40) ---
+
+    #[test]
+    fn overlay_rejects_browser_and_session_fields() {
+        // The overlay is a chrome-only subset: browser panes and the
+        // session name are server-side truth. deny_unknown_fields rejects
+        // them at parse time so a typo or a stale server-side block does
+        // not silently get dropped (AC7).
+        let with_browser: Result<RawOverlay, _> =
+            serde_json::from_str(r##"{"browser": {"cdp_url": "http://localhost:9222"}}"##);
+        assert!(with_browser.is_err(), "overlay must reject a browser field");
+
+        let with_session: Result<RawOverlay, _> =
+            serde_json::from_str(r##"{"session": "main"}"##);
+        assert!(with_session.is_err(), "overlay must reject a session field");
+    }
+
+    #[test]
+    fn overlay_applies_only_chrome_keys() {
+        let raw: RawOverlay = toml::from_str(
+            r##"
+[theme]
+sidebar_rail = 42
+
+[tabs]
+min_width = 9
+
+[sidebar]
+width = 30
+
+[keys]
+prefix = "ctrl+s"
+"##,
+        )
+        .unwrap();
+        let overlay = Overlay::from_raw(raw);
+        assert_eq!(overlay.override_count(), 4);
+
+        let mut config = Config::default();
+        let browser_before = config.browser.clone();
+        let scrollbar_before = config.scrollbar;
+        overlay.apply(&mut config);
+
+        // Chrome fields the overlay is allowed to touch: all applied.
+        assert_eq!(config.theme.sidebar_rail, Color::Indexed(42));
+        assert_eq!(config.tabs.min_width, 9);
+        assert_eq!(config.sidebar.width, 30);
+        assert_eq!(
+            config.keys.prefix,
+            Chord { code: KeyCode::Char('s'), mods: KeyModifiers::CONTROL }
+        );
+
+        // Server-side truth is untouched: browser and scrollbar stay as
+        // they were (AC3/AC7).
+        assert_eq!(config.browser, browser_before);
+        assert_eq!(config.browser, Browser::default());
+        assert_eq!(config.scrollbar, scrollbar_before);
+    }
+
+    #[test]
+    fn local_config_path_resolution_order() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+
+        // Explicit --config wins over env and XDG, even when the file
+        // does not exist (the caller logs the missing path).
+        let explicit = Path::new("/tmp/cmux-overlay-explicit-4af0.toml");
+        std::env::set_var("CMUX_LOCAL_CONFIG", "/tmp/cmux-overlay-env-4af0.json");
+        assert_eq!(local_config_path(Some(explicit)), Some(explicit.to_path_buf()));
+
+        // With no explicit path, $CMUX_LOCAL_CONFIG wins over XDG.
+        assert_eq!(
+            local_config_path(None),
+            Some(PathBuf::from("/tmp/cmux-overlay-env-4af0.json"))
+        );
+        std::env::remove_var("CMUX_LOCAL_CONFIG");
+
+        // XDG mux.local.toml wins over mux.json when both exist.
+        let dir = unique_dir("overlay-res");
+        let _ = std::fs::remove_dir_all(&dir);
+        let cmux = dir.join("cmux");
+        std::fs::create_dir_all(&cmux).unwrap();
+        std::fs::write(cmux.join("mux.local.toml"), "[theme]\nsidebar_rail = 1\n").unwrap();
+        std::fs::write(cmux.join("mux.json"), "{\"theme\": {\"sidebar_rail\": 2}}").unwrap();
+        std::env::set_var("XDG_CONFIG_HOME", &dir);
+        assert_eq!(local_config_path(None), Some(cmux.join("mux.local.toml")));
+
+        // mux.json is the fallback when mux.local.toml is absent.
+        let _ = std::fs::remove_file(cmux.join("mux.local.toml"));
+        assert_eq!(local_config_path(None), Some(cmux.join("mux.json")));
+
+        // Nothing present: None, so the attach uses server-side config.
+        let _ = std::fs::remove_file(cmux.join("mux.json"));
+        assert_eq!(local_config_path(None), None);
+
+        std::env::remove_var("XDG_CONFIG_HOME");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -75,6 +75,14 @@ OPTIONS:
   --socket <path>    Explicit control socket path.
   --headless         Run only the control socket, no TUI.
   --term <value>     TERM for child shells (default: xterm-256color).
+  --apply-local-config
+                    Attach only: overlay the local mux.local.toml/mux.json
+                    (theme, tabs, sidebar, keys) on top of the server config.
+  --config <path>    Attach only: explicit local overlay file (overrides
+                    $CMUX_LOCAL_CONFIG and the XDG defaults).
+  --show-local-config-resolution
+                    Attach only: print which local config would apply and
+                    how many keys it overrides, then exit without attaching.
   -h, --help         Show this help.
 
 KEYS (prefix: Ctrl-b)
@@ -173,6 +181,9 @@ struct Args {
     socket: Option<PathBuf>,
     headless: bool,
     term: Option<String>,
+    apply_local_config: bool,
+    show_local_config_resolution: bool,
+    config: Option<PathBuf>,
 }
 
 fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
@@ -182,6 +193,9 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
         socket: None,
         headless: false,
         term: None,
+        apply_local_config: false,
+        show_local_config_resolution: false,
+        config: None,
     };
     let mut args = args.into_iter().peekable();
     if args.peek().map(|s| s.as_str()) == Some("attach") {
@@ -200,6 +214,15 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
             "--headless" => out.headless = true,
             "--term" => {
                 out.term = Some(args.next().unwrap_or_else(|| usage_exit("--term needs a value")))
+            }
+            "--apply-local-config" => out.apply_local_config = true,
+            "--show-local-config-resolution" => out.show_local_config_resolution = true,
+            "--config" => {
+                out.config = Some(
+                    args.next()
+                        .unwrap_or_else(|| usage_exit("--config needs a value"))
+                        .into(),
+                )
             }
             "-h" | "--help" => {
                 print!("{USAGE}");
@@ -255,6 +278,9 @@ fn main() {
         std::process::exit(cli::run(&raw_args, USAGE));
     }
     let args = parse_args(raw_args);
+    if args.show_local_config_resolution {
+        return show_local_config_resolution(args);
+    }
     let result = if args.attach { run_attach(args) } else { run_server(args) };
     if let Err(e) = result {
         eprintln!("cmux: {e}");
@@ -263,10 +289,62 @@ fn main() {
 }
 
 fn run_attach(args: Args) -> anyhow::Result<()> {
+    let overlay = if args.apply_local_config {
+        resolve_local_overlay(args.config.as_deref())
+    } else {
+        None
+    };
     let socket_path =
         args.socket.unwrap_or_else(|| mux_core::server::default_socket_path(&args.session));
     let remote = RemoteSession::connect(&socket_path)?;
-    run_tui(Session::Remote(remote), args.session)
+    run_tui(Session::Remote(remote), args.session, overlay)
+}
+
+/// Resolve the local overlay for an attach: log which file applies (or that
+/// none was found) and return the parsed `Overlay`. Returns `None` when no
+/// path resolves or the file fails to parse, so the attach degrades to the
+/// server-side config instead of failing.
+fn resolve_local_overlay(explicit: Option<&std::path::Path>) -> Option<config::Overlay> {
+    match config::local_config_path(explicit) {
+        Some(path) => match config::load_overlay_file(&path) {
+            Some(overlay) => {
+                eprintln!(
+                    "cmux: applying local config from {} (overrides {} keys)",
+                    path.display(),
+                    overlay.override_count()
+                );
+                Some(overlay)
+            }
+            None => {
+                eprintln!("cmux: no local config found at {}", path.display());
+                None
+            }
+        },
+        None => {
+            eprintln!("cmux: no local config found");
+            None
+        }
+    }
+}
+
+/// Dry-run for `--show-local-config-resolution`: print which local file
+/// would apply and how many keys it overrides, then exit without
+/// attaching. Exits 0 whether or not a file resolved.
+fn show_local_config_resolution(args: Args) {
+    if let Some(path) = config::local_config_path(args.config.as_deref()) {
+        if let Some(overlay) = config::load_overlay_file(&path) {
+            println!(
+                "cmux: local config resolves to {} (overrides {} keys)",
+                path.display(),
+                overlay.override_count()
+            );
+        } else {
+            eprintln!("cmux: no local config found at {}", path.display());
+        }
+    } else {
+        eprintln!("cmux: no local config found");
+    }
+    std::process::exit(0);
 }
 
 fn run_server(args: Args) -> anyhow::Result<()> {
@@ -303,7 +381,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     let result = if args.headless {
         run_headless(&mux, &socket_path)
     } else {
-        run_tui(Session::Local(mux.clone()), args.session)
+        run_tui(Session::Local(mux.clone()), args.session, None)
     };
     mux.shutdown();
     // Issue #28: after known surfaces are killed, sweep anything that
@@ -317,7 +395,11 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     result
 }
 
-fn run_tui(session: Session, session_label: String) -> anyhow::Result<()> {
+fn run_tui(
+    session: Session,
+    session_label: String,
+    overlay: Option<config::Overlay>,
+) -> anyhow::Result<()> {
     crossterm::terminal::enable_raw_mode()?;
     let colors = host_colors::probe_default_colors();
     let color_result = session.set_default_colors(colors);
@@ -326,7 +408,7 @@ fn run_tui(session: Session, session_label: String) -> anyhow::Result<()> {
         eprintln!("cmux: failed to set default colors: {err}");
     }
     raw_result?;
-    app::run(session, session_label)
+    app::run(session, session_label, overlay)
 }
 
 fn run_headless(mux: &Arc<Mux>, socket_path: &std::path::Path) -> anyhow::Result<()> {

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -83,6 +83,12 @@ OPTIONS:
   --show-local-config-resolution
                     Attach only: print which local config would apply and
                     how many keys it overrides, then exit without attaching.
+  --print-resolved-config
+                    Attach only: fetch the server's resolved presentation
+                    chrome, layer the local overlay on top (requires
+                    --apply-local-config), print the merged chrome as JSON,
+                    and exit without starting the TUI. For inspecting
+                    overlay layering without a live terminal.
   -h, --help         Show this help.
 
 KEYS (prefix: Ctrl-b)
@@ -183,6 +189,7 @@ struct Args {
     term: Option<String>,
     apply_local_config: bool,
     show_local_config_resolution: bool,
+    print_resolved_config: bool,
     config: Option<PathBuf>,
 }
 
@@ -195,6 +202,7 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
         term: None,
         apply_local_config: false,
         show_local_config_resolution: false,
+        print_resolved_config: false,
         config: None,
     };
     let mut args = args.into_iter().peekable();
@@ -217,6 +225,7 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
             }
             "--apply-local-config" => out.apply_local_config = true,
             "--show-local-config-resolution" => out.show_local_config_resolution = true,
+            "--print-resolved-config" => out.print_resolved_config = true,
             "--config" => {
                 out.config = Some(
                     args.next()
@@ -297,7 +306,33 @@ fn run_attach(args: Args) -> anyhow::Result<()> {
     let socket_path =
         args.socket.unwrap_or_else(|| mux_core::server::default_socket_path(&args.session));
     let remote = RemoteSession::connect(&socket_path)?;
+    // `--print-resolved-config` is an inspection escape for thin-client
+    // attaches (issue #40 blocker 1): fetch the server's resolved chrome,
+    // layer the local overlay on top, print the merged chrome as JSON,
+    // and exit without starting the TUI. Used by the integration test
+    // that proves the overlay layers over the *server* config.
+    if args.print_resolved_config {
+        return print_resolved_config(remote, overlay);
+    }
     run_tui(Session::Remote(remote), args.session, overlay)
+}
+
+/// Print the merged resolved chrome (server base + local overlay) as a
+/// JSON object to stdout and exit 0 without attaching the TUI. The shape
+/// matches `Config::resolved_chrome_value` so a caller can assert the
+/// server's theme survived alongside the local overlay's key bindings.
+fn print_resolved_config(
+    remote: Arc<RemoteSession>,
+    overlay: Option<config::Overlay>,
+) -> anyhow::Result<()> {
+    let data = remote.request(serde_json::json!({ "cmd": "get-resolved-config" }))?;
+    let mut config = config::Config::from_server_chrome(&data);
+    if let Some(o) = &overlay {
+        o.apply(&mut config);
+    }
+    let json = serde_json::to_string_pretty(&config.resolved_chrome_value())?;
+    println!("{json}");
+    Ok(())
 }
 
 /// Resolve the local overlay for an attach: log which file applies (or that
@@ -371,6 +406,13 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     surface_options.extra_env.push(("CMUX_MUX_SOCKET".into(), socket_path.display().to_string()));
 
     let mux = Mux::new(args.session.clone(), surface_options);
+    // Issue #40 blocker 1: publish this server's resolved presentation
+    // chrome (theme/tabs/sidebar/keys) so a thin-client `cmux attach
+    // --apply-local-config` can fetch it via the `get-resolved-config`
+    // verb and layer its local overlay on top instead of replacing the
+    // server config with the laptop's own. Browser and scrollbar stay
+    // server-side truth and are not published here.
+    mux.set_resolved_chrome(config.resolved_chrome_value());
     mux.restore_session();
     mux.enable_persistence();
     mux_core::server::serve(mux.clone(), Some(socket_path.clone()))?;

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -990,3 +990,51 @@ fn sigkill_watchdog_removes_socket_and_pid_within_5s() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+/// Issue #40: `cmux attach --show-local-config-resolution` is a dry run that
+/// resolves the local overlay file (theme/sidebar_rail + keys/prefix here)
+/// and prints the path plus the override count, without attaching to a
+/// server or starting the TUI. Exits 0 and needs no live session.
+#[test]
+fn show_local_config_resolution_prints_path_without_attaching() {
+    let dir = unique_temp_dir("show-local-config-res");
+    fs::create_dir_all(&dir).unwrap();
+    let cmux_dir = dir.join("cmux");
+    fs::create_dir_all(&cmux_dir).unwrap();
+    fs::write(
+        cmux_dir.join("mux.local.toml"),
+        "[theme]\nsidebar_rail = 42\n[keys]\nprefix = \"ctrl+s\"\n",
+    )
+    .unwrap();
+
+    let output = Command::new(bin())
+        .args(["attach", "--show-local-config-resolution"])
+        .env("XDG_CONFIG_HOME", &dir)
+        .env_remove("CMUX_LOCAL_CONFIG")
+        .env_remove("CMUX_MUX_CONFIG")
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "expected exit 0, got {:?}\n{}",
+        output.status.code(),
+        combined
+    );
+    assert!(
+        combined.contains("mux.local.toml"),
+        "expected the resolved overlay path, got: {combined}"
+    );
+    assert!(
+        combined.contains("overrides 2 keys"),
+        "expected theme+keys = 2 overrides, got: {combined}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -1038,3 +1038,194 @@ fn show_local_config_resolution_prints_path_without_attaching() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+/// Issue #40 round-2 blocker 1: a thin-client `cmux attach
+/// --apply-local-config` must layer the local overlay on top of the
+/// *server's* resolved config, not replace it with the laptop's own. We
+/// start a headless server whose `mux.json` sets a distinctive theme
+/// colour (server-side truth), then run `cmux attach --socket <sock>
+/// --apply-local-config --print-resolved-config` with a local overlay
+/// that overrides a key binding (NOT theme), and assert the merged
+/// chrome JSON carries the server's theme colour AND the local overlay's
+/// key binding — proving layering, not replacement. `--print-resolved-config`
+/// is the attach-only inspection escape added for this: it fetches the
+/// server chrome, applies the overlay, and prints the merged result as
+/// JSON without starting the TUI.
+#[test]
+fn attach_overlay_layers_over_server_config() {
+    let dir = unique_temp_dir("attach-overlay-layering");
+
+    // Server-side config: only a theme colour, so the local overlay (keys
+    // only) must NOT clobber it.
+    let server_cfg_root = dir.join("server-config");
+    let server_cmux_dir = server_cfg_root.join("cmux");
+    fs::create_dir_all(&server_cmux_dir).unwrap();
+    fs::write(
+        server_cmux_dir.join("mux.json"),
+        r##"{"theme": {"sidebar_rail": "#112233"}}"##,
+    )
+    .unwrap();
+
+    let socket = dir.join("mux.sock");
+    let mut server = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&socket)
+        .env("XDG_CONFIG_HOME", &server_cfg_root)
+        .env_remove("CMUX_MUX_CONFIG")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if socket.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    if !socket.exists() {
+        let _ = server.kill();
+        let _ = server.wait();
+        panic!(
+            "headless server did not create socket at {}",
+            socket.display()
+        );
+    }
+    // Give the server a moment to register its resolved chrome (it is set
+    // before `serve()` binds, so a live socket implies it is published).
+    std::thread::sleep(Duration::from_millis(100));
+
+    // Local laptop config dir: a local overlay that overrides a key
+    // binding only, not theme, so the server theme must survive.
+    let local_cfg_root = dir.join("local-config");
+    let local_cmux_dir = local_cfg_root.join("cmux");
+    fs::create_dir_all(&local_cmux_dir).unwrap();
+    fs::write(
+        local_cmux_dir.join("mux.local.toml"),
+        "[keys]\nprefix = \"ctrl+s\"\n",
+    )
+    .unwrap();
+
+    let output = Command::new(bin())
+        .args(["attach", "--socket"])
+        .arg(&socket)
+        .args(["--apply-local-config", "--print-resolved-config"])
+        .env("XDG_CONFIG_HOME", &local_cfg_root)
+        .env_remove("CMUX_LOCAL_CONFIG")
+        .env_remove("CMUX_MUX_CONFIG")
+        .output()
+        .unwrap();
+
+    let _ = server.kill();
+    let _ = server.wait();
+    let _ = fs::remove_dir_all(&dir);
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "attach --print-resolved-config failed: {combined}"
+    );
+
+    let merged: serde_json::Value =
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+            panic!("expected merged chrome JSON on stdout, parse failed:{e}\n{combined}")
+        });
+
+    // Server's theme colour survived: the overlay layered, not replaced.
+    assert_eq!(
+        merged["theme"]["sidebar_rail"].as_str(),
+        Some("#112233"),
+        "server theme colour lost — overlay did not layer over server config: {merged}"
+    );
+    // Local overlay's key binding applied on top of the server config.
+    assert_eq!(
+        merged["keys"]["prefix"].as_str(),
+        Some("ctrl+s"),
+        "local overlay key binding missing from merged config: {merged}"
+    );
+}
+
+/// Issue #40 blocker 1: the `get-resolved-config` protocol verb is also
+/// exposed as a standalone read-only CLI verb (`cmux get-resolved-config`)
+/// so ops scripts can inspect the server's chrome without attaching. It
+/// must return the server's published chrome verbatim (no local overlay).
+/// We start a headless server whose config sets a distinctive theme
+/// colour, then call `cmux --json get-resolved-config` against its
+/// socket and assert the colour is present in the returned object.
+#[test]
+fn get_resolved_config_cli_verb_returns_server_chrome() {
+    let dir = unique_temp_dir("get-resolved-config");
+
+    // Server-side config: a distinctive theme colour only.
+    let server_cfg_root = dir.join("server-config");
+    let server_cmux_dir = server_cfg_root.join("cmux");
+    fs::create_dir_all(&server_cmux_dir).unwrap();
+    fs::write(
+        server_cmux_dir.join("mux.json"),
+        r##"{"theme": {"sidebar_rail": "#445566"}}"##,
+    )
+    .unwrap();
+
+    let socket = dir.join("mux.sock");
+    let mut server = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&socket)
+        .env("XDG_CONFIG_HOME", &server_cfg_root)
+        .env_remove("CMUX_MUX_CONFIG")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if socket.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    if !socket.exists() {
+        let _ = server.kill();
+        let _ = server.wait();
+        panic!(
+            "headless server did not create socket at {}",
+            socket.display()
+        );
+    }
+    // `set_resolved_chrome` runs before `serve()` binds, so a live socket
+    // implies the chrome is published; still give it a beat to settle.
+    std::thread::sleep(Duration::from_millis(100));
+
+    let output = Command::new(bin())
+        .args(["--socket"])
+        .arg(&socket)
+        .args(["--json", "get-resolved-config"])
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+
+    let _ = server.kill();
+    let _ = server.wait();
+    let _ = fs::remove_dir_all(&dir);
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "cmux get-resolved-config failed: {combined}"
+    );
+
+    let chrome: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("expected chrome JSON on stdout, parse failed:{e}\n{combined}"));
+    assert_eq!(
+        chrome["theme"]["sidebar_rail"].as_str(),
+        Some("#445566"),
+        "server theme colour missing from get-resolved-config output: {chrome}"
+    );
+}

--- a/mux/docs/configuration.md
+++ b/mux/docs/configuration.md
@@ -239,3 +239,35 @@ alt_shortcuts = false
 "close-pane" = "none"
 detach = "d"
 ```
+
+## Local config overlay (attach)
+
+`cmux attach --apply-local-config` layers the *local* `mux.local.toml`/`mux.json`
+on top of the server-side session config, so the laptop acts as a thin client:
+the server keeps the truth for the workspace tree (panes, browser, session
+name), while the client wins for presentation chrome and key bindings (theme,
+tabs, sidebar, keys). Per-key override, not replace: only the fields present in
+the local file are applied, everything else stays server-side.
+
+Resolution order for the overlay file:
+
+1. explicit `--config <path>`
+2. `$CMUX_LOCAL_CONFIG`
+3. `~/.config/cmux/mux.local.toml`
+4. `~/.config/cmux/mux.json`
+5. server-side config (no overlay applied)
+
+A local overlay is a typed subset of the full config: `theme`, `tabs`,
+`sidebar`, and `keys` only. Browser panes, scrollbar, and the session name are
+server-side truth and are rejected at parse time with a clear error (a stale
+server-side `browser` block copied into the overlay will not be silently
+ignored). When an overlay applies, attach logs:
+
+```text
+cmux: applying local config from /home/me/.config/cmux/mux.local.toml (overrides 2 keys)
+```
+
+`cmux attach --show-local-config-resolution` is a dry run: it resolves and loads
+the local file the same way, prints the resolved path plus the override count,
+then exits without attaching. Use it to sanity check which config travels to a
+remote box before connecting.

--- a/mux/docs/getting-started.md
+++ b/mux/docs/getting-started.md
@@ -41,6 +41,34 @@ cargo run -p mux-tui -- attach --session agents
 
 Detach from an attached TUI with prefix `d`. With default keys, that is `Ctrl-b d`. The server keeps running, and another `attach` reconnects to the same tree. PTY tabs attach with a Ghostty VT-state replay followed by a live output stream.
 
+### SSH and remote attach with local config
+
+For a remote box, run the server headless there and attach from your laptop,
+carrying your local colours and key bindings onto the remote session:
+
+```bash
+# on the remote box
+cmux --headless --session agents
+
+# on the laptop, over SSH, overlaying the local config
+ssh remotehost 'cmux attach --session agents --apply-local-config'
+```
+
+The local `~/.config/cmux/mux.local.toml` (or `mux.json`, or `$CMUX_LOCAL_CONFIG`,
+or an explicit `--config <path>`) is layered on top of the server config: the
+server keeps the truth for the workspace tree; your laptop wins for theme,
+tabs, sidebar, and keys. So your preferred leader key and colour scheme work
+the same way they do locally. Check which file would apply before connecting
+with the dry run:
+
+```bash
+cmux attach --show-local-config-resolution
+cmux attach --session agents --config ~/.config/cmux/mux.local.toml
+```
+
+The attach logs `cmux: applying local config from <path> (overrides N keys)`.
+See [Configuration > Local config overlay](configuration.md#local-config-overlay-attach).
+
 ## Sessions and sockets
 
 The default socket path is:

--- a/mux/docs/getting-started.md
+++ b/mux/docs/getting-started.md
@@ -45,35 +45,64 @@ Detach from an attached TUI with prefix `d`. With default keys, that is `Ctrl-b 
 
 For a remote box, run the server headless there, then attach from your
 laptop carrying your local colours and key bindings onto the remote
-session. The point is that the *laptop's* cmux process does the attaching,
-so the laptop's `~/.config/cmux/mux.local.toml` (not the remote host's)
-is what applies. Run the cmux **client** locally and forward the remote
-control socket back to the laptop over SSH:
+session. The point is that the *laptop's* cmux process does the
+attaching, so the laptop's `~/.config/cmux/mux.local.toml` (not the
+remote host's) is what applies. Run the cmux **client** locally and
+forward the remote control socket back to the laptop over SSH, so the
+local cmux process attaches to the forwarded socket and layers the
+local overlay on top of the *server's* resolved config.
+
+The remote `cmux --headless` server is reached over an OpenSSH Unix
+domain socket forward: `-L <local-path>:<remote-path>`. The remote
+path must be a concrete filesystem path: OpenSSH does not expand
+environment variables or command substitution in the forward target
+(the remote sshd connects to the path directly, no shell). The
+easiest way to keep the two ends in sync is to start the headless
+server with an explicit `--socket <path>`, then forward that exact
+path:
 
 ```bash
-# on the remote box: serve headless, no TUI
-remotehost$ cmux --headless --session agents
+# on the remote box: serve headless on a known socket, no TUI
+remotehost$ cmux --headless --session agents \
+            --socket /run/user/$(id -u)/cmux-agents.sock
 
-# on the laptop: forward the remote control socket to a local path,
-# then run cmux attach LOCALLY against the forwarded socket with
-# --apply-local-config so the laptop's config overlays the server's.
-# The remote socket path is the documented default (see Sessions and
-# sockets below), e.g. $XDG_RUNTIME_DIR/cmux-<uid>/agents.sock.
-laptop$ ssh -Nf -L /tmp/cmux-agents.sock:'"$XDG_RUNTIME_DIR/cmux-$(id -u)/agents.sock"' remotehost
+# on the laptop: forward that remote socket to a local path (-Nf runs
+# ssh in the background with no shell), then run cmux attach LOCALLY
+# against the forwarded socket with --apply-local-config so the
+# laptop's config overlays the server's resolved config.
+laptop$ ssh -Nf -L /tmp/cmux-agents.sock:/run/user/1000/cmux-agents.sock remotehost
 laptop$ cmux attach --socket /tmp/cmux-agents.sock --apply-local-config
 ```
 
-The local `~/.config/cmux/mux.local.toml` (or `mux.json`, or `$CMUX_LOCAL_CONFIG`,
-or an explicit `--config <path>`) is layered on top of the server config the
-laptop reads back over that forwarded socket: the server keeps the truth for
-the workspace tree; your laptop wins for theme, tabs, sidebar, and keys. So
-your preferred leader key and colour scheme work the same way they do locally.
+If the remote server was started without `--socket` (so its socket lives
+at the default `$XDG_RUNTIME_DIR/cmux-<uid>/<session>.sock`, e.g.
+`/run/user/1000/cmux-1000/agents.sock`), sub that path into both the
+remote command above and the `-L` target. `ssh remotehost 'cmux
+get-sessions'` (or the session's startup log) reports the live socket.
+
+Inspecting layering without a live terminal:
+
+```bash
+# fetch the server chrome, layer the local overlay, print merged JSON, exit
+laptop$ cmux attach --socket /tmp/cmux-agents.sock \
+            --apply-local-config --print-resolved-config
+# server chrome only (no overlay), for ops scripts
+laptop$ cmux --socket /tmp/cmux-agents.sock get-resolved-config
+```
+
+The local `~/.config/cmux/mux.local.toml` (or `mux.json`, or
+`$CMUX_LOCAL_CONFIG`, or an explicit `--config <path>`) is layered on
+top of the server config the laptop fetches over that forwarded socket
+via the `get-resolved-config` verb: the server keeps the truth for the
+workspace tree, browser, and scrollbar; your laptop wins for theme,
+tabs, sidebar, and keys. So your preferred leader key and colour
+scheme work the same way they do locally.
 
 Do NOT run `cmux attach` inside the SSH command string (e.g.
-`ssh remotehost 'cmux attach ... --apply-local-config'`): that executes cmux
-on the remote host and resolves the *remote* `~/.config/cmux/mux.local.toml`,
-the opposite of what this feature is for. The laptop cmux process must be the
-one that loads the overlay.
+`ssh remotehost 'cmux attach ... --apply-local-config'`): that executes
+cmux on the remote host and resolves the *remote*
+`~/.config/cmux/mux.local.toml`, the opposite of what this feature is
+for. The laptop cmux process must be the one that loads the overlay.
 
 Check which local file would apply before connecting with the dry run:
 

--- a/mux/docs/getting-started.md
+++ b/mux/docs/getting-started.md
@@ -43,23 +43,39 @@ Detach from an attached TUI with prefix `d`. With default keys, that is `Ctrl-b 
 
 ### SSH and remote attach with local config
 
-For a remote box, run the server headless there and attach from your laptop,
-carrying your local colours and key bindings onto the remote session:
+For a remote box, run the server headless there, then attach from your
+laptop carrying your local colours and key bindings onto the remote
+session. The point is that the *laptop's* cmux process does the attaching,
+so the laptop's `~/.config/cmux/mux.local.toml` (not the remote host's)
+is what applies. Run the cmux **client** locally and forward the remote
+control socket back to the laptop over SSH:
 
 ```bash
-# on the remote box
-cmux --headless --session agents
+# on the remote box: serve headless, no TUI
+remotehost$ cmux --headless --session agents
 
-# on the laptop, over SSH, overlaying the local config
-ssh remotehost 'cmux attach --session agents --apply-local-config'
+# on the laptop: forward the remote control socket to a local path,
+# then run cmux attach LOCALLY against the forwarded socket with
+# --apply-local-config so the laptop's config overlays the server's.
+# The remote socket path is the documented default (see Sessions and
+# sockets below), e.g. $XDG_RUNTIME_DIR/cmux-<uid>/agents.sock.
+laptop$ ssh -Nf -L /tmp/cmux-agents.sock:'"$XDG_RUNTIME_DIR/cmux-$(id -u)/agents.sock"' remotehost
+laptop$ cmux attach --socket /tmp/cmux-agents.sock --apply-local-config
 ```
 
 The local `~/.config/cmux/mux.local.toml` (or `mux.json`, or `$CMUX_LOCAL_CONFIG`,
-or an explicit `--config <path>`) is layered on top of the server config: the
-server keeps the truth for the workspace tree; your laptop wins for theme,
-tabs, sidebar, and keys. So your preferred leader key and colour scheme work
-the same way they do locally. Check which file would apply before connecting
-with the dry run:
+or an explicit `--config <path>`) is layered on top of the server config the
+laptop reads back over that forwarded socket: the server keeps the truth for
+the workspace tree; your laptop wins for theme, tabs, sidebar, and keys. So
+your preferred leader key and colour scheme work the same way they do locally.
+
+Do NOT run `cmux attach` inside the SSH command string (e.g.
+`ssh remotehost 'cmux attach ... --apply-local-config'`): that executes cmux
+on the remote host and resolves the *remote* `~/.config/cmux/mux.local.toml`,
+the opposite of what this feature is for. The laptop cmux process must be the
+one that loads the overlay.
+
+Check which local file would apply before connecting with the dry run:
 
 ```bash
 cmux attach --show-local-config-resolution

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -52,6 +52,7 @@ The generated CLI requires one of `--index` or `--delta` for `select-tab`, `sele
 | --- | --- | --- | --- | --- |
 | `identify` | implemented | none | global flags | one metadata line |
 | `list-workspaces` | implemented | none | global flags | tree lines |
+| `get-resolved-config` | implemented | none | global flags | pretty JSON chrome object |
 | `send` | implemented | `--surface <id>` | `--text <text>`, `--bytes <base64>` | none |
 | `read-screen` | implemented | `--surface <id>` | none | screen text |
 | `vt-state` | implemented | `--surface <id>` | none | `cols=<n> rows=<n> data=<base64>` |
@@ -62,6 +63,7 @@ The generated CLI requires one of `--index` or `--delta` for `select-tab`, `sele
 | `split` | implemented | `--pane <id> --dir right|down` | `--cols <n> --rows <n>` | surface id |
 | `set-ratio` | implemented | `--pane <id> --dir right|down --ratio <n>` | none | none |
 | `set-default-colors` | implemented | none | `--fg #rrggbb`, `--bg #rrggbb` | none |
+| `get-resolved-config` | implemented | none | global flags | JSON chrome (theme/tabs/sidebar/keys); used by `cmux attach --apply-local-config`/`--print-resolved-config` to layer the local overlay over the server config |
 | `close-surface` | implemented | `--surface <id>` | none | none |
 | `close-pane` | implemented | `--pane <id>` | none | none |
 | `close-screen` | implemented | `--screen <id>` | none | none |

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -168,6 +168,74 @@ Example:
 {"id":2,"ok":true,"data":{"workspaces":[{"id":4,"name":"1","color":null,"active":true,"screens":[{"id":3,"name":null,"active":true,"active_pane":2,"layout":{"type":"leaf","pane":2},"panes":[{"id":2,"name":null,"active_tab":0,"tabs":[{"surface":1,"kind":"pty","browser_source":null,"name":null,"title":"","size":{"cols":80,"rows":24},"dead":false}]}]}]}]}}
 ```
 
+### get-resolved-config
+
+| Field | Value |
+| --- | --- |
+| name | `get-resolved-config` |
+| status | implemented |
+| since | protocol 6 |
+
+Returns the server process's resolved presentation chrome (theme, tabs, sidebar, keys) so a thin-client `cmux attach --apply-local-config` can fetch it and layer the laptop's local `Overlay` on top of the *server* config rather than replacing it with the laptop's own `config::load()` (issue #40). Browser and scrollbar are server-side truth and intentionally omitted: the server keeps them, the attach client does not spawn browsers or scrollbars locally. The shape matches `mux-tui`'s `Config::resolved_chrome_value`; a client rebuilds a base `Config` from it via `Config::from_server_chrome` and then applies the local `Overlay`. A server that has registered no chrome (e.g. a `mux-core`-only host with no TUI) returns an empty object `{}`.
+
+Params: none.
+
+Result:
+
+```text
+object{
+  theme: object{
+    selection_background: ColorHex?,
+    selection_foreground: ColorHex?|null?,
+    sidebar_rail: ColorHex?,
+    sidebar_active_bg: ColorHex?,
+    tab_rail: ColorHex?,
+    tab_bg: ColorHex?,
+    tab_active_bg: ColorHex?,
+    border_active: ColorHex?,
+    border_inactive: ColorHex?
+  }?,
+  tabs: object{
+    min_width: uint16?,
+    solid_background: boolean?,
+    show_titles: boolean?,
+    agents: array<string>?
+  }?,
+  sidebar: object{
+    width: uint16?,
+    max_width: uint16?
+  }?,
+  keys: object<string, string|array<string>>  // Raw keys map; see `Keys::apply` in mux-tui
+}
+```
+
+Colours are `#rrggbb` for true colour, a bare integer for an xterm-256 index, or `null` when they have no portable raw form (named/reset colours). `keys` carries the same raw shape the config loader consumes: `prefix`, `alt_shortcuts`, and one entry per action config key mapped to a chord string or array of chord strings.
+
+Errors:
+
+| Error | Condition |
+| --- | --- |
+| `bad request: ...` | Malformed request envelope (e.g. extra fields) |
+
+CLI mapping:
+
+| Item | Value |
+| --- | --- |
+| Verb | `get-resolved-config` |
+| Flags | none (read-only metadata verb; supports global `--session`/`--socket` and `--json`) |
+| Plain stdout | pretty JSON object, the server's resolved chrome |
+| JSON stdout | exact result object |
+| Exit codes | common |
+
+The same verb is invoked internally by `cmux attach --apply-local-config`, which fetches the chrome, rebuilds a base `Config`, layers the local `Overlay`, and starts the TUI. `cmux attach --print-resolved-config` (issue #40) prints the *merged* chrome (server base + local overlay) as JSON without attaching, for inspecting layering without a live terminal.
+
+Example:
+
+```json
+{"id":3,"cmd":"get-resolved-config"}
+{"id":3,"ok":true,"data":{"theme":{"sidebar_rail":"#112233"},"tabs":{"min_width":8,"solid_background":true,"show_titles":true,"agents":[]},"sidebar":{"width":24,"max_width":40},"keys":{"alt_shortcuts":false,"prefix":"ctrl+b"}}}
+```
+
 ### send
 
 | Field | Value |
@@ -1620,6 +1688,64 @@ Example:
 {"id":28,"cmd":"attach-surface","surface":1}
 {"event":"vt-state","surface":1,"cols":80,"rows":24,"data":"G1s/bA=="}
 {"id":28,"ok":true,"data":{}}
+```
+
+### get-resolved-config
+
+| Field | Value |
+| --- | --- |
+| name | `get-resolved-config` |
+| status | implemented |
+| since | protocol 6 |
+
+Returns the server process's resolved presentation chrome (the keys relevant to a thin-client `Overlay`: theme, tabs, sidebar, keys) so a `cmux attach --apply-local-config` client can layer its local overlay on top of the *server's* config rather than replacing it with the laptop's own (issue #40). Browser and scrollbar are server-side truth and are intentionally not part of the payload. The shape matches what `mux-tui`'s `Config::resolved_chrome_value()` emits and `Config::from_server_chrome()` consumes, so the client round-trips it back through the same `apply_*` resolution helpers `load()` uses.
+
+The server publishes this from its own `config::load()` at startup; if it has not registered any chrome (for example a `mux-core`-only host with no TUI), it returns an empty object `{}` and the client falls back to its local config.
+
+Params: none.
+
+Result:
+
+```text
+object{
+  theme: object{
+    selection_background: ColorHex|uint16,
+    selection_foreground: ColorHex|uint16|null,
+    sidebar_rail: ColorHex|uint16,
+    sidebar_active_bg: ColorHex|uint16,
+    tab_rail: ColorHex|uint16,
+    tab_bg: ColorHex|uint16,
+    tab_active_bg: ColorHex|uint16|null,
+    border_active: ColorHex|uint16,
+    border_inactive: ColorHex|uint16
+  },
+  tabs: object{min_width:uint16,solid_background:boolean,show_titles:boolean,agents:array<string>},
+  sidebar: object{width:uint16,max_width:uint16},
+  keys: object<string,string|boolean|array<string>>
+}
+```
+
+Errors:
+
+| Error | Condition |
+| --- | --- |
+| `bad request: ...` | Wrong JSON type |
+
+CLI mapping:
+
+| Item | Value |
+| --- | --- |
+| Verb | `get-resolved-config` (also consumed internally by `cmux attach --print-resolved-config` and `cmux attach --apply-local-config`) |
+| Flags | n/a |
+| Plain stdout | n/a |
+| JSON stdout | n/a |
+| Exit codes | n/a |
+
+Example:
+
+```json
+{"id":32,"cmd":"get-resolved-config"}
+{"id":32,"ok":true,"data":{"theme":{"sidebar_rail":"#778899",...},"tabs":{...},"sidebar":{...},"keys":{...}}}
 ```
 
 ## Proposed Commands


### PR DESCRIPTION
## Summary
Adds `cmux-mux attach --apply-local-config`, which overlays the *local* `mux.json`/`mux.toml` (theme, tabs, sidebar, keys) on top of the server-side session config, so a laptop becomes a true thin client — matches typecraft's herdr demo workflow named in the issue.

- New `Overlay`/`RawOverlay` types in `config.rs` (theme/tabs/sidebar/keys only; `#[serde(deny_unknown_fields)]` rejects `browser`/`session` at parse time — server stays truth for the tree, client only overrides chrome).
- Resolution order: `--config` → `$CMUX_LOCAL_CONFIG` → `~/.config/cmux/mux.local.toml` → `~/.config/cmux/mux.json` → none.
- New `--show-local-config-resolution` dry-run flag.
- New `get-resolved-config` protocol command + matching `cmux get-resolved-config` CLI verb, so a remote attach can fetch the server's resolved chrome config as the overlay base (round 2 — round 1 shipped the overlay logic but never actually fetched server config for `Session::Remote`, so it silently replaced instead of layered; caught by an independent review + verify pass).
- Docs: `docs/configuration.md` overlay section, `docs/getting-started.md` worked SSH + socket-forward example (verified end-to-end against a real forwarded socket, not just written from memory).

## Test plan
- [x] `cargo check -p mux-tui --locked` — clean, `Cargo.lock` stayed lockfile v3
- [x] `cargo test -p mux-tui` — 101 unit + 16 integration tests, 0 failed (independently re-run, not just trusting the builder's own report)
- [x] Independent review pass: `lgtm_with_warnings` (0 critical, 0 warning, 1 suggestion + 1 nit, both cosmetic — logged as follow-up, not blocking)
- [x] Independent verify pass: 8/8 acceptance-criteria claims PASS, each with concrete reproduction evidence (real CLI runs against a headless server + a real forwarded socket)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the Pi Factory fleet