### PR TITLE
feat(plugin): manifest + registry loader (issue #42, scoped PR 1 of ~3)

### DIFF
--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -23,6 +23,7 @@ mod hook_merge;
 mod host_colors;
 mod keys;
 mod pi_hook;
+mod plugin;
 mod session;
 mod skill_content;
 mod socket_watchdog;
@@ -68,6 +69,7 @@ USAGE:
   cmux pi install-hooks           Pi agent extension integration (see below)
   cmux aider install-hooks        Aider wrapper integration (see below)
   cmux grok install-hooks         Grok CLI hook integration (see below)
+  cmux plugin <subcommand> Manage cmux-plugin.toml manifests (see below)
   cmux ssh <host> [OPTS]   Open a remote workspace over SSH (see below)
 
 OPTIONS:
@@ -170,6 +172,19 @@ GROK CLI INTEGRATION
   cmux grok install-skill [--uninstall] [--global]
       Installs the orchestration skill to .agents/skills/cmux-orchestration/SKILL.md
       (or ~/.grok/skills/cmux-orchestration/SKILL.md if --global).
+
+PLUGIN LOADER (manifest + registry only; no execution yet)
+  cmux plugin list                       List installed plugins (read-only)
+  cmux plugin install <manifest-path>    Install a plugin from a cmux-plugin.toml
+  cmux plugin uninstall <name>           Remove an installed plugin
+  cmux plugin enable <name>              Mark a plugin enabled
+  cmux plugin disable <name>             Mark a plugin disabled
+
+      These verbs only manage on-disk manifest state and a small JSON
+      registry under ~/.local/share/cmux/plugins.json. Plugin *execution*
+      (proxying `cmux <plugin-name> <verb>` to a running plugin process,
+      WASM/WASI sandboxing) is NOT implemented by this verb group and is
+      deferred to a follow-up PR.
 
 REMOTE (SSH) WORKSPACES
   cmux ssh <host> [--name <workspace-name>] [--session <mux-session>]
@@ -276,6 +291,9 @@ fn main() {
                 std::process::exit(2);
             }
         }
+    }
+    if raw_args.first().map(|arg| arg.as_str()) == Some("plugin") {
+        std::process::exit(plugin::run(&raw_args[1..]));
     }
     if raw_args.first().map(|arg| arg.as_str()) == Some("ssh") {
         std::process::exit(ssh_bootstrap::run(&raw_args[1..]));

--- a/mux/crates/mux-tui/src/plugin.rs
+++ b/mux/crates/mux-tui/src/plugin.rs
@@ -1,0 +1,612 @@
+//! `cmux plugin` verb group: manifest-only plugin registry.
+//!
+//! Implements `list`, `install`, `uninstall`, `enable`, and `disable`
+//! for `cmux-plugin.toml` manifests. This PR does NOT spawn, execute,
+//! or sandbox any plugin code; it only manages on-disk manifest state
+//! and a small JSON registry file. Plugin *execution* (proxying
+//! `cmux <plugin-name> <verb>` calls to a running plugin process,
+//! WASM/WASI sandboxing) is deferred to a follow-up PR and is not
+//! implemented by anything in this module.
+//!
+//! On-disk layout (under the cmux data directory, which honours
+//! `XDG_DATA_HOME` and falls back to `~/.local/share/cmux`):
+//!
+//! ```text
+//! <base>/
+//!   plugins.json          <- registry: { "plugins": [PluginEntry, ...] }
+//!   plugins/
+//!     <name>/
+//!       cmux-plugin.toml  <- the manifest copied verbatim at install time
+//! ```
+//!
+//! Manifest shape (`cmux-plugin.toml`):
+//!
+//! ```toml
+//! [plugin]
+//! name = "pifactory-fleet"
+//! entry = "bin/fleet.wasm"
+//! verbs = ["deploy", "rollback"]
+//! ```
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const USAGE: &str = "\
+cmux plugin - manage cmux-plugin.toml manifests (no execution yet)
+
+USAGE:
+  cmux plugin list                       List installed plugins (read-only)
+  cmux plugin install <manifest-path>    Install a plugin from a manifest
+  cmux plugin uninstall <name>           Remove an installed plugin
+  cmux plugin enable <name>              Mark a plugin enabled
+  cmux plugin disable <name>             Mark a plugin disabled
+
+Shared global flags (accepted before the subcommand):
+  --json     Emit machine-readable JSON for `list`.
+
+NOT IMPLEMENTED (deferred to a follow-up PR):
+  Plugin *execution* (proxying `cmux <plugin-name> <verb>` to a running
+  plugin process, WASM/WASI sandboxing, the permission model) is out of
+  scope for this verb group. These verbs only manage manifest state.
+
+The manifest file is `cmux-plugin.toml` with a single `[plugin]` table:
+  name   (string, required, non-empty)    plugin id and on-disk dir name
+  entry  (string, required, non-empty)    path to the plugin entry artefact
+                                          (stored verbatim; not resolved,
+                                          not validated as executable here)
+  verbs  (array of strings, required,    the verbs this plugin claims
+          non-empty, each non-empty)      (stored verbatim; not proxied)
+";
+
+/// Entry-level dispatch. Returns a process exit code. Called from
+/// `main.rs` when `raw_args.first() == Some("plugin")`.
+pub fn run(args: &[String]) -> i32 {
+    let mut json = false;
+    let mut rest: Vec<&str> = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        if !json && arg == "--json" {
+            json = true;
+            i += 1;
+            continue;
+        }
+        rest.push(arg);
+        i += 1;
+    }
+
+    let Some(sub) = rest.first().copied() else {
+        print!("{USAGE}");
+        return 0;
+    };
+
+    let positional = &rest[1..];
+    match base_dir() {
+        Ok(base) => dispatch(&base, sub, positional, json),
+        Err(err) => {
+            eprintln!("cmux plugin: {err}");
+            1
+        }
+    }
+}
+
+fn dispatch(base: &Path, sub: &str, positional: &[&str], json: bool) -> i32 {
+    match sub {
+        "list" => cmd_list(base, json),
+        "install" => cmd_install(base, positional),
+        "uninstall" => cmd_uninstall(base, positional),
+        "enable" => cmd_set_enabled(base, positional, true),
+        "disable" => cmd_set_enabled(base, positional, false),
+        "-h" | "--help" | "help" => {
+            print!("{USAGE}");
+            0
+        }
+        other => {
+            eprintln!("cmux plugin: unknown subcommand {other:?}\n\n{USAGE}");
+            2
+        }
+    }
+}
+
+// ----- paths ---------------------------------------------------------------
+
+/// Resolve the cmux data base directory (`<base>/plugins` and
+/// `<base>/plugins.json` live under this). Honours `XDG_DATA_HOME` and
+/// falls back to `~/.local/share/cmux`, mirroring the chrome profile
+/// resolution in `mux_core::platform`. Pure: no IO.
+fn base_dir() -> Result<PathBuf, String> {
+    if let Some(raw) = std::env::var_os("XDG_DATA_HOME") {
+        if !raw.is_empty() {
+            return Ok(PathBuf::from(raw).join("cmux"));
+        }
+    }
+    std::env::var_os("HOME")
+        .filter(|h| !h.is_empty())
+        .map(|h| PathBuf::from(h).join(".local").join("share").join("cmux"))
+        .ok_or_else(|| "could not resolve cmux data dir (set XDG_DATA_HOME or HOME)".to_string())
+}
+
+fn plugins_dir(base: &Path) -> PathBuf {
+    base.join("plugins")
+}
+
+fn registry_path(base: &Path) -> PathBuf {
+    base.join("plugins.json")
+}
+
+// ----- manifest ------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+struct ManifestFile {
+    plugin: ManifestPlugin,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ManifestPlugin {
+    name: String,
+    entry: String,
+    verbs: Vec<String>,
+}
+
+/// Parse a manifest string into a validated `ManifestPlugin`. Returns a
+/// clear, single-line error for malformed TOML, missing required
+/// fields, or semantically empty required fields. Pure: no IO.
+fn parse_manifest(content: &str) -> Result<ManifestPlugin, String> {
+    let file: ManifestFile =
+        toml::from_str(content).map_err(|err| format!("malformed cmux-plugin.toml: {err}"))?;
+    let ManifestPlugin { name, entry, verbs } = &file.plugin;
+    if name.trim().is_empty() {
+        return Err("manifest missing required field [plugin] name".to_string());
+    }
+    if entry.trim().is_empty() {
+        return Err("manifest missing required field [plugin] entry".to_string());
+    }
+    if verbs.is_empty() {
+        return Err("manifest missing required field [plugin] verbs".to_string());
+    }
+    for verb in verbs {
+        if verb.trim().is_empty() {
+            return Err("manifest [plugin] verbs contains an empty entry".to_string());
+        }
+    }
+    // The name becomes a directory under `plugins/`, so it must be a
+    // single path component (no separators, no "." / "..").
+    if name.contains(std::path::MAIN_SEPARATOR) || name == "." || name == ".." || name.contains('/')
+    {
+        return Err(format!("plugin name {name:?} must not be a path"));
+    }
+    Ok(file.plugin)
+}
+
+// ----- registry ------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PluginEntry {
+    name: String,
+    enabled: bool,
+    entry: String,
+    verbs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct Registry {
+    plugins: Vec<PluginEntry>,
+}
+
+/// Read the registry file. Missing file is an empty registry, not an
+/// error: a fresh install has no `plugins.json` yet.
+fn load_registry(base: &Path) -> Result<Registry, String> {
+    let path = registry_path(base);
+    match fs::read_to_string(&path) {
+        Ok(content) => {
+            if content.trim().is_empty() {
+                return Ok(Registry::default());
+            }
+            serde_json::from_str::<Registry>(&content)
+                .map_err(|err| format!("corrupt registry {}: {err}", path.display()))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Registry::default()),
+        Err(err) => Err(format!("failed to read {}: {err}", path.display())),
+    }
+}
+
+/// Persist the registry as pretty JSON. Creates the parent directory
+/// on demand so a fresh install works without a pre-existing base dir.
+fn save_registry(base: &Path, reg: &Registry) -> Result<(), String> {
+    let path = registry_path(base);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(reg)
+        .map_err(|err| format!("failed to encode registry: {err}"))?;
+    fs::write(&path, json).map_err(|err| format!("failed to write {}: {err}", path.display()))
+}
+
+fn find_entry_mut<'a>(reg: &'a mut Registry, name: &str) -> Option<&'a mut PluginEntry> {
+    reg.plugins.iter_mut().find(|p| p.name == name)
+}
+
+// ----- subcommands ---------------------------------------------------------
+
+fn cmd_list(base: &Path, json: bool) -> i32 {
+    let reg = match load_registry(base) {
+        Ok(reg) => reg,
+        Err(err) => {
+            eprintln!("cmux plugin list: {err}");
+            return 1;
+        }
+    };
+    if reg.plugins.is_empty() {
+        if json {
+            let _ = println!("{}", serde_json::to_string(&reg).unwrap_or_default());
+        } else {
+            println!("no plugins installed");
+        }
+        return 0;
+    }
+    // Sorted, stable, greppable output (matches the repo output style).
+    let mut entries = reg.plugins.clone();
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    if json {
+        let _ = println!("{}", serde_json::to_string(&reg).unwrap_or_default());
+        return 0;
+    }
+    for e in &entries {
+        let state = if e.enabled { "enabled" } else { "disabled" };
+        let verbs = e.verbs.join(",");
+        println!("{} {} {} {}", e.name, state, e.entry, verbs);
+    }
+    0
+}
+
+fn cmd_install(base: &Path, positional: &[&str]) -> i32 {
+    let Some(&manifest_path) = positional.first() else {
+        eprintln!("cmux plugin install: missing <manifest-path>\n\n{USAGE}");
+        return 2;
+    };
+    if positional.len() > 1 {
+        eprintln!("cmux plugin install: unexpected extra argument {:?}", positional[1]);
+        return 2;
+    }
+    let content = match fs::read_to_string(manifest_path) {
+        Ok(c) => c,
+        Err(err) => {
+            eprintln!("cmux plugin install: cannot read {manifest_path:?}: {err}");
+            return 1;
+        }
+    };
+    let plugin = match parse_manifest(&content) {
+        Ok(p) => p,
+        Err(err) => {
+            eprintln!("cmux plugin install: {err}");
+            return 1;
+        }
+    };
+    let mut reg = match load_registry(base) {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!("cmux plugin install: {err}");
+            return 1;
+        }
+    };
+    if reg.plugins.iter().any(|p| p.name == plugin.name) {
+        eprintln!(
+            "cmux plugin install: a plugin named {:?} is already installed",
+            plugin.name
+        );
+        return 1;
+    }
+    let plugin_dir = plugins_dir(base).join(&plugin.name);
+    if let Err(err) = fs::create_dir_all(&plugin_dir) {
+        eprintln!("cmux plugin install: failed to create {}: {err}", plugin_dir.display());
+        return 1;
+    }
+    let dest = plugin_dir.join("cmux-plugin.toml");
+    if let Err(err) = fs::write(&dest, &content) {
+        // Roll back the directory we just made so a failed install does
+        // not leave an empty half-registered plugin on disk.
+        let _ = fs::remove_dir_all(&plugin_dir);
+        eprintln!("cmux plugin install: failed to write {}: {err}", dest.display());
+        return 1;
+    }
+    reg.plugins.push(PluginEntry {
+        name: plugin.name.clone(),
+        enabled: true,
+        entry: plugin.entry.clone(),
+        verbs: plugin.verbs.clone(),
+    });
+    if let Err(err) = save_registry(base, &reg) {
+        let _ = fs::remove_dir_all(&plugin_dir);
+        eprintln!("cmux plugin install: {err}");
+        return 1;
+    }
+    println!("installed plugin {} from {}", plugin.name, Path::new(manifest_path).display());
+    0
+}
+
+fn cmd_uninstall(base: &Path, positional: &[&str]) -> i32 {
+    let Some(&name) = positional.first() else {
+        eprintln!("cmux plugin uninstall: missing <name>\n\n{USAGE}");
+        return 2;
+    };
+    if positional.len() > 1 {
+        eprintln!("cmux plugin uninstall: unexpected extra argument {:?}", positional[1]);
+        return 2;
+    }
+    let mut reg = match load_registry(base) {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!("cmux plugin uninstall: {err}");
+            return 1;
+        }
+    };
+    let before = reg.plugins.len();
+    reg.plugins.retain(|p| p.name != name);
+    if reg.plugins.len() == before {
+        eprintln!("cmux plugin uninstall: no plugin named {name:?} is installed");
+        return 1;
+    }
+    let plugin_dir = plugins_dir(base).join(name);
+    if plugin_dir.exists() {
+        if let Err(err) = fs::remove_dir_all(&plugin_dir) {
+            eprintln!(
+                "cmux plugin uninstall: failed to remove {}: {err}",
+                plugin_dir.display()
+            );
+            return 1;
+        }
+    }
+    if let Err(err) = save_registry(base, &reg) {
+        eprintln!("cmux plugin uninstall: {err}");
+        return 1;
+    }
+    println!("uninstalled plugin {name}");
+    0
+}
+
+fn cmd_set_enabled(base: &Path, positional: &[&str], enabled: bool) -> i32 {
+    let label = if enabled { "enable" } else { "disable" };
+    let Some(&name) = positional.first() else {
+        eprintln!("cmux plugin {label}: missing <name>\n\n{USAGE}");
+        return 2;
+    };
+    if positional.len() > 1 {
+        eprintln!("cmux plugin {label}: unexpected extra argument {:?}", positional[1]);
+        return 2;
+    }
+    let mut reg = match load_registry(base) {
+        Ok(r) => r,
+        Err(err) => {
+            eprintln!("cmux plugin {label}: {err}");
+            return 1;
+        }
+    };
+    let Some(entry) = find_entry_mut(&mut reg, name) else {
+        eprintln!("cmux plugin {label}: no plugin named {name:?} is installed");
+        return 1;
+    };
+    let already = entry.enabled == enabled;
+    if !already {
+        entry.enabled = enabled;
+    }
+    if let Err(err) = save_registry(base, &reg) {
+        eprintln!("cmux plugin {label}: {err}");
+        return 1;
+    }
+    let state = if enabled { "enabled" } else { "disabled" };
+    if already {
+        println!("plugin {name} already {state}");
+    } else {
+        println!("plugin {name} {state}");
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest(name: &str, entry: &str, verbs: &[&str]) -> String {
+        let verbs = verbs
+            .iter()
+            .map(|v| format!("\"{v}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "[plugin]\nname = \"{name}\"\nentry = \"{entry}\"\nverbs = [{verbs}]\n"
+        )
+    }
+
+    fn tmp_base(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-plugin-test-{tag}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parse_manifest_success() {
+        let m = parse_manifest(&manifest("fleet", "bin/fleet.wasm", &["deploy", "rollback"]))
+            .expect("valid manifest parses");
+        assert_eq!(m.name, "fleet");
+        assert_eq!(m.entry, "bin/fleet.wasm");
+        assert_eq!(m.verbs, vec!["deploy".to_string(), "rollback".to_string()]);
+    }
+
+    #[test]
+    fn parse_manifest_missing_name() {
+        let err = parse_manifest("[plugin]\nentry = \"x\"\nverbs = [\"y\"]\n").unwrap_err();
+        assert!(err.contains("name"), "error should name the missing field: {err}");
+    }
+
+    #[test]
+    fn parse_manifest_missing_entry() {
+        let err = parse_manifest("[plugin]\nname = \"x\"\nverbs = [\"y\"]\n").unwrap_err();
+        assert!(err.contains("entry"), "error should name the missing field: {err}");
+    }
+
+    #[test]
+    fn parse_manifest_missing_verbs() {
+        let err = parse_manifest("[plugin]\nname = \"x\"\nentry = \"y\"\n").unwrap_err();
+        assert!(err.contains("verbs"), "error should name the missing field: {err}");
+    }
+
+    #[test]
+    fn parse_manifest_malformed_toml() {
+        let err = parse_manifest("this is not = = valid toml").unwrap_err();
+        assert!(err.contains("malformed cmux-plugin.toml"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_manifest_empty_verbs_list() {
+        let err =
+            parse_manifest("[plugin]\nname = \"x\"\nentry = \"y\"\nverbs = []\n").unwrap_err();
+        assert!(err.contains("verbs"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_manifest_name_must_not_be_a_path() {
+        let err = parse_manifest(&manifest("../evil", "x", &["y"])).unwrap_err();
+        assert!(err.contains("path"), "error: {err}");
+        let err = parse_manifest(&manifest("a/b", "x", &["y"])).unwrap_err();
+        assert!(err.contains("path"), "error: {err}");
+    }
+
+    /// Covers AC1..AC5 against an injected temp base dir (no env-var
+    /// mutation, so it is safe under `cargo test` parallelism).
+    #[test]
+    fn install_list_uninstall_enable_disable_round_trip() {
+        let base = tmp_base("roundtrip");
+
+        // Empty list prints the empty message, exit 0.
+        assert_eq!(cmd_list(&base, false), 0);
+        assert_eq!(load_registry(&base).unwrap().plugins.len(), 0);
+
+        // Install a valid manifest from a temp file.
+        let manifest_dir = std::env::temp_dir().join(format!(
+            "cmux-plugin-manifest-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&manifest_dir).unwrap();
+        let manifest_file = manifest_dir.join("cmux-plugin.toml");
+        fs::write(&manifest_file, manifest("fleet", "bin/fleet.wasm", &["deploy", "rollback"]))
+            .unwrap();
+        let path_str = manifest_file.to_str().unwrap().to_string();
+        assert_eq!(cmd_install(&base, &[path_str.as_str()]), 0);
+
+        // AC1: registered enabled by default, manifest copied under plugins/.
+        let reg = load_registry(&base).unwrap();
+        assert_eq!(reg.plugins.len(), 1);
+        let entry = &reg.plugins[0];
+        assert_eq!(entry.name, "fleet");
+        assert!(entry.enabled);
+        assert_eq!(entry.entry, "bin/fleet.wasm");
+        assert_eq!(
+            entry.verbs,
+            vec!["deploy".to_string(), "rollback".to_string()]
+        );
+        let dest = plugins_dir(&base).join("fleet").join("cmux-plugin.toml");
+        assert!(dest.exists(), "manifest should be copied to {}", dest.display());
+        assert_eq!(
+            fs::read_to_string(&dest).unwrap(),
+            manifest("fleet", "bin/fleet.wasm", &["deploy", "rollback"])
+        );
+
+        // AC5: duplicate name fails, does not partially register.
+        assert_eq!(cmd_install(&base, &[path_str.as_str()]), 1);
+        assert_eq!(load_registry(&base).unwrap().plugins.len(), 1);
+
+        // AC4: list reflects the installed plugin.
+        assert_eq!(cmd_list(&base, false), 0);
+
+        // AC3: disable persists across a fresh registry read.
+        assert_eq!(cmd_set_enabled(&base, &["fleet"], false), 0);
+        assert!(!load_registry(&base).unwrap().plugins[0].enabled);
+        assert_eq!(cmd_set_enabled(&base, &["fleet"], true), 0);
+        assert!(load_registry(&base).unwrap().plugins[0].enabled);
+
+        // AC5: enable/disable of an unknown plugin fails clearly.
+        assert_eq!(cmd_set_enabled(&base, &["nope"], true), 1);
+
+        // AC4: uninstall of an unknown plugin fails clearly.
+        assert_eq!(cmd_uninstall(&base, &["nope"]), 1);
+
+        // AC2: uninstall removes the registry entry and the plugin dir.
+        assert_eq!(cmd_uninstall(&base, &["fleet"]), 0);
+        assert_eq!(load_registry(&base).unwrap().plugins.len(), 0);
+        assert!(!dest.exists(), "plugin dir should be removed after uninstall");
+
+        let _ = fs::remove_dir_all(&base);
+        let _ = fs::remove_dir_all(&manifest_dir);
+    }
+
+    #[test]
+    fn install_missing_manifest_arg_is_usage_error() {
+        let base = tmp_base("noarg");
+        assert_eq!(cmd_install(&base, &[]), 2);
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn install_nonexistent_file_is_command_error() {
+        let base = tmp_base("nofile");
+        assert_eq!(cmd_install(&base, &["/nonexistent/cmux-plugin.toml"]), 1);
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn install_malformed_manifest_is_command_error() {
+        let base = tmp_base("badman");
+        let dir = std::env::temp_dir().join(format!(
+            "cmux-plugin-bad-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("cmux-plugin.toml");
+        fs::write(&file, "[plugin]\nname = \"x\"\n").unwrap();
+        let path = file.to_str().unwrap().to_string();
+        assert_eq!(cmd_install(&base, &[path.as_str()]), 1);
+        assert_eq!(load_registry(&base).unwrap().plugins.len(), 0);
+        let _ = fs::remove_dir_all(&base);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unknown_subcommand_is_usage_error() {
+        let base = tmp_base("unknown");
+        assert_eq!(dispatch(&base, "frobnicate", &[], false), 2);
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn dispatch_help_prints_usage() {
+        let base = tmp_base("help");
+        assert_eq!(dispatch(&base, "--help", &[], false), 0);
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn list_empty_prints_no_plugins_installed() {
+        let base = tmp_base("empty");
+        // Human mode prints the empty message.
+        assert_eq!(cmd_list(&base, false), 0);
+        // JSON mode emits an empty registry object.
+        assert_eq!(cmd_list(&base, true), 0);
+        let _ = fs::remove_dir_all(&base);
+    }
+}

--- a/mux/crates/mux-tui/src/plugin.rs
+++ b/mux/crates/mux-tui/src/plugin.rs
@@ -214,11 +214,27 @@ fn load_registry(base: &Path) -> Result<Registry, String> {
 
 /// Persist the registry as pretty JSON. Creates the parent directory
 /// on demand so a fresh install works without a pre-existing base dir.
+///
+/// Refuses to write if `<base>/plugins.json` already exists and is a
+/// symlink: `fs::write` would follow the symlink and overwrite its
+/// target, which is dangerous here because an attacker with write access
+/// to the cmux data dir could plant such a symlink pointing at a
+/// sensitive file. Plugin manifests are a third-party-trust boundary
+/// even though execution is deferred, so the same paranoia applies to
+/// the registry file.
 fn save_registry(base: &Path, reg: &Registry) -> Result<(), String> {
     let path = registry_path(base);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
             .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
+    }
+    if let Ok(meta) = fs::symlink_metadata(&path) {
+        if meta.file_type().is_symlink() {
+            return Err(format!(
+                "refusing to write through symlink at {}",
+                path.display()
+            ));
+        }
     }
     let json = serde_json::to_string_pretty(reg)
         .map_err(|err| format!("failed to encode registry: {err}"))?;
@@ -227,6 +243,61 @@ fn save_registry(base: &Path, reg: &Registry) -> Result<(), String> {
 
 fn find_entry_mut<'a>(reg: &'a mut Registry, name: &str) -> Option<&'a mut PluginEntry> {
     reg.plugins.iter_mut().find(|p| p.name == name)
+}
+
+/// Recursive directory removal that refuses to follow symlinks.
+/// `fs::remove_dir_all` will happily walk through a symlink and delete
+/// the target's contents, which is dangerous here: an attacker with
+/// write access to the cmux data dir could plant a symlink inside (or
+/// at the root of) a plugin directory pointing at a sensitive file, and
+/// `uninstall` would then delete through it. We walk the tree top-down
+/// using `fs::symlink_metadata` and refuse the whole removal if any
+/// entry is a symlink. The same helper is used by the rollback path
+/// inside `install` so a partial install cannot be cleaned up through
+/// an attacker-planted symlink either.
+fn remove_dir_safely(path: &Path) -> std::io::Result<()> {
+    let meta = fs::symlink_metadata(path)?;
+    if meta.file_type().is_symlink() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("refusing to remove through symlink at {}", path.display()),
+        ));
+    }
+    if meta.is_dir() {
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            remove_dir_safely(&entry.path())?;
+        }
+        fs::remove_dir(path)
+    } else {
+        fs::remove_file(path)
+    }
+}
+
+/// Format the registry for either human or `--json` output, sorted by
+/// plugin name in both branches so scripted consumers see the same
+/// order a human reading the plain output sees. JSON serialization
+/// failure is surfaced as a `Result::Err` rather than silently collapsed
+/// to an empty string (the prior code used `unwrap_or_default()`, which
+/// would print `""` and exit 0 on the (rare) failure path, contradicting
+/// the file's own no-silent-fallback style).
+fn format_list_output(reg: &Registry, json: bool) -> Result<String, String> {
+    let mut sorted = reg.clone();
+    sorted.plugins.sort_by(|a, b| a.name.cmp(&b.name));
+    if json {
+        return serde_json::to_string(&sorted)
+            .map_err(|err| format!("failed to encode registry: {err}"));
+    }
+    if sorted.plugins.is_empty() {
+        return Ok("no plugins installed".to_string());
+    }
+    let mut out = String::new();
+    for e in &sorted.plugins {
+        let state = if e.enabled { "enabled" } else { "disabled" };
+        let verbs = e.verbs.join(",");
+        out.push_str(&format!("{} {} {} {}\n", e.name, state, e.entry, verbs));
+    }
+    Ok(out)
 }
 
 // ----- subcommands ---------------------------------------------------------
@@ -239,27 +310,20 @@ fn cmd_list(base: &Path, json: bool) -> i32 {
             return 1;
         }
     };
-    if reg.plugins.is_empty() {
-        if json {
-            let _ = println!("{}", serde_json::to_string(&reg).unwrap_or_default());
-        } else {
-            println!("no plugins installed");
+    // Both human and --json output sort by name, so a script reading
+    // JSON sees the same order a human reading the plain output sees.
+    // Serialization failure is reported and returns 1, not silently
+    // collapsed to an empty string.
+    match format_list_output(&reg, json) {
+        Ok(out) => {
+            print!("{out}");
+            0
         }
-        return 0;
+        Err(err) => {
+            eprintln!("cmux plugin list: {err}");
+            1
+        }
     }
-    // Sorted, stable, greppable output (matches the repo output style).
-    let mut entries = reg.plugins.clone();
-    entries.sort_by(|a, b| a.name.cmp(&b.name));
-    if json {
-        let _ = println!("{}", serde_json::to_string(&reg).unwrap_or_default());
-        return 0;
-    }
-    for e in &entries {
-        let state = if e.enabled { "enabled" } else { "disabled" };
-        let verbs = e.verbs.join(",");
-        println!("{} {} {} {}", e.name, state, e.entry, verbs);
-    }
-    0
 }
 
 fn cmd_install(base: &Path, positional: &[&str]) -> i32 {
@@ -300,15 +364,51 @@ fn cmd_install(base: &Path, positional: &[&str]) -> i32 {
         return 1;
     }
     let plugin_dir = plugins_dir(base).join(&plugin.name);
+    // Refuse to install through a symlink: an attacker with write
+    // access to the cmux data dir could have pre-placed a symlink at
+    // `<base>/plugins/<name>` pointing at a sensitive directory, and
+    // `create_dir_all` would silently treat it as a present directory
+    // (because the symlink target is a directory), after which the
+    // manifest write below would land inside the symlink target rather
+    // than the intended plugin slot.
+    if let Ok(meta) = fs::symlink_metadata(&plugin_dir) {
+        if meta.file_type().is_symlink() {
+            eprintln!(
+                "cmux plugin install: refusing to install through symlink at {}",
+                plugin_dir.display()
+            );
+            return 1;
+        }
+    }
     if let Err(err) = fs::create_dir_all(&plugin_dir) {
         eprintln!("cmux plugin install: failed to create {}: {err}", plugin_dir.display());
         return 1;
     }
     let dest = plugin_dir.join("cmux-plugin.toml");
+    // Defence in depth: also refuse if the manifest slot itself is a
+    // symlink planted inside a directory we just created (or a
+    // directory we adopted). `fs::write` would follow it and clobber
+    // the target. On refusal we attempt a best-effort rollback:
+    // `fs::remove_file` on a symlink removes the link itself, not the
+    // target, then `fs::remove_dir` clears the (now-empty) parent.
+    // This is the only place we deviate from `remove_dir_safely`,
+    // because that helper refuses to touch the symlink at all and would
+    // leave the half-created plugin dir behind.
+    if let Ok(meta) = fs::symlink_metadata(&dest) {
+        if meta.file_type().is_symlink() {
+            let _ = fs::remove_file(&dest);
+            let _ = fs::remove_dir(&plugin_dir);
+            eprintln!(
+                "cmux plugin install: refusing to write through symlink at {}",
+                dest.display()
+            );
+            return 1;
+        }
+    }
     if let Err(err) = fs::write(&dest, &content) {
         // Roll back the directory we just made so a failed install does
         // not leave an empty half-registered plugin on disk.
-        let _ = fs::remove_dir_all(&plugin_dir);
+        let _ = remove_dir_safely(&plugin_dir);
         eprintln!("cmux plugin install: failed to write {}: {err}", dest.display());
         return 1;
     }
@@ -319,7 +419,7 @@ fn cmd_install(base: &Path, positional: &[&str]) -> i32 {
         verbs: plugin.verbs.clone(),
     });
     if let Err(err) = save_registry(base, &reg) {
-        let _ = fs::remove_dir_all(&plugin_dir);
+        let _ = remove_dir_safely(&plugin_dir);
         eprintln!("cmux plugin install: {err}");
         return 1;
     }
@@ -351,11 +451,11 @@ fn cmd_uninstall(base: &Path, positional: &[&str]) -> i32 {
     }
     let plugin_dir = plugins_dir(base).join(name);
     if plugin_dir.exists() {
-        if let Err(err) = fs::remove_dir_all(&plugin_dir) {
-            eprintln!(
-                "cmux plugin uninstall: failed to remove {}: {err}",
-                plugin_dir.display()
-            );
+        // Use the symlink-aware walker rather than `fs::remove_dir_all`,
+        // which would happily delete through an attacker-planted symlink
+        // inside (or at the root of) the plugin directory.
+        if let Err(err) = remove_dir_safely(&plugin_dir) {
+            eprintln!("cmux plugin uninstall: {}", err);
             return 1;
         }
     }
@@ -608,5 +708,283 @@ mod tests {
         // JSON mode emits an empty registry object.
         assert_eq!(cmd_list(&base, true), 0);
         let _ = fs::remove_dir_all(&base);
+    }
+
+    /// `save_registry` must refuse to write when `<base>/plugins.json`
+    /// is already a symlink: an attacker with write access to the cmux
+    /// data dir could plant such a symlink pointing at a sensitive
+    /// file, and `fs::write` would silently follow it. We assert the
+    /// error is reported AND the symlink target's contents are
+    /// untouched.
+    #[test]
+    fn save_registry_refuses_symlink_at_plugins_json() {
+        let base = tmp_base("save_sym");
+        // Symlink target the attacker is trying to clobber.
+        let target = base.join("victim.txt");
+        fs::write(&target, "do-not-touch").unwrap();
+        // Pre-place a symlink at <base>/plugins.json -> target.
+        std::os::unix::fs::symlink(&target, registry_path(&base)).unwrap();
+        let reg = Registry::default();
+        let err = save_registry(&base, &reg).expect_err("must refuse symlink target");
+        assert!(
+            err.contains("symlink"),
+            "error should mention symlink: {err}"
+        );
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "do-not-touch",
+            "symlink target must remain untouched"
+        );
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    /// `install` must refuse when `<base>/plugins/<name>` is itself a
+    /// symlink. `create_dir_all` would otherwise treat the symlink-to-
+    /// directory as a present directory and the manifest write below
+    /// would land inside the symlink target. Assert the install fails,
+    /// the registry is not populated, and the symlink target is
+    /// untouched.
+    #[test]
+    fn install_refuses_symlink_at_plugin_dir() {
+        let base = tmp_base("install_sym_dir");
+        fs::create_dir_all(plugins_dir(&base)).unwrap();
+        // Symlink target is a sensitive-looking directory.
+        let target = base.join("sensitive");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("passwords.txt"), "do-not-touch").unwrap();
+        // Pre-place the symlink at the plugin slot.
+        let plugin_link = plugins_dir(&base).join("fleet");
+        std::os::unix::fs::symlink(&target, &plugin_link).unwrap();
+
+        // Stage a real manifest in a separate temp dir.
+        let manifest_dir = std::env::temp_dir().join(format!(
+            "cmux-plugin-test-manifest-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&manifest_dir).unwrap();
+        let manifest_file = manifest_dir.join("cmux-plugin.toml");
+        fs::write(
+            &manifest_file,
+            manifest("fleet", "bin/fleet.wasm", &["deploy"]),
+        )
+        .unwrap();
+        let path_str = manifest_file.to_str().unwrap();
+
+        assert_eq!(cmd_install(&base, &[path_str]), 1);
+        assert_eq!(
+            load_registry(&base).unwrap().plugins.len(),
+            0,
+            "registry must not be populated when install is refused"
+        );
+        assert_eq!(
+            fs::read_to_string(target.join("passwords.txt")).unwrap(),
+            "do-not-touch",
+            "symlink target contents must remain untouched"
+        );
+
+        let _ = fs::remove_dir_all(&base);
+        let _ = fs::remove_dir_all(&manifest_dir);
+    }
+
+    /// `install` must also refuse when the manifest slot
+    /// `<base>/plugins/<name>/cmux-plugin.toml` is itself a symlink,
+    /// even if the parent directory is regular. Defence in depth: an
+    /// attacker who could replace just the manifest file inside an
+    /// otherwise-normal plugin directory must not be able to redirect
+    /// the write into a sensitive file.
+    #[test]
+    fn install_refuses_symlink_at_manifest_dest() {
+        let base = tmp_base("install_sym_dest");
+        fs::create_dir_all(plugins_dir(&base)).unwrap();
+        let plugin_dir = plugins_dir(&base).join("fleet");
+        fs::create_dir_all(&plugin_dir).unwrap();
+        // Pre-place a symlink at the manifest slot.
+        let target = base.join("victim.txt");
+        fs::write(&target, "do-not-touch").unwrap();
+        std::os::unix::fs::symlink(&target, plugin_dir.join("cmux-plugin.toml")).unwrap();
+
+        let manifest_dir = std::env::temp_dir().join(format!(
+            "cmux-plugin-test-manifest-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&manifest_dir).unwrap();
+        let manifest_file = manifest_dir.join("cmux-plugin.toml");
+        fs::write(
+            &manifest_file,
+            manifest("fleet", "bin/fleet.wasm", &["deploy"]),
+        )
+        .unwrap();
+        let path_str = manifest_file.to_str().unwrap();
+
+        assert_eq!(cmd_install(&base, &[path_str]), 1);
+        assert_eq!(
+            load_registry(&base).unwrap().plugins.len(),
+            0,
+            "registry must not be populated when install is refused"
+        );
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "do-not-touch",
+            "symlink target contents must remain untouched"
+        );
+        // The plugin dir we just created (above the symlink) should be
+        // rolled back by the symlink check path so we do not leave a
+        // dangling empty directory behind.
+        assert!(
+            !plugin_dir.exists(),
+            "plugin dir should be cleaned up after a refused install, found {}",
+            plugin_dir.display()
+        );
+
+        let _ = fs::remove_dir_all(&base);
+        let _ = fs::remove_dir_all(&manifest_dir);
+    }
+
+    /// `uninstall` must refuse when the plugin directory itself is a
+    /// symlink. `fs::remove_dir_all` would otherwise walk through the
+    /// symlink and delete the target's contents, which is exactly the
+    /// damage the warning is about. Assert the symlink target survives
+    /// AND the registry is left untouched (the round-1 ordering is
+    /// "remove dir, then rewrite registry", so on refusal we never
+    /// reach the registry write). That keeps the on-disk state
+    /// consistent: if the user fixes the symlink and retries, the
+    /// plugin still shows in `list`.
+    #[test]
+    fn uninstall_refuses_symlink_at_plugin_dir() {
+        let base = tmp_base("uninstall_sym_dir");
+        // Symlink target is a sensitive directory.
+        let target = base.join("sensitive");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(target.join("do-not-delete.txt"), "do-not-touch").unwrap();
+        // Pre-place a symlink at the plugin slot. Parent dir must exist
+        // for the symlink(2) call to succeed.
+        fs::create_dir_all(plugins_dir(&base)).unwrap();
+        let plugin_dir = plugins_dir(&base).join("fleet");
+        std::os::unix::fs::symlink(&target, &plugin_dir).unwrap();
+        // Seed the registry so the plugin is "installed" from cmux's POV.
+        let mut reg = Registry::default();
+        reg.plugins.push(PluginEntry {
+            name: "fleet".to_string(),
+            enabled: true,
+            entry: "bin/fleet.wasm".to_string(),
+            verbs: vec!["deploy".to_string()],
+        });
+        save_registry(&base, &reg).unwrap();
+
+        assert_eq!(cmd_uninstall(&base, &["fleet"]), 1);
+        assert!(
+            target.join("do-not-delete.txt").exists(),
+            "symlink target contents must remain untouched"
+        );
+        let reg_after = load_registry(&base).unwrap();
+        assert_eq!(
+            reg_after.plugins.len(),
+            1,
+            "registry must not be rewritten when dir removal is refused"
+        );
+        assert_eq!(reg_after.plugins[0].name, "fleet");
+
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    /// `uninstall` must also refuse when a symlink exists anywhere
+    /// inside the plugin directory tree. `fs::remove_dir_all` would
+    /// happily walk through such a symlink and delete the target.
+    /// Assert the registry is rolled back to its pre-removal state
+    /// (the round-1 code writes the registry after the dir removal, so
+    /// on refusal the registry still shows the plugin) and the
+    /// symlink target survives.
+    #[test]
+    fn uninstall_refuses_symlink_inside_plugin_dir() {
+        let base = tmp_base("uninstall_sym_inside");
+        let plugin_dir = plugins_dir(&base).join("fleet");
+        fs::create_dir_all(&plugin_dir).unwrap();
+        fs::write(
+            plugin_dir.join("cmux-plugin.toml"),
+            manifest("fleet", "bin/fleet.wasm", &["deploy"]),
+        )
+        .unwrap();
+        // Plant a symlink inside the plugin dir at a sensitive target.
+        let target = base.join("victim.txt");
+        fs::write(&target, "do-not-touch").unwrap();
+        std::os::unix::fs::symlink(&target, plugin_dir.join("evil-link")).unwrap();
+
+        // Seed the registry so the plugin is "installed" from cmux's POV.
+        let mut reg = Registry::default();
+        reg.plugins.push(PluginEntry {
+            name: "fleet".to_string(),
+            enabled: true,
+            entry: "bin/fleet.wasm".to_string(),
+            verbs: vec!["deploy".to_string()],
+        });
+        save_registry(&base, &reg).unwrap();
+
+        assert_eq!(cmd_uninstall(&base, &["fleet"]), 1);
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "do-not-touch",
+            "symlink target contents must remain untouched"
+        );
+        // The registry should still show the plugin because the round-1
+        // ordering writes the updated registry AFTER the dir removal.
+        let reg_after = load_registry(&base).unwrap();
+        assert_eq!(
+            reg_after.plugins.len(),
+            1,
+            "registry should not be rewritten when dir removal is refused"
+        );
+        assert_eq!(reg_after.plugins[0].name, "fleet");
+
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    /// The `--json` output of `cmd_list` (via `format_list_output`) must
+    /// sort plugin entries by name so a script reading JSON sees the
+    /// same order a human reading the plain output sees. The
+    /// round-1 code sorted only the plain branch.
+    #[test]
+    fn list_json_output_is_sorted_by_name() {
+        // Insert in non-alphabetical order so a sort bug is observable.
+        let mut reg = Registry::default();
+        reg.plugins.push(PluginEntry {
+            name: "gamma".to_string(),
+            enabled: true,
+            entry: "x".to_string(),
+            verbs: vec!["a".to_string()],
+        });
+        reg.plugins.push(PluginEntry {
+            name: "alpha".to_string(),
+            enabled: true,
+            entry: "x".to_string(),
+            verbs: vec!["a".to_string()],
+        });
+        reg.plugins.push(PluginEntry {
+            name: "beta".to_string(),
+            enabled: true,
+            entry: "x".to_string(),
+            verbs: vec!["a".to_string()],
+        });
+        let json = format_list_output(&reg, true).expect("serialise sorted JSON");
+        let a = json.find("\"alpha\"").expect("alpha must be present");
+        let b = json.find("\"beta\"").expect("beta must be present");
+        let c = json.find("\"gamma\"").expect("gamma must be present");
+        assert!(
+            a < b && b < c,
+            "JSON output must sort by name; got: {json}"
+        );
+
+        // Plain output must use the same order.
+        let plain = format_list_output(&reg, false).expect("format plain");
+        let lines: Vec<&str> = plain.lines().collect();
+        assert_eq!(lines.len(), 3);
+        assert!(lines[0].starts_with("alpha "), "plain line 0: {}", lines[0]);
+        assert!(lines[1].starts_with("beta "), "plain line 1: {}", lines[1]);
+        assert!(lines[2].starts_with("gamma "), "plain line 2: {}", lines[2]);
     }
 }

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -1229,3 +1229,74 @@ fn get_resolved_config_cli_verb_returns_server_chrome() {
         "server theme colour missing from get-resolved-config output: {chrome}"
     );
 }
+
+/// Issue #42 (scoped first PR): the `cmux plugin` verb group manages
+/// `cmux-plugin.toml` manifests on disk only (no execution yet). We
+/// install a fixture manifest against a HeadlessServer-style temp env
+/// (an isolated XDG_DATA_HOME under the server's temp dir), then list
+/// it, then uninstall and confirm `list` reports empty. The server
+/// itself is idle for these verbs: the spec scopes this PR to manifest
+/// state only, no socket traffic.
+#[test]
+fn plugin_install_list_uninstall_round_trip() {
+    let server = HeadlessServer::start("plugin");
+    let data_home = server.dir.join("xdg-data");
+    fs::create_dir_all(&data_home).unwrap();
+    let manifest_dir = server.dir.join("manifest");
+    fs::create_dir_all(&manifest_dir).unwrap();
+    let manifest_path = manifest_dir.join("cmux-plugin.toml");
+    fs::write(
+        &manifest_path,
+        "[plugin]\nname = \"pifactory-fleet\"\nentry = \"bin/fleet.wasm\"\nverbs = [\"deploy\", \"rollback\"]\n",
+    )
+    .unwrap();
+
+    let run = |args: &[&str]| {
+        Command::new(bin())
+            .args(args)
+            .env("XDG_DATA_HOME", &data_home)
+            .env_remove("CMUX_MUX_SOCKET")
+            .output()
+            .unwrap()
+    };
+
+    let manifest_str = manifest_path.to_str().unwrap().to_string();
+    let install = run(&["plugin", "install", &manifest_str]);
+    assert_success(&install);
+    let install_out = String::from_utf8_lossy(&install.stdout);
+    assert!(
+        install_out.contains("pifactory-fleet"),
+        "install should report the plugin name: {install_out}"
+    );
+
+    let list = run(&["plugin", "list"]);
+    assert_success(&list);
+    let list_out = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        list_out.contains("pifactory-fleet"),
+        "list should name the installed plugin: {list_out}"
+    );
+    assert!(
+        list_out.contains("enabled"),
+        "list should show the enabled state: {list_out}"
+    );
+    assert!(
+        list_out.contains("deploy,rollback"),
+        "list should show the claimed verbs: {list_out}"
+    );
+
+    let uninstall = run(&["plugin", "uninstall", "pifactory-fleet"]);
+    assert_success(&uninstall);
+    assert!(
+        String::from_utf8_lossy(&uninstall.stdout).contains("pifactory-fleet"),
+        "uninstall should echo the removed plugin name"
+    );
+
+    let list2 = run(&["plugin", "list"]);
+    assert_success(&list2);
+    let list2_out = String::from_utf8_lossy(&list2.stdout);
+    assert!(
+        list2_out.contains("no plugins installed"),
+        "after uninstall list should report empty: {list2_out}"
+    );
+}

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -93,6 +93,40 @@ The generated CLI requires one of `--index` or `--delta` for `select-tab`, `sele
 | `list-agents` | proposed | none | `--surface <id>`, `--state <state>` | agent lines |
 | `report-agent` | proposed | `--surface <id> --state <state> --source socket|hook` | `--session <id>` | none |
 
+## Plugin Verb Group
+
+`cmux plugin` is a local verb group (no control-socket traffic). It manages
+`cmux-plugin.toml` manifests and a small JSON registry under the cmux data
+directory (`$XDG_DATA_HOME/cmux`, or `~/.local/share/cmux` by default).
+
+NOT IMPLEMENTED by this group (deferred to a follow-up PR): plugin
+*execution* (proxying `cmux <plugin-name> <verb>` calls to a running
+plugin process, WASM/WASI sandboxing, the permission model). The verbs
+below only manage manifest state. Do not read them as implying execution.
+
+Manifest file `cmux-plugin.toml`:
+
+```toml
+[plugin]
+name = "pifactory-fleet"        # required, non-empty, single path component
+entry = "bin/fleet.wasm"         # required, non-empty; stored verbatim,
+                                 # not resolved or validated as executable
+verbs = ["deploy", "rollback"]   # required, non-empty; stored verbatim,
+                                 # not proxied to anything yet
+```
+
+| Subcommand | Required args | Optional flags | Human stdout |
+| --- | --- | --- | --- |
+| `cmux plugin list` | none | `--json`, global flags | one line per plugin (`<name> <enabled|disabled> <entry> <verb,verb>`), or `no plugins installed` when empty |
+| `cmux plugin install <manifest-path>` | `<manifest-path>` | none | `installed plugin <name> from <path>` |
+| `cmux plugin uninstall <name>` | `<name>` | none | `uninstalled plugin <name>` |
+| `cmux plugin enable <name>` | `<name>` | none | `plugin <name> enabled` (or `... already enabled`) |
+| `cmux plugin disable <name>` | `<name>` | none | `plugin <name> disabled` (or `... already disabled`) |
+
+Exit codes follow the global convention: `0` success, `1` command error
+(missing/malformed manifest, name collision, unknown plugin), `2` usage
+error (missing/extra positional argument, unknown subcommand).
+
 ## Worked Examples
 
 1. Identify a session:

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -1748,6 +1748,64 @@ Example:
 {"id":32,"ok":true,"data":{"theme":{"sidebar_rail":"#778899",...},"tabs":{...},"sidebar":{...},"keys":{...}}}
 ```
 
+## Local Verb Groups (no wire protocol)
+
+These verb groups run entirely in the `cmux` client binary; they do not
+send JSON commands over the control socket and have no entry in the
+protocol command set. They are documented here so the surface has one
+home for every `cmux <verb> ...` invocation.
+
+### plugin
+
+| Field | Value |
+| --- | --- |
+| name | `plugin` (verb group: `cmux plugin <subcommand>`) |
+| status | implemented (manifest + registry only) |
+| since | local client surface, issue #42 scoped first PR |
+
+Manages `cmux-plugin.toml` manifests and a small JSON registry under the
+cmux data directory (`$XDG_DATA_HOME/cmux`, or `~/.local/share/cmux`
+by default). Layout:
+
+```text
+<base>/plugins.json          registry: {"plugins":[{name,enabled,entry,verbs}, ...]}
+<base>/plugins/<name>/         one directory per installed plugin
+                cmux-plugin.toml   manifest copied verbatim at install time
+```
+
+Manifest (`cmux-plugin.toml`):
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `[plugin] name` | string | yes | non-empty, single path component (used as the on-disk dir name) |
+| `[plugin] entry` | string | yes | non-empty; path to the plugin entry artefact, stored verbatim, not resolved or validated as executable in this PR |
+| `[plugin] verbs` | array of strings | yes | non-empty, each entry non-empty; the verbs this plugin claims, stored verbatim, not proxied in this PR |
+
+CLI mappings:
+
+| Subcommand | Required args | Optional flags | Plain stdout | JSON stdout |
+| --- | --- | --- | --- | --- |
+| `plugin list` | none | `--json` | one line per plugin `<name> <enabled|disabled> <entry> <verb,verb>`; `no plugins installed` when empty | the registry object `{"plugins":[...]}` |
+| `plugin install <manifest-path>` | `<manifest-path>` | none | `installed plugin <name> from <path>` | n/a (exit code only) |
+| `plugin uninstall <name>` | `<name>` | none | `uninstalled plugin <name>` | n/a (exit code only) |
+| `plugin enable <name>` | `<name>` | none | `plugin <name> enabled` (or `already enabled`) | n/a (exit code only) |
+| `plugin disable <name>` | `<name>` | none | `plugin <name> disabled` (or `already disabled`) | n/a (exit code only) |
+
+Errors:
+
+| Error | Condition |
+| --- | --- |
+| `malformed cmux-plugin.toml: ...` | manifest is not valid TOML or a required field is missing/empty |
+| `a plugin named "..." is already installed` | `install` against a name already in the registry (AC5 collision) |
+| `no plugin named "..." is installed` | `uninstall`/`enable`/`disable` against an unknown name |
+| `plugin name "..." must not be a path` | `install` where `name` contains a separator or is `.`/`..` |
+
+NOT IMPLEMENTED (deferred to a follow-up PR): plugin *execution*
+(proxying `cmux <plugin-name> <verb>` to a running plugin process,
+WASM/WASI sandboxing, the permission model) is out of scope for this
+PR. These verbs only manage manifest state and must not be read as
+implying that any plugin code runs.
+
 ## Proposed Commands
 
 ### wait-for


### PR DESCRIPTION
## Summary
First PR toward issue #42's `cmux plugin` loader, deliberately scoped down per the issue's own effort note ("Large. Real WASM runtime + manifest spec + plugin loader = ~2-3 PRs minimum"). This PR covers the manifest format and local registry management only — **no plugin execution** (no process spawning, no WASM/WASI runtime, no proxy dispatch). That's out of scope here and left for a follow-up PR/issue; it's a separate security-relevant architectural decision (running third-party code) that deserves its own review, not something to bundle into an overnight scope-down.

- `cmux-plugin.toml` manifest parser (`name`, `entry`, `verbs`).
- `cmux plugin install|uninstall|enable|disable|list` — local-only verbs that manage `~/.local/share/cmux/plugins/<name>/` and a `plugins.json` registry. `entry` is stored as an opaque string; nothing resolves or executes it.
- Symlink-safe writes/removes (round 2 — round 1 followed symlinks on `save_registry`/manifest-copy/`uninstall`'s `remove_dir_all`, a real risk given plugin manifests are inherently a third-party-trust-boundary feature even before execution lands; caught by independent review citing this repo's own `AGENTS.md` security checklist).
- `spec/cli.md` / `spec/commands.md` document the verbs with an explicit "execution is deferred to a follow-up PR" note so the docs don't imply more than what's built.

## Test plan
- [x] `cargo check -p mux-tui --locked` — clean, `Cargo.lock` stayed lockfile v3
- [x] `cargo test -p mux-tui` — 126 unit + 17 integration tests, 0 failed (independently re-run)
- [x] Independent review pass: `lgtm`, 1 nit (unnecessary disk write on a no-op enable/disable — non-blocking, left as a fast-follow)
- [x] Independent verify pass: 6/6 acceptance-criteria claims PASS, including the 3 new symlink-refusal tests

Does not close #42 — the execution mechanism (proxy dispatch, WASM/WASI sandboxing, the `pifactory-fleet` example plugin) is still open work.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the Pi Factory fleet