### PR TITLE
feat(agents): umbrella cmux agents install --all

### DIFF
--- a/mux/crates/mux-tui/src/agents.rs
+++ b/mux/crates/mux-tui/src/agents.rs
@@ -1,0 +1,245 @@
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+const HOOK_VERSION: &str = "v0.2.0";
+
+type Runner = fn(&[String]) -> i32;
+type PathResolver = fn(bool) -> Option<PathBuf>;
+
+struct AgentSpec {
+    name: &'static str,
+    runner: Runner,
+    path: PathResolver,
+}
+
+const REGISTRY: &[AgentSpec] = &[
+    AgentSpec { name: "claude", runner: crate::claude_hook::run, path: claude_path },
+    AgentSpec { name: "antigravity", runner: crate::antigravity_hook::run, path: antigravity_path },
+    AgentSpec { name: "codex", runner: crate::codex_hook::run, path: codex_path },
+    AgentSpec { name: "aider", runner: crate::aider_hook::run, path: aider_path },
+    AgentSpec { name: "pi", runner: crate::pi_hook::run, path: pi_path },
+    AgentSpec { name: "grok", runner: crate::grok_hook::run, path: grok_path },
+];
+
+pub fn run(args: &[String]) -> i32 {
+    match args.first().map(String::as_str) {
+        Some("list") => run_list(args),
+        Some("install") => run_install_command(REGISTRY, args),
+        _ => {
+            eprintln!("cmux: usage: cmux agents <list|install --all|install --only <agent>> [--uninstall] [--global]");
+            2
+        }
+    }
+}
+
+fn run_install_command(registry: &[AgentSpec], args: &[String]) -> i32 {
+    let mut only = None;
+    let mut all = false;
+    let mut global = false;
+    let mut uninstall = false;
+    let mut index = 1;
+    while let Some(arg) = args.get(index) {
+        match arg.as_str() {
+            "--all" => all = true,
+            "--global" => global = true,
+            "--uninstall" => uninstall = true,
+            "--only" => {
+                index += 1;
+                only = args.get(index).map(String::as_str);
+                if only.is_none() {
+                    eprintln!("cmux: --only needs an agent name");
+                    return 2;
+                }
+            }
+            other => {
+                eprintln!("cmux: unknown agents install argument {other:?}");
+                return 2;
+            }
+        }
+        index += 1;
+    }
+    if all == only.is_some() {
+        eprintln!("cmux: agents install requires exactly one of --all or --only <agent>");
+        return 2;
+    }
+    if let Some(name) = only {
+        if !is_registered(registry, name) {
+            eprintln!("cmux: unknown agent {name:?}");
+            return 2;
+        }
+    }
+    if install_selected(registry, only, global, uninstall) {
+        0
+    } else {
+        1
+    }
+}
+
+fn install_selected(
+    registry: &[AgentSpec],
+    only: Option<&str>,
+    global: bool,
+    uninstall: bool,
+) -> bool {
+    let mut success = true;
+    for agent in registry.iter().filter(|agent| only.map_or(true, |name| name == agent.name)) {
+        let mut args = vec!["install-hooks".to_string()];
+        if uninstall {
+            args.push("--uninstall".to_string());
+        }
+        if global {
+            args.push("--global".to_string());
+        }
+        let code = (agent.runner)(&args);
+        if code == 0 {
+            println!("agents: {}: {}", agent.name, if uninstall { "removed" } else { "installed" });
+        } else {
+            eprintln!("agents: {}: failed (exit code {code})", agent.name);
+            success = false;
+        }
+    }
+    success
+}
+
+fn is_registered(registry: &[AgentSpec], name: &str) -> bool {
+    registry.iter().any(|agent| agent.name == name)
+}
+
+fn run_list(args: &[String]) -> i32 {
+    let mut global = false;
+    for arg in args.iter().skip(1) {
+        if arg == "--global" {
+            global = true;
+        } else {
+            eprintln!("cmux: unknown agents list argument {arg:?}");
+            return 2;
+        }
+    }
+    println!("agent\tstatus\tversion\tlast-installed\tinstall-path");
+    for agent in REGISTRY {
+        let path = (agent.path)(global);
+        let installed = path.as_deref().is_some_and(Path::exists);
+        let timestamp = path
+            .as_deref()
+            .and_then(|p| p.metadata().ok())
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs().to_string())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{}\t{}\t{}\t{}\t{}",
+            agent.name,
+            if installed { "installed" } else { "not-installed" },
+            if installed { HOOK_VERSION } else { "-" },
+            if installed { timestamp } else { "-".to_string() },
+            path.map_or_else(|| "-".to_string(), |p| p.display().to_string())
+        );
+    }
+    0
+}
+
+fn home_join(parts: &[&str]) -> Option<PathBuf> {
+    let mut path = mux_core::platform::home_dir()?;
+    for part in parts {
+        path.push(part);
+    }
+    Some(path)
+}
+
+fn claude_path(_: bool) -> Option<PathBuf> {
+    home_join(&[".claude", "settings.json"])
+}
+fn antigravity_path(global: bool) -> Option<PathBuf> {
+    if global {
+        home_join(&[".gemini", "config", "hooks.json"])
+    } else {
+        Some(PathBuf::from(".agents/hooks.json"))
+    }
+}
+fn codex_path(global: bool) -> Option<PathBuf> {
+    if global {
+        home_join(&[".codex", "hooks.json"])
+    } else {
+        Some(PathBuf::from(".codex/hooks.json"))
+    }
+}
+fn aider_path(global: bool) -> Option<PathBuf> {
+    if global {
+        home_join(&[".local", "bin", "aider"])
+    } else {
+        Some(PathBuf::from(".bin/aider"))
+    }
+}
+fn pi_path(global: bool) -> Option<PathBuf> {
+    if global {
+        home_join(&[".pi", "agent", "extensions", "cmux.ts"])
+    } else {
+        Some(PathBuf::from(".pi/extensions/cmux.ts"))
+    }
+}
+fn grok_path(global: bool) -> Option<PathBuf> {
+    if global {
+        home_join(&[".grok", "hooks.json"])
+    } else {
+        Some(PathBuf::from(".grok/hooks.json"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    static ATTEMPTS: AtomicUsize = AtomicUsize::new(0);
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn succeeds(_: &[String]) -> i32 {
+        ATTEMPTS.fetch_add(1, Ordering::SeqCst);
+        0
+    }
+    fn fails(_: &[String]) -> i32 {
+        ATTEMPTS.fetch_add(1, Ordering::SeqCst);
+        1
+    }
+    fn records_args(args: &[String]) -> i32 {
+        ATTEMPTS.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(args, &["install-hooks", "--uninstall", "--global"]);
+        0
+    }
+    fn test_path(_: bool) -> Option<PathBuf> {
+        None
+    }
+
+    #[test]
+    fn install_all_continues_after_an_agent_failure() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        ATTEMPTS.store(0, Ordering::SeqCst);
+        let registry = [
+            AgentSpec { name: "one", runner: succeeds, path: test_path },
+            AgentSpec { name: "two", runner: fails, path: test_path },
+            AgentSpec { name: "three", runner: succeeds, path: test_path },
+        ];
+        let args = vec!["install".to_string(), "--all".to_string()];
+        assert_eq!(run_install_command(&registry, &args), 1);
+        assert_eq!(ATTEMPTS.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn only_selects_one_registered_agent() {
+        let _lock = TEST_LOCK.lock().unwrap();
+        ATTEMPTS.store(0, Ordering::SeqCst);
+        let registry = [
+            AgentSpec { name: "one", runner: succeeds, path: test_path },
+            AgentSpec { name: "two", runner: records_args, path: test_path },
+        ];
+        assert!(install_selected(&registry, Some("two"), true, true));
+        assert_eq!(ATTEMPTS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn unknown_only_agent_is_rejected() {
+        let registry = [AgentSpec { name: "one", runner: succeeds, path: test_path }];
+        assert!(!is_registered(&registry, "missing"));
+    }
+}

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -6,6 +6,7 @@
 //! `cmux attach` connects the same TUI to an existing (usually
 //! headless) session over that socket, which is how detach/reattach works.
 
+mod agents;
 mod aider_hook;
 mod antigravity_hook;
 mod app;
@@ -69,6 +70,7 @@ USAGE:
   cmux pi install-hooks           Pi agent extension integration (see below)
   cmux aider install-hooks        Aider wrapper integration (see below)
   cmux grok install-hooks         Grok CLI hook integration (see below)
+  cmux agents <list|install>     Manage all agent hook integrations (see below)
   cmux plugin <subcommand> Manage cmux-plugin.toml manifests (see below)
   cmux ssh <host> [OPTS]   Open a remote workspace over SSH (see below)
 
@@ -172,6 +174,14 @@ GROK CLI INTEGRATION
   cmux grok install-skill [--uninstall] [--global]
       Installs the orchestration skill to .agents/skills/cmux-orchestration/SKILL.md
       (or ~/.grok/skills/cmux-orchestration/SKILL.md if --global).
+
+AGENT HOOK INTEGRATION
+  cmux agents list [--global]
+      Lists installed status, version, timestamp, and path for all six agents.
+  cmux agents install --all [--uninstall] [--global]
+      Installs or removes every registered agent hook, continuing after failures.
+  cmux agents install --only <agent> [--uninstall] [--global]
+      Installs or removes one registered agent hook.
 
 PLUGIN LOADER (manifest + registry only; no execution yet)
   cmux plugin list                       List installed plugins (read-only)
@@ -291,6 +301,9 @@ fn main() {
                 std::process::exit(2);
             }
         }
+    }
+    if raw_args.first().map(|arg| arg.as_str()) == Some("agents") {
+        std::process::exit(agents::run(&raw_args[1..]));
     }
     if raw_args.first().map(|arg| arg.as_str()) == Some("plugin") {
         std::process::exit(plugin::run(&raw_args[1..]));

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -8,6 +8,41 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use mux_core::platform::transport;
 
+#[test]
+fn agents_list_reports_only_claude_as_installed_after_claude_install() {
+    let project = unique_temp_dir("agents-list-project");
+    let home = unique_temp_dir("agents-list-home");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&home).unwrap();
+
+    let install = Command::new(bin())
+        .args(["claude", "install-hooks"])
+        .current_dir(&project)
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+    assert_success(&install);
+
+    let listed = Command::new(bin())
+        .args(["agents", "list"])
+        .current_dir(&project)
+        .env("HOME", &home)
+        .output()
+        .unwrap();
+    assert_success(&listed);
+    let output = String::from_utf8(listed.stdout).unwrap();
+    let rows = output.lines().skip(1).collect::<Vec<_>>();
+    assert_eq!(rows.len(), 6);
+    assert!(rows.iter().any(|row| row.starts_with("claude\tinstalled\tv0.2.0\t")));
+    for agent in ["antigravity", "codex", "aider", "pi", "grok"] {
+        let row = rows.iter().find(|row| row.starts_with(&format!("{agent}\t"))).unwrap();
+        assert!(row.contains("\tnot-installed\t-\t-\t"), "unexpected row: {row}");
+    }
+
+    fs::remove_dir_all(project).unwrap();
+    fs::remove_dir_all(home).unwrap();
+}
+
 struct HeadlessServer {
     child: Child,
     socket: PathBuf,
@@ -255,7 +290,7 @@ fn set_workspace_color_sets_and_clears() {
     // (2026-07-10, issue #16).
     let created = cli(&server, &["new-workspace", "--name", "color-test"]);
     assert_success(&created);
-    let created_id: u64 = String::from_utf8(created.stdout)
+    let _created_id: u64 = String::from_utf8(created.stdout)
         .unwrap()
         .trim()
         .parse()

--- a/mux/spec/cli.md
+++ b/mux/spec/cli.md
@@ -127,6 +127,23 @@ Exit codes follow the global convention: `0` success, `1` command error
 (missing/malformed manifest, name collision, unknown plugin), `2` usage
 error (missing/extra positional argument, unknown subcommand).
 
+## Agents Verb Group
+
+`cmux agents` is a local verb group (no control-socket traffic). It manages
+hooks for the six registered agents: `claude`, `antigravity`, `codex`,
+`aider`, `pi`, and `grok`.
+
+| Subcommand | Required args | Optional flags | Human stdout |
+| --- | --- | --- | --- |
+| `cmux agents list` | none | `--global` | header plus one tab-separated row per agent: name, status, version, last-installed epoch seconds, install path |
+| `cmux agents install --all` | `--all` | `--uninstall`, `--global` | one result per agent; all agents are attempted even after a failure |
+| `cmux agents install --only <agent>` | `--only <agent>` | `--uninstall`, `--global` | one result for the selected agent |
+
+`--global` is forwarded to each agent installer. `--uninstall` removes the
+managed hook instead of installing it. Install returns exit code `1` when any
+agent fails after all selected agents have been attempted. Unknown agents and
+invalid flag combinations return exit code `2`.
+
 ## Worked Examples
 
 1. Identify a session:

--- a/mux/spec/commands.md
+++ b/mux/spec/commands.md
@@ -1806,6 +1806,34 @@ WASM/WASI sandboxing, the permission model) is out of scope for this
 PR. These verbs only manage manifest state and must not be read as
 implying that any plugin code runs.
 
+### agents
+
+| Field | Value |
+| --- | --- |
+| name | `agents` (verb group: `cmux agents <subcommand>`) |
+| status | implemented |
+| transport | local filesystem only; no control-socket request |
+
+The registry contains `claude`, `antigravity`, `codex`, `aider`, `pi`, and
+`grok`. Hook install paths are resolved from the current project for local
+installs and from the user's home directory for `--global` installs.
+
+CLI mappings:
+
+| Subcommand | Required args | Optional flags | Plain stdout |
+| --- | --- | --- | --- |
+| `agents list` | none | `--global` | `agent<TAB>status<TAB>version<TAB>last-installed<TAB>install-path`, followed by one row per registered agent |
+| `agents install --all` | `--all` | `--uninstall`, `--global` | one per-agent result; processing continues after failures |
+| `agents install --only <agent>` | `--only <agent>` | `--uninstall`, `--global` | one result for the selected agent |
+
+A listed agent is `installed` when its registered install path exists. The
+version is the managed hook version and `last-installed` is the install path's
+modification time in Unix epoch seconds. Missing values are printed as `-`.
+`--uninstall` is passed to each selected installer. If an installer returns a
+non-zero code, its failure is printed and the remaining selected installers
+still run; the umbrella command then returns exit code `1`. Invalid command
+shapes and unknown agent names return exit code `2`.
+
 ## Proposed Commands
 
 ### wait-for


### PR DESCRIPTION
## Summary
Adds an umbrella `cmux agents` verb group so onboarding a machine or updating hooks is one command instead of six.

- `cmux agents install --all` iterates all 6 supported agent hooks (claude, antigravity, codex, aider, pi, grok).
- `cmux agents install --only <agent>` for selective install.
- `cmux agents install --all --uninstall` as the inverse.
- `--global` passes through to each agent's installer, matching the existing per-agent pattern.
- `cmux agents list` prints per-agent install status (version, last-installed timestamp, path) read from disk, without needing a live session socket.
- If one agent's install fails, the rest still get processed and the umbrella exits non-zero rather than failing fast on the first error.

## Test plan
- [x] `cargo check -p mux-tui --locked` — clean, `Cargo.lock` stayed lockfile v3
- [x] `cargo test -p mux-tui` — 129 unit + 18 integration tests, 0 failed (independently re-run)
- [x] Independent review pass: 2 minor suggestions (both style, no critical/warning) — `--global` accepted on `list` beyond the literal spec text, and the list timestamp is raw Unix epoch rather than a formatted string. Neither blocks correctness; left as fast-follow.
- [x] Independent verify pass: 9/9 acceptance-criteria claims PASS with concrete test evidence

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the Pi Factory fleet