### PR TITLE
feat(finder): state-key filter (B/W/I/D/A) for the fuzzy finder

### DIFF
--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -1005,6 +1005,17 @@ impl App {
                 self.flashing.insert(workspace, Instant::now());
                 Ok(RenderAction::Draw)
             }
+            // An agent reported a new state; refresh the tree snapshot and,
+            // when the finder overlay is open, rebuild its item list so the
+            // filtered view updates in real time (AC4). The query, active
+            // state filter, and cursor are preserved by set_items.
+            AppEvent::Mux(MuxEvent::AgentStateChanged { .. }) => {
+                self.tree = self.session.tree();
+                if let Some(finder) = self.finder.as_mut() {
+                    finder.set_items(crate::finder::build_items(&self.tree));
+                }
+                Ok(RenderAction::Draw)
+            }
             AppEvent::Mux(_) => Ok(RenderAction::Draw),
             AppEvent::Input(Event::Key(key)) => {
                 if key.kind != KeyEventKind::Release {
@@ -1497,11 +1508,11 @@ impl App {
                 }
                 return Ok(RenderAction::Draw);
             }
-            KeyCode::Char('B') => finder.state_filter = crate::finder::StateFilter::Blocked,
-            KeyCode::Char('W') => finder.state_filter = crate::finder::StateFilter::Working,
-            KeyCode::Char('I') => finder.state_filter = crate::finder::StateFilter::Idle,
-            KeyCode::Char('D') => finder.state_filter = crate::finder::StateFilter::Done,
-            KeyCode::Char('A') => finder.state_filter = crate::finder::StateFilter::All,
+            KeyCode::Char('B') => finder.set_state_filter(crate::finder::StateFilter::Blocked),
+            KeyCode::Char('W') => finder.set_state_filter(crate::finder::StateFilter::Working),
+            KeyCode::Char('I') => finder.set_state_filter(crate::finder::StateFilter::Idle),
+            KeyCode::Char('D') => finder.set_state_filter(crate::finder::StateFilter::Done),
+            KeyCode::Char('A') => finder.set_state_filter(crate::finder::StateFilter::All),
             _ => match finder.input.handle_key(&key) {
                 crate::ui::input::InputEvent::Cancel => {
                     self.finder = None;

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -1482,14 +1482,11 @@ impl App {
 
     /// Keys while the finder is open: typing edits the query, Up/Down
     /// move the cursor, `B`/`W`/`I`/`D`/`A` set the state filter, Enter
-    /// focuses the selected target, Escape closes.
+    /// focuses the selected target, Escape clears an active filter first
+    /// and only closes the finder when the filter is already `All`.
     fn handle_finder_key(&mut self, key: KeyEvent) -> anyhow::Result<RenderAction> {
         let Some(finder) = self.finder.as_mut() else { return Ok(RenderAction::None) };
         match key.code {
-            KeyCode::Esc => {
-                self.finder = None;
-                return Ok(RenderAction::Draw);
-            }
             KeyCode::Up => {
                 let rows = crate::finder::FinderState::rows_visible(self.screen);
                 finder.move_cursor(-1, rows);
@@ -1515,7 +1512,13 @@ impl App {
             KeyCode::Char('A') => finder.set_state_filter(crate::finder::StateFilter::All),
             _ => match finder.input.handle_key(&key) {
                 crate::ui::input::InputEvent::Cancel => {
-                    self.finder = None;
+                    // Esc clears an active state filter first; only a second
+                    // Esc (filter already All) closes the finder (AC3).
+                    let close =
+                        finder.cancel() == crate::finder::FinderCancel::CloseFinder;
+                    if close {
+                        self.finder = None;
+                    }
                     return Ok(RenderAction::Draw);
                 }
                 crate::ui::input::InputEvent::Commit => {

--- a/mux/crates/mux-tui/src/finder.rs
+++ b/mux/crates/mux-tui/src/finder.rs
@@ -61,6 +61,17 @@ impl StateFilter {
     }
 }
 
+/// Outcome of an Esc/Cancel on the finder: clear an active state filter
+/// first (keeping the overlay open), and only close the finder when the
+/// filter is already `All`. See [`FinderState::cancel`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FinderCancel {
+    /// An active state filter was reset to `All`; the finder stayed open.
+    ClearedFilter,
+    /// No filter was active, so the caller should close the finder.
+    CloseFinder,
+}
+
 /// One searchable row. `agent_state` is `None` for workspaces and panes
 /// (they have no agent report) and `Some` for surfaces, sourced from the
 /// tab's reported state.
@@ -115,8 +126,29 @@ impl FinderState {
         if len == 0 {
             self.cursor = 0;
             self.scroll = 0;
-        } else if self.cursor >= len {
-            self.cursor = len - 1;
+        } else {
+            if self.cursor >= len {
+                self.cursor = len - 1;
+            }
+            self.clamp_scroll_after_shrink(len);
+        }
+    }
+
+    /// Handle an Esc/Cancel. If a state filter is active, clear it back to
+    /// `All` and stay open (returns `ClearedFilter`); only when the filter
+    /// is already `All` does this signal the caller to close the finder
+    /// (`CloseFinder`). Mirrors the same-key-toggle clear so Esc clears the
+    /// filter first and only closes on a second press (AC3 Esc path). The
+    /// cursor and scroll reset to the top, matching what the toggle path
+    /// does after a filter change.
+    pub fn cancel(&mut self) -> FinderCancel {
+        if self.state_filter != StateFilter::All {
+            self.state_filter = StateFilter::All;
+            self.cursor = 0;
+            self.scroll = 0;
+            FinderCancel::ClearedFilter
+        } else {
+            FinderCancel::CloseFinder
         }
     }
 
@@ -131,8 +163,30 @@ impl FinderState {
         if len == 0 {
             self.cursor = 0;
             self.scroll = 0;
-        } else if self.cursor >= len {
-            self.cursor = len - 1;
+        } else {
+            if self.cursor >= len {
+                self.cursor = len - 1;
+            }
+            self.clamp_scroll_after_shrink(len);
+        }
+    }
+
+    /// Clamp `scroll` so it never sits past the cursor (or past the last
+    /// row) after the ranked list shrinks. Without this an
+    /// `agent-state-changed` refresh that shrinks the matching set below
+    /// the current scroll offset would leave `draw()`'s
+    /// `ranked.iter().skip(scroll).take(rows)` skipping every row and
+    /// rendering a blank viewport until the next keypress resets scroll.
+    /// The cursor is already clamped to `[0, len - 1]` so capping scroll
+    /// at the cursor keeps a row on screen without needing the screen size
+    /// (which the finder does not store).
+    fn clamp_scroll_after_shrink(&mut self, len: usize) {
+        let max_scroll = len.saturating_sub(1);
+        if self.scroll > self.cursor {
+            self.scroll = self.cursor;
+        }
+        if self.scroll > max_scroll {
+            self.scroll = max_scroll;
         }
     }
 
@@ -746,5 +800,107 @@ mod tests {
         finder.set_state_filter(StateFilter::Blocked);
         assert_eq!(finder.state_filter, StateFilter::All);
         assert_eq!(finder.ranked().len(), 2);
+    }
+
+    /// Esc/Cancel on an active state filter clears the filter and keeps the
+    /// finder open; a second Esc/Cancel (filter now `All`) signals the
+    /// caller to close it (AC3 Esc path, round-2 blocker).
+    #[test]
+    fn cancel_clears_active_filter_then_closes_on_second_press() {
+        let items = vec![
+            item("working-agent", Some(AgentState::Working), surf(1)),
+            item("blocked-agent", Some(AgentState::Blocked), surf(2)),
+            item("idle-agent", Some(AgentState::Idle), surf(3)),
+            item("workspace-one", None, FinderTarget::Workspace(1)),
+        ];
+        let mut finder = FinderState::new(items);
+        finder.set_state_filter(StateFilter::Blocked);
+        assert_eq!(finder.state_filter, StateFilter::Blocked);
+        // There is an active filter, so the finder must NOT close yet.
+        assert_ne!(finder.state_filter, StateFilter::All);
+
+        // First Cancel: clear the filter, finder stays open.
+        assert_eq!(finder.cancel(), FinderCancel::ClearedFilter);
+        assert_eq!(finder.state_filter, StateFilter::All);
+        assert_eq!(finder.cancel(), FinderCancel::CloseFinder);
+    }
+
+    /// A snapshot refresh that shrinks the ranked list below the current
+    /// scroll offset must re-clamp `scroll` so the viewport is not blank
+    /// (round-2 warning: scroll not clamped when the filtered list shrinks).
+    #[test]
+    fn set_items_clamps_scroll_when_list_shrinks() {
+        let screen = Rect { x: 0, y: 0, width: 100, height: 40 };
+        let rows_visible = FinderState::rows_visible(screen);
+        assert!(rows_visible >= 1, "overlay should show at least one row");
+
+        // Build a list longer than the viewport and scroll toward the bottom.
+        let total = rows_visible + 6;
+        let items: Vec<FinderItem> = (0..total as u64)
+            .map(|i| item(&format!("row-{i}"), None, surf(i)))
+            .collect();
+        let mut finder = FinderState::new(items);
+        for _ in 0..(rows_visible + 2) {
+            finder.move_cursor(1, rows_visible);
+        }
+        assert!(finder.scroll > 0, "viewport should have scrolled down");
+
+        // An agent-state-changed refresh shrinks the matching set well below
+        // the current scroll offset.
+        let shrunk: Vec<FinderItem> = (0..3u64)
+            .map(|i| item(&format!("shrunk-{i}"), None, surf(i)))
+            .collect();
+        finder.set_items(shrunk);
+        let new_len = finder.ranked().len();
+        let new_max = new_len.saturating_sub(1);
+        assert!(
+            finder.scroll <= new_max,
+            "scroll {} must be within [0, {new_max}] after shrink",
+            finder.scroll
+        );
+        // The viewport is non-empty: at least one ranked row falls inside
+        // [scroll, scroll + rows_visible).
+        let visible_rows = (finder.scroll..new_len).take(rows_visible).count();
+        assert!(visible_rows >= 1, "viewport must be non-empty after shrink, got {visible_rows}");
+    }
+
+    /// Switching the state filter to a narrower set must likewise re-clamp
+    /// `scroll` so a previously scrolled viewport does not go blank when the
+    /// ranked list shrinks under the new filter (round-2 warning).
+    #[test]
+    fn set_state_filter_clamps_scroll_when_list_shrinks() {
+        let screen = Rect { x: 0, y: 0, width: 100, height: 40 };
+        let rows_visible = FinderState::rows_visible(screen);
+        assert!(rows_visible >= 1);
+
+        // A long mix of states so narrowing the filter leaves only a few
+        // matching rows down the list.
+        let mut items: Vec<FinderItem> = Vec::new();
+        for i in 0..(rows_visible + 6) as u64 {
+            let state = if i == (rows_visible + 4) as u64 {
+                Some(AgentState::Blocked)
+            } else {
+                Some(AgentState::Working)
+            };
+            items.push(item(&format!("row-{i}"), state, surf(i)));
+        }
+        let mut finder = FinderState::new(items);
+        // Scroll toward the bottom of the full (Working) list.
+        for _ in 0..(rows_visible + 2) {
+            finder.move_cursor(1, rows_visible);
+        }
+        assert!(finder.scroll > 0);
+
+        // Narrow to Blocked: only one row matches, far below the old scroll.
+        finder.set_state_filter(StateFilter::Blocked);
+        let new_len = finder.ranked().len();
+        let new_max = new_len.saturating_sub(1);
+        assert!(
+            finder.scroll <= new_max,
+            "scroll {} must be within [0, {new_max}] after narrowing",
+            finder.scroll
+        );
+        let visible_rows = (finder.scroll..new_len).take(rows_visible).count();
+        assert!(visible_rows >= 1, "viewport must be non-empty after narrowing, got {visible_rows}");
     }
 }

--- a/mux/crates/mux-tui/src/finder.rs
+++ b/mux/crates/mux-tui/src/finder.rs
@@ -102,6 +102,40 @@ impl FinderState {
         }
     }
 
+    /// Apply `next` as the active state filter, toggling back to `All`
+    /// when the same filter key is pressed again (so `B` then `B`
+    /// returns to the unfiltered list). Pressing `A` always collapses to
+    /// `All` (it is the explicit "no filter" key), which is a no-op when
+    /// the filter is already `All`. The cursor and scroll are clamped to
+    /// the new (smaller or larger) ranked list so the selection never
+    /// points past the end.
+    pub fn set_state_filter(&mut self, next: StateFilter) {
+        self.state_filter = if self.state_filter == next { StateFilter::All } else { next };
+        let len = self.ranked().len();
+        if len == 0 {
+            self.cursor = 0;
+            self.scroll = 0;
+        } else if self.cursor >= len {
+            self.cursor = len - 1;
+        }
+    }
+
+    /// Replace the snapshot of finder items built on open. Used when an
+    /// `agent-state-changed` event arrives while the finder is open so the
+    /// live agent states refresh without losing the current query, state
+    /// filter, or cursor position. The cursor is clamped to the new ranked
+    /// list length in case the refresh shrank the matching set.
+    pub fn set_items(&mut self, items: Vec<FinderItem>) {
+        self.items = items;
+        let len = self.ranked().len();
+        if len == 0 {
+            self.cursor = 0;
+            self.scroll = 0;
+        } else if self.cursor >= len {
+            self.cursor = len - 1;
+        }
+    }
+
     /// Number of result rows the overlay can show at once on `screen`.
     /// Zero when the overlay does not fit. Shared by the draw path, the
     /// cursor/scroll handling, and the click hit-test arithmetic so all
@@ -649,5 +683,68 @@ mod tests {
         assert_eq!(finder.cursor, 0);
         assert_eq!(finder.scroll, 0);
         assert_eq!(finder_row_at(screen, rect.x + 5, rows_y, finder.scroll), Some(0));
+    }
+
+    /// Pressing the same state-filter key twice clears the filter back to
+    /// the full list (AC3 same-key toggle, AC6 unit test). A fixture list
+    /// spans every agent state plus two stateless rows.
+    #[test]
+    fn pressing_same_state_key_twice_clears_filter() {
+        let items = vec![
+            item("working-agent", Some(AgentState::Working), surf(1)),
+            item("blocked-agent", Some(AgentState::Blocked), surf(2)),
+            item("idle-agent", Some(AgentState::Idle), surf(3)),
+            item("done-agent", Some(AgentState::Done), surf(4)),
+            item("workspace-one", None, FinderTarget::Workspace(1)),
+            item("pane-one", None, FinderTarget::Pane(1)),
+        ];
+        let mut finder = FinderState::new(items.clone());
+        // Start unfiltered: every row shows.
+        assert_eq!(finder.state_filter, StateFilter::All);
+        assert_eq!(finder.ranked().len(), items.len());
+
+        // Press B: only the blocked agent remains (stateless rows drop out).
+        finder.set_state_filter(StateFilter::Blocked);
+        let ranked = finder.ranked();
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(finder.items[ranked[0].0].label, "blocked-agent");
+
+        // Press B again: the same-key toggle reverts to All, restoring the
+        // full list including the stateless workspace and pane rows.
+        finder.set_state_filter(StateFilter::Blocked);
+        assert_eq!(finder.state_filter, StateFilter::All);
+        assert_eq!(finder.ranked().len(), items.len());
+    }
+
+    /// `set_items` rebuilds the snapshot from a fresh tree without losing
+    /// the active query, state filter, or cursor window, so an
+    /// `agent-state-changed` event while the finder is open updates the
+    /// list in real time (AC4 live refresh).
+    #[test]
+    fn set_items_refreshes_snapshot_preserving_filter() {
+        let items = vec![
+            item("blocked-agent", Some(AgentState::Blocked), surf(1)),
+            item("working-agent", Some(AgentState::Working), surf(2)),
+            item("workspace-one", None, FinderTarget::Workspace(1)),
+        ];
+        let mut finder = FinderState::new(items.clone());
+        finder.set_state_filter(StateFilter::Blocked);
+        assert_eq!(finder.ranked().len(), 1);
+
+        // The server reports the blocked agent transitioned to working; the
+        // refreshed snapshot drops the blocked row, so the active Blocked
+        // filter now yields zero matches while the filter itself is kept.
+        let refreshed = vec![
+            item("working-agent", Some(AgentState::Working), surf(2)),
+            item("workspace-one", None, FinderTarget::Workspace(1)),
+        ];
+        finder.set_items(refreshed);
+        assert_eq!(finder.state_filter, StateFilter::Blocked);
+        assert_eq!(finder.ranked().len(), 0);
+
+        // Clearing the filter shows the refreshed full list.
+        finder.set_state_filter(StateFilter::Blocked);
+        assert_eq!(finder.state_filter, StateFilter::All);
+        assert_eq!(finder.ranked().len(), 2);
     }
 }

--- a/mux/docs/keyboard.md
+++ b/mux/docs/keyboard.md
@@ -139,3 +139,23 @@ detach
 Chord strings are case-sensitive for single characters. Uppercase letters and symbols represent the shifted character.
 
 Supported examples include `"c"`, `"%"`, `"ctrl+b"`, `"alt+enter"`, `"tab"`, `"backtab"`, `"shift+tab"`, `"pageup"`, `"pagedown"`, `"esc"`, `"space"`, `"left"`, `"right"`, `"up"`, `"down"`, `"home"`, and `"end"`.
+
+## Fuzzy Finder
+
+Press `Ctrl-b G` (`leader G`) to open the fuzzy finder overlay, which lists
+workspaces, panes, and surfaces for type-ahead navigation. While the finder
+is open, the following state-filter keys narrow the result set to one agent
+state. Pressing the same key again, or `Esc`, clears the filter back to the
+full list. The active filter is shown in the finder footer (for example
+`[blocked: B W I D A]`).
+
+| Key | Filter |
+| --- | --- |
+| `B` | blocked agents |
+| `W` | working agents |
+| `I` | idle agents |
+| `D` | done agents |
+| `A` | all agents (no filter) |
+
+The finder subscribes to `agent-state-changed` events, so the filtered list
+updates in real time as agents report new states while the overlay is open.

--- a/mux/docs/keyboard.md
+++ b/mux/docs/keyboard.md
@@ -146,8 +146,8 @@ Press `Ctrl-b G` (`leader G`) to open the fuzzy finder overlay, which lists
 workspaces, panes, and surfaces for type-ahead navigation. While the finder
 is open, the following state-filter keys narrow the result set to one agent
 state. Pressing the same key again, or `Esc`, clears the filter back to the
-full list. The active filter is shown in the finder footer (for example
-`[blocked: B W I D A]`).
+full list. The active filter is shown on the finder title row (for example
+`[blocked: B W I D A]`), not a separate footer.
 
 | Key | Filter |
 | --- | --- |


### PR DESCRIPTION
## Summary
Extends the fuzzy finder (`leader G`, issue #38) with single-key state filters mirroring cmux's agent-state model: `B` blocked, `W` working, `I` idle, `D` done, `A` all.

- Pressing a state key narrows the ranked list to that state; pressing the same key again clears it.
- `Esc` clears an active filter first, only closing the finder if there's no filter to clear (round 2 — round 1 shipped Esc always closing the finder outright, missed by the spec; caught by independent review).
- Subscribes to `agent-state-changed` so the filtered list updates live; scroll position is now re-clamped when a state-changed event shrinks the list (round 2 — round 1 could leave a blank viewport until the next keypress; caught by independent review).
- `docs/keyboard.md` documents the keys and clarifies the active-filter indicator lives on the finder's title row, not a separate footer.

## Test plan
- [x] `cargo check -p mux-tui --locked` — clean, `Cargo.lock` stayed lockfile v3
- [x] `cargo test -p mux-tui` — 106 unit + 16 integration tests, 0 failed (independently re-run)
- [x] Independent review pass: `lgtm`, 0 findings
- [x] Independent verify pass: 6/7 acceptance-criteria claims PASS with concrete test evidence; the 1 remaining "fail" is a stale wording check against round-1's original footer claim, superseded once the docs were corrected to match the actual (title-row) placement in round 2

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the Pi Factory fleet