### PR TITLE
feat(help): richer floating help overlay (leader ?)

### DIFF
--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -428,6 +428,8 @@ pub struct App {
     /// Fuzzy finder overlay (`leader G`). Open mutably borrows the tree
     /// to build its item list, so it holds no `Session` of its own.
     pub finder: Option<crate::finder::FinderState>,
+    /// Key binding help overlay (`leader ?`), generated from the live keys.
+    pub help: Option<crate::help::HelpState>,
     pub toast: Option<Toast>,
     pub(crate) shake_frames: u8,
     /// Workspaces with an active manual flash pulse, keyed by when it
@@ -710,6 +712,7 @@ pub fn run(session: Session, session_label: String, overlay: Option<crate::confi
         prompt: None,
         omnibar: None,
         finder: None,
+        help: None,
         toast: None,
         shake_frames: 0,
         flashing: HashMap::new(),
@@ -1032,6 +1035,11 @@ impl App {
                 if let Some(prompt) = self.prompt.as_mut() {
                     prompt.input.insert_str(&text);
                     Ok(RenderAction::Draw)
+                } else if let Some(help) = self.help.as_mut() {
+                    help.input.insert_str(&text);
+                    help.cursor = 0;
+                    help.scroll = 0;
+                    Ok(RenderAction::Draw)
                 } else if let Some(finder) = self.finder.as_mut() {
                     finder.input.insert_str(&text);
                     Ok(RenderAction::Draw)
@@ -1188,6 +1196,9 @@ impl App {
         self.status_message = None;
         if self.prompt.is_some() {
             return self.handle_prompt_key(key);
+        }
+        if self.help.is_some() {
+            return self.handle_help_key(key);
         }
         if self.finder.is_some() {
             return self.handle_finder_key(key);
@@ -1464,6 +1475,10 @@ impl App {
                 self.open_finder();
                 return Ok(RenderAction::Draw);
             }
+            Action::ShowHelp => {
+                self.open_help();
+                return Ok(RenderAction::Draw);
+            }
         }
         self.status_message = None;
         Ok(RenderAction::Draw)
@@ -1478,6 +1493,73 @@ impl App {
     fn open_finder(&mut self) {
         let items = crate::finder::build_items(&self.tree);
         self.finder = Some(crate::finder::FinderState::new(items));
+    }
+
+    /// Open the help overlay from the current resolved bindings.
+    fn open_help(&mut self) {
+        let entries = crate::help::build_entries(&self.config.keys);
+        self.help = Some(crate::help::HelpState::new(entries));
+    }
+
+    /// Handle keys captured by the help overlay. Typeable input is fed to the
+    /// filter after `/`; navigation keys never reach the active pane.
+    fn handle_help_key(&mut self, key: KeyEvent) -> anyhow::Result<RenderAction> {
+        if key.code == KeyCode::Esc
+            || (key.code == KeyCode::Char('q') && key.modifiers == KeyModifiers::NONE)
+        {
+            self.help = None;
+            return Ok(RenderAction::Draw);
+        }
+        let rows = crate::help::HelpState::rows_visible(self.screen).max(1);
+        let Some(help) = self.help.as_mut() else { return Ok(RenderAction::None) };
+        match key.code {
+            KeyCode::Char('/') if key.modifiers == KeyModifiers::NONE => {
+                help.set_query(String::new());
+            }
+            KeyCode::Char('j') if key.modifiers == KeyModifiers::NONE => {
+                help.move_cursor(1, rows);
+            }
+            KeyCode::Char('k') if key.modifiers == KeyModifiers::NONE => {
+                help.move_cursor(-1, rows);
+            }
+            KeyCode::Down if key.modifiers == KeyModifiers::NONE => {
+                help.move_cursor(1, rows);
+            }
+            KeyCode::Up if key.modifiers == KeyModifiers::NONE => {
+                help.move_cursor(-1, rows);
+            }
+            KeyCode::PageDown if key.modifiers == KeyModifiers::NONE => {
+                help.move_cursor(rows as isize, rows);
+            }
+            KeyCode::PageUp if key.modifiers == KeyModifiers::NONE => {
+                help.move_cursor(-(rows as isize), rows);
+            }
+            _ => match help.input.handle_key(&key) {
+                InputEvent::Changed => {
+                    help.cursor = 0;
+                    help.scroll = 0;
+                }
+                InputEvent::Commit | InputEvent::Cancel | InputEvent::None => {}
+            },
+        }
+        help.clamp(rows);
+        Ok(RenderAction::Draw)
+    }
+
+    /// A help click selects a row but never forwards the click to a pane.
+    fn handle_help_click(&mut self, x: u16, y: u16) -> anyhow::Result<RenderAction> {
+        let scroll = self.help.as_ref().map(|help| help.scroll).unwrap_or(0);
+        let Some(row) = crate::help::help_row_at(self.screen, x, y, scroll) else {
+            return Ok(RenderAction::Draw);
+        };
+        let rows = crate::help::rows_visible(self.screen).max(1);
+        if let Some(help) = self.help.as_mut() {
+            if row < help.ranked().len() {
+                help.cursor = row;
+                help.clamp(rows);
+            }
+        }
+        Ok(RenderAction::Draw)
     }
 
     /// Keys while the finder is open: typing edits the query, Up/Down
@@ -2230,17 +2312,22 @@ impl App {
         self.selection = None;
         self.drag = None;
 
+        // An open rename dialog captures the click.
+        if self.prompt.is_some() {
+            return self.handle_prompt_click(x, y);
+        }
+
+        // The help overlay sits above the finder and captures every click.
+        if self.help.is_some() {
+            return self.handle_help_click(x, y);
+        }
+
         // An open finder overlay captures the click: a click on a results
         // row focuses that target and closes the finder; a click in the
         // overlay chrome or off it leaves the finder open so an errant
         // click does not discard the typed query.
         if self.finder.is_some() {
             return self.handle_finder_click(x, y);
-        }
-
-        // An open rename dialog captures the click.
-        if self.prompt.is_some() {
-            return self.handle_prompt_click(x, y);
         }
 
         // An open menu captures the click: activate or dismiss. Clicks on
@@ -2771,6 +2858,18 @@ impl App {
     }
 
     fn handle_scroll(&mut self, x: u16, y: u16, down: bool) -> anyhow::Result<RenderAction> {
+        if self.help.is_some() {
+            let screen = self.screen;
+            let inside = crate::help::help_rect(screen).is_some_and(|rect| rect.contains(x, y));
+            if inside {
+                let rows = crate::help::rows_visible(screen).max(1);
+                if let Some(help) = self.help.as_mut() {
+                    help.scroll_by(if down { 3 } else { -3 }, rows);
+                }
+                return Ok(RenderAction::Draw);
+            }
+            return Ok(RenderAction::None);
+        }
         let Some(area) = self.pane_area_at(x, y).copied() else { return Ok(RenderAction::None) };
         if self.active_pane() != Some(area.pane) {
             self.session.focus_pane(area.pane);

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -295,6 +295,43 @@ impl Default for Browser {
     }
 }
 
+/// Categories used to group key bindings in the help overlay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum HelpCategory {
+    Window,
+    Workspace,
+    Pane,
+    Tab,
+    Browser,
+    Agent,
+    Misc,
+}
+
+impl HelpCategory {
+    /// Categories in the display order used by the help overlay.
+    pub const ALL: [Self; 7] = [
+        Self::Window,
+        Self::Workspace,
+        Self::Pane,
+        Self::Tab,
+        Self::Browser,
+        Self::Agent,
+        Self::Misc,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Window => "Window",
+            Self::Workspace => "Workspace",
+            Self::Pane => "Pane",
+            Self::Tab => "Tab",
+            Self::Browser => "Browser",
+            Self::Agent => "Agent",
+            Self::Misc => "Misc",
+        }
+    }
+}
+
 /// Every prefix-key action, so bindings are configurable end to end.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
@@ -331,10 +368,11 @@ pub enum Action {
     BrowserEditUrl,
     Detach,
     OpenFuzzyFinder,
+    ShowHelp,
 }
 
 impl Action {
-    fn config_key(&self) -> &'static str {
+    pub fn config_key(&self) -> &'static str {
         match self {
             Action::NewTab => "new-tab",
             Action::NewBrowserTab => "new-browser-tab",
@@ -369,6 +407,126 @@ impl Action {
             Action::BrowserEditUrl => "browser-edit-url",
             Action::Detach => "detach",
             Action::OpenFuzzyFinder => "open-fuzzy-finder",
+            Action::ShowHelp => "show-help",
+        }
+    }
+
+    /// Human-readable action name shown in the help overlay.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Action::NewTab => "New tab",
+            Action::NewBrowserTab => "New browser tab",
+            Action::NewPaneSmart => "New pane",
+            Action::NextTab => "Next tab",
+            Action::PrevTab => "Previous tab",
+            Action::SplitRight => "Split right",
+            Action::SplitDown => "Split down",
+            Action::CloseTab => "Close tab",
+            Action::ClosePane => "Close pane",
+            Action::RenameTab => "Rename tab",
+            Action::RenameScreen => "Rename screen",
+            Action::RenameWorkspace => "Rename workspace",
+            Action::CloseScreen => "Close screen",
+            Action::PrevScreen => "Previous screen",
+            Action::NextScreen => "Next screen",
+            Action::NewScreen => "New screen",
+            Action::NextWorkspace => "Next workspace",
+            Action::NewWorkspace => "New workspace",
+            Action::ToggleSidebar => "Toggle sidebar",
+            Action::FocusLeft => "Focus left",
+            Action::FocusRight => "Focus right",
+            Action::FocusUp => "Focus up",
+            Action::FocusDown => "Focus down",
+            Action::ResizeGrow => "Grow pane",
+            Action::ResizeShrink => "Shrink pane",
+            Action::ScrollUp => "Scroll up",
+            Action::ScrollDown => "Scroll down",
+            Action::BrowserBack => "Browser back",
+            Action::BrowserForward => "Browser forward",
+            Action::BrowserReload => "Reload browser",
+            Action::BrowserEditUrl => "Edit browser URL",
+            Action::Detach => "Detach",
+            Action::OpenFuzzyFinder => "Open fuzzy finder",
+            Action::ShowHelp => "Show help",
+        }
+    }
+
+    /// One-line explanation of the action for the help overlay.
+    pub fn description(self) -> &'static str {
+        match self {
+            Action::NewTab => "Create a new terminal tab",
+            Action::NewBrowserTab => "Open a new browser tab",
+            Action::NewPaneSmart => "Create a smartly placed pane",
+            Action::NextTab => "Select the next tab",
+            Action::PrevTab => "Select the previous tab",
+            Action::SplitRight => "Split the pane to the right",
+            Action::SplitDown => "Split the pane below",
+            Action::CloseTab => "Close the active tab",
+            Action::ClosePane => "Close the active pane",
+            Action::RenameTab => "Rename the active tab",
+            Action::RenameScreen => "Rename the active screen",
+            Action::RenameWorkspace => "Rename the active workspace",
+            Action::CloseScreen => "Close the active screen",
+            Action::PrevScreen => "Select the previous screen",
+            Action::NextScreen => "Select the next screen",
+            Action::NewScreen => "Create a new screen",
+            Action::NextWorkspace => "Select the next workspace",
+            Action::NewWorkspace => "Create a new workspace",
+            Action::ToggleSidebar => "Show or hide the sidebar",
+            Action::FocusLeft => "Focus the pane to the left",
+            Action::FocusRight => "Focus the pane to the right",
+            Action::FocusUp => "Focus the pane above",
+            Action::FocusDown => "Focus the pane below",
+            Action::ResizeGrow => "Grow the focused pane",
+            Action::ResizeShrink => "Shrink the focused pane",
+            Action::ScrollUp => "Scroll the active surface up",
+            Action::ScrollDown => "Scroll the active surface down",
+            Action::BrowserBack => "Go back in browser history",
+            Action::BrowserForward => "Go forward in browser history",
+            Action::BrowserReload => "Reload the browser page",
+            Action::BrowserEditUrl => "Edit the browser URL",
+            Action::Detach => "Detach from the current session",
+            Action::OpenFuzzyFinder => "Open the fuzzy finder",
+            Action::ShowHelp => "Show this key binding help",
+        }
+    }
+
+    pub fn category(self) -> HelpCategory {
+        match self {
+            Action::RenameScreen
+            | Action::CloseScreen
+            | Action::PrevScreen
+            | Action::NextScreen
+            | Action::NewScreen => HelpCategory::Window,
+            Action::RenameWorkspace
+            | Action::NextWorkspace
+            | Action::NewWorkspace
+            | Action::ToggleSidebar => HelpCategory::Workspace,
+            Action::NewPaneSmart
+            | Action::SplitRight
+            | Action::SplitDown
+            | Action::ClosePane
+            | Action::FocusLeft
+            | Action::FocusRight
+            | Action::FocusUp
+            | Action::FocusDown
+            | Action::ResizeGrow
+            | Action::ResizeShrink => HelpCategory::Pane,
+            Action::NewTab
+            | Action::NewBrowserTab
+            | Action::NextTab
+            | Action::PrevTab
+            | Action::CloseTab
+            | Action::RenameTab => HelpCategory::Tab,
+            Action::BrowserBack
+            | Action::BrowserForward
+            | Action::BrowserReload
+            | Action::BrowserEditUrl => HelpCategory::Browser,
+            Action::ScrollUp
+            | Action::ScrollDown
+            | Action::Detach
+            | Action::OpenFuzzyFinder
+            | Action::ShowHelp => HelpCategory::Misc,
         }
     }
 }
@@ -381,6 +539,11 @@ pub struct Chord {
 }
 
 impl Chord {
+    /// Render this chord in the same syntax accepted by the config parser.
+    pub fn display(self) -> String {
+        chord_to_string(self)
+    }
+
     pub fn matches(&self, key: &KeyEvent) -> bool {
         // Shift is implied by uppercase/symbol chars; compare it only
         // for non-char codes.
@@ -456,12 +619,18 @@ impl Default for Keys {
                 bind(KeyCode::Char('u'), Action::BrowserEditUrl),
                 bind(KeyCode::Char('d'), Action::Detach),
                 bind(KeyCode::Char('G'), Action::OpenFuzzyFinder),
+                bind(KeyCode::Char('?'), Action::ShowHelp),
             ],
         }
     }
 }
 
 impl Keys {
+    /// Return every resolved binding in registry order.
+    pub fn bindings(&self) -> &[(Chord, Action)] {
+        &self.bindings
+    }
+
     /// The action bound to a key event (after the prefix).
     pub fn action_for(&self, key: &KeyEvent) -> Option<Action> {
         self.bindings.iter().find(|(chord, _)| chord.matches(key)).map(|(_, a)| *a)
@@ -640,6 +809,7 @@ fn all_actions() -> &'static [Action] {
         Action::BrowserEditUrl,
         Action::Detach,
         Action::OpenFuzzyFinder,
+        Action::ShowHelp,
     ]
 }
 
@@ -1634,6 +1804,16 @@ sidebar_rail = 77
         assert_eq!(
             keys.action_for(&KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE)),
             Some(Action::OpenFuzzyFinder)
+        );
+    }
+
+    #[test]
+    fn default_question_mark_opens_help() {
+        let keys = Keys::default();
+        // The question mark is the unmodified suffix after the Ctrl-b prefix.
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE)),
+            Some(Action::ShowHelp)
         );
     }
 

--- a/mux/crates/mux-tui/src/help.rs
+++ b/mux/crates/mux-tui/src/help.rs
@@ -1,0 +1,382 @@
+//! Floating, scrollable help overlay generated from the resolved key registry.
+
+use mux_core::Rect;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Position;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::Frame;
+
+use crate::config::{Action, Keys};
+use crate::finder::fuzzy_score;
+use crate::ui::input::TextInput;
+use crate::ui::truncate;
+
+pub use crate::config::HelpCategory;
+
+pub const ROWS_TOP_OFFSET: u16 = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelpEntry {
+    pub chord: String,
+    pub action: Action,
+    pub description: &'static str,
+    pub category: HelpCategory,
+}
+
+#[derive(Debug, Clone)]
+pub struct HelpState {
+    pub input: TextInput,
+    pub cursor: usize,
+    pub scroll: usize,
+    pub items: Vec<HelpEntry>,
+}
+
+impl HelpState {
+    pub fn new(items: Vec<HelpEntry>) -> Self {
+        HelpState { input: TextInput::new(String::new()), cursor: 0, scroll: 0, items }
+    }
+
+    pub fn rows_visible(screen: Rect) -> usize {
+        crate::help::rows_visible(screen)
+    }
+
+    /// Return matching item indices in the stable category order supplied by
+    /// `build_entries`. A query matches the action name, config key,
+    /// description, or chord.
+    pub fn ranked(&self) -> Vec<(usize, u32)> {
+        let query = self.input.as_str();
+        self.items
+            .iter()
+            .enumerate()
+            .filter_map(|(index, entry)| {
+                let score = fuzzy_score(query, entry.action.display_name())
+                    .or_else(|| fuzzy_score(query, entry.action.config_key()))
+                    .or_else(|| fuzzy_score(query, entry.description))
+                    .or_else(|| fuzzy_score(query, &entry.chord))?;
+                Some((index, score))
+            })
+            .collect()
+    }
+
+    pub fn set_query(&mut self, query: impl Into<String>) {
+        self.input = TextInput::new(query.into());
+        self.cursor = 0;
+        self.scroll = 0;
+    }
+
+    /// Move the selected result by a clamped number of rows.
+    pub fn move_cursor(&mut self, delta: isize, rows_visible: usize) {
+        let len = self.ranked().len();
+        if len == 0 {
+            self.cursor = 0;
+            self.scroll = 0;
+            return;
+        }
+        let magnitude = delta.checked_abs().unwrap_or(isize::MAX) as usize;
+        let next = if delta < 0 {
+            self.cursor.saturating_sub(magnitude)
+        } else {
+            self.cursor.saturating_add(magnitude)
+        };
+        self.cursor = next.min(len - 1);
+        self.clamp(rows_visible);
+    }
+
+    /// Scroll the viewport and keep the selected row visible.
+    pub fn scroll_by(&mut self, delta: isize, rows_visible: usize) {
+        let len = self.ranked().len();
+        if len == 0 {
+            self.cursor = 0;
+            self.scroll = 0;
+            return;
+        }
+        let visible = rows_visible.max(1).min(len);
+        let max_scroll = len - visible;
+        let magnitude = delta.checked_abs().unwrap_or(isize::MAX) as usize;
+        self.scroll = if delta < 0 {
+            self.scroll.saturating_sub(magnitude)
+        } else {
+            self.scroll.saturating_add(magnitude).min(max_scroll)
+        };
+        if self.cursor < self.scroll {
+            self.cursor = self.scroll;
+        }
+        let last_visible = self.scroll + visible - 1;
+        if self.cursor > last_visible {
+            self.cursor = last_visible;
+        }
+    }
+
+    /// Clamp cursor and scroll after filtering or a terminal resize.
+    pub fn clamp(&mut self, rows_visible: usize) {
+        let len = self.ranked().len();
+        if len == 0 {
+            self.cursor = 0;
+            self.scroll = 0;
+            return;
+        }
+        self.cursor = self.cursor.min(len - 1);
+        let visible = rows_visible.max(1).min(len);
+        let max_scroll = len - visible;
+        if self.cursor < self.scroll {
+            self.scroll = self.cursor;
+        }
+        if self.cursor >= self.scroll + visible {
+            self.scroll = self.cursor + 1 - visible;
+        }
+        self.scroll = self.scroll.min(max_scroll);
+    }
+}
+
+/// Build one help row for every resolved binding, including alternate chords.
+pub fn build_entries(keys: &Keys) -> Vec<HelpEntry> {
+    let mut entries: Vec<HelpEntry> = keys
+        .bindings()
+        .iter()
+        .map(|(chord, action)| HelpEntry {
+            chord: chord.display(),
+            action: *action,
+            description: action.description(),
+            category: action.category(),
+        })
+        .collect();
+    entries.sort_by(|left, right| {
+        left.category
+            .cmp(&right.category)
+            .then_with(|| left.chord.cmp(&right.chord))
+            .then_with(|| left.action.display_name().cmp(right.action.display_name()))
+    });
+    entries
+}
+
+/// Return the centred help pane rectangle, or no rectangle when it cannot fit.
+pub fn help_rect(screen: Rect) -> Option<Rect> {
+    const MIN_WIDTH: u16 = 60;
+    const MIN_HEIGHT: u16 = 14;
+    if screen.width < MIN_WIDTH || screen.height < MIN_HEIGHT {
+        return None;
+    }
+    let width = 90.min(screen.width);
+    let height = 30.min(screen.height);
+    Some(Rect {
+        x: screen.x + (screen.width - width) / 2,
+        y: screen.y + (screen.height - height) / 2,
+        width,
+        height,
+    })
+}
+
+pub fn rows_visible(screen: Rect) -> usize {
+    help_rect(screen)
+        .map(|rect| rect.height.saturating_sub(ROWS_TOP_OFFSET + 1) as usize)
+        .unwrap_or(0)
+}
+
+/// Convert a click in the results region to a ranked row index.
+pub fn help_row_at(screen: Rect, x: u16, y: u16, scroll: usize) -> Option<usize> {
+    let rect = help_rect(screen)?;
+    if !rect.contains(x, y) {
+        return None;
+    }
+    let rows_y = rect.y + ROWS_TOP_OFFSET;
+    let rows_h = rect.height.saturating_sub(ROWS_TOP_OFFSET + 1);
+    if y < rows_y || y >= rows_y.saturating_add(rows_h) {
+        return None;
+    }
+    Some(scroll + (y - rows_y) as usize)
+}
+
+/// Draw the help overlay without touching session state. Small terminals
+/// simply keep the underlying frame visible rather than panicking.
+pub fn draw(app: &mut crate::app::App, frame: &mut Frame) {
+    let area = frame.area();
+    let screen = Rect { x: area.x, y: area.y, width: area.width, height: area.height };
+    let Some(rect) = help_rect(screen) else { return };
+    let Some(help) = app.help.as_mut() else { return };
+
+    let x = rect.x;
+    let y = rect.y;
+    let width = rect.width;
+    let height = rect.height;
+    let visible = rows_visible(screen);
+    help.clamp(visible);
+    let ranked = help.ranked();
+
+    let base = Style::default().bg(Color::Indexed(236)).fg(Color::Indexed(252));
+    let border = base.fg(Color::Indexed(244));
+    let title = base.fg(Color::Indexed(255)).add_modifier(Modifier::BOLD);
+    let input_style = Style::default().bg(Color::Indexed(233)).fg(Color::Indexed(255));
+    let selected = Style::default()
+        .bg(Color::Indexed(242))
+        .fg(Color::Indexed(255))
+        .add_modifier(Modifier::BOLD);
+    let input_w = width.saturating_sub(4);
+    let input_label = "Filter: ";
+    let input_label_w = input_label.chars().count() as u16;
+    let query_w = input_w.saturating_sub(input_label_w);
+    let (shown, cursor_col) = help.input.visible_text_and_cursor(query_w as usize);
+    let cursor_x = x + 2 + input_label_w + (cursor_col as u16).min(query_w);
+    let rows_y = y + ROWS_TOP_OFFSET;
+    let rows_h = height.saturating_sub(ROWS_TOP_OFFSET + 1);
+    let category_legend =
+        HelpCategory::ALL.iter().map(|category| category.label()).collect::<Vec<_>>().join("  ");
+
+    {
+        let buf = frame.buffer_mut();
+        for dy in 0..height {
+            for dx in 0..width {
+                set_cell(buf, x + dx, y + dy, " ", base);
+            }
+        }
+        draw_border(buf, x, y, width, height, border);
+        buf.set_stringn(x + 2, y + 1, "Help", 4, title);
+        let hint = "/ filter  j/k move  PgUp/PgDn page  Esc/q close";
+        let hint_x = x + width.saturating_sub(hint.chars().count() as u16 + 2);
+        buf.set_stringn(hint_x, y + 1, hint, hint.chars().count(), base.fg(Color::Indexed(244)));
+        for dx in 0..input_w {
+            set_cell(buf, x + 2 + dx, y + 2, " ", input_style);
+        }
+        buf.set_stringn(x + 2, y + 2, input_label, input_label_w as usize, input_style);
+        buf.set_stringn(x + 2 + input_label_w, y + 2, &shown, query_w as usize, input_style);
+        buf.set_stringn(
+            x + 2,
+            y + 3,
+            &category_legend,
+            input_w as usize,
+            base.fg(Color::Indexed(244)),
+        );
+    }
+    frame.set_cursor_position(Position::new(cursor_x, y + 2));
+
+    let inner_w = width.saturating_sub(2);
+    let category_w = 10.min(inner_w);
+    let chord_w = 12.min(inner_w.saturating_sub(category_w + 1));
+    let action_w = 22.min(inner_w.saturating_sub(category_w + chord_w + 2));
+    let description_x = x + 1 + category_w + 1 + chord_w + 1 + action_w + 1;
+    let description_w = (x + width.saturating_sub(1)).saturating_sub(description_x);
+
+    let buf = frame.buffer_mut();
+    for (ranked_i, &(item_i, _)) in
+        ranked.iter().enumerate().skip(help.scroll).take(rows_h as usize)
+    {
+        let row_y = rows_y + (ranked_i - help.scroll) as u16;
+        let entry = &help.items[item_i];
+        let style = if ranked_i == help.cursor { selected } else { base };
+        for dx in 0..inner_w {
+            set_cell(buf, x + 1 + dx, row_y, " ", style);
+        }
+        let category_style = if ranked_i == help.cursor {
+            style.add_modifier(Modifier::BOLD)
+        } else {
+            style.fg(Color::Indexed(110)).add_modifier(Modifier::BOLD)
+        };
+        let category = truncate(entry.category.label(), category_w as usize);
+        let chord = truncate(&entry.chord, chord_w as usize);
+        let action = truncate(entry.action.display_name(), action_w as usize);
+        let description = truncate(entry.description, description_w as usize);
+        buf.set_stringn(x + 1, row_y, &category, category_w as usize, category_style);
+        buf.set_stringn(x + 1 + category_w + 1, row_y, &chord, chord_w as usize, style);
+        buf.set_stringn(x + 1 + category_w + chord_w + 2, row_y, &action, action_w as usize, style);
+        buf.set_stringn(description_x, row_y, &description, description_w as usize, style);
+    }
+    if ranked.is_empty() && rows_h > 0 {
+        buf.set_stringn(
+            x + 2,
+            rows_y,
+            "No bindings match the filter",
+            inner_w.saturating_sub(2) as usize,
+            base,
+        );
+    }
+}
+
+fn set_cell(buf: &mut Buffer, x: u16, y: u16, symbol: &str, style: Style) {
+    let cell = &mut buf[(x, y)];
+    cell.reset();
+    cell.set_symbol(symbol).set_style(style);
+}
+
+fn draw_border(buf: &mut Buffer, x: u16, y: u16, width: u16, height: u16, style: Style) {
+    if width < 2 || height < 2 {
+        return;
+    }
+    let right = x + width - 1;
+    let bottom = y + height - 1;
+    for col in x + 1..right {
+        set_cell(buf, col, y, "-", style);
+        set_cell(buf, col, bottom, "-", style);
+    }
+    for row in y + 1..bottom {
+        set_cell(buf, x, row, "|", style);
+        set_cell(buf, right, row, "|", style);
+    }
+    set_cell(buf, x, y, "+", style);
+    set_cell(buf, right, y, "+", style);
+    set_cell(buf, x, bottom, "+", style);
+    set_cell(buf, right, bottom, "+", style);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn help_entries_match_every_registered_binding() {
+        let keys = Keys::default();
+        let entries = build_entries(&keys);
+        assert_eq!(entries.len(), keys.bindings().len());
+        assert!(entries.iter().all(|entry| !entry.description.is_empty()));
+    }
+
+    #[test]
+    fn help_filter_matches_action_name_or_chord() {
+        let keys = Keys::default();
+        let mut state = HelpState::new(build_entries(&keys));
+        state.set_query("new");
+        assert!(state.ranked().iter().any(|(index, _)| {
+            let entry = &state.items[*index];
+            fuzzy_score(state.input.as_str(), entry.action.display_name()).is_some()
+                || fuzzy_score(state.input.as_str(), &entry.chord).is_some()
+        }));
+
+        state.set_query("?");
+        assert!(state.ranked().iter().any(|(index, _)| state.items[*index].chord == "?"));
+    }
+
+    #[test]
+    fn entries_are_grouped_by_category_and_chord() {
+        let entries = build_entries(&Keys::default());
+        let mut previous: Option<(HelpCategory, String)> = None;
+        for entry in entries {
+            let current = (entry.category, entry.chord.clone());
+            if let Some(previous) = &previous {
+                assert!(
+                    *previous <= current,
+                    "entries are not grouped: {previous:?} > {current:?}"
+                );
+            }
+            previous = Some(current);
+        }
+        assert_eq!(HelpCategory::ALL.len(), 7);
+        assert!(HelpCategory::ALL.iter().all(|category| !category.label().is_empty()));
+    }
+
+    #[test]
+    fn navigation_and_hit_testing_clamp_to_the_visible_list() {
+        let screen = Rect { x: 0, y: 0, width: 100, height: 40 };
+        let visible = rows_visible(screen);
+        assert!(visible > 0);
+        let mut state = HelpState::new(build_entries(&Keys::default()));
+        state.move_cursor(isize::MAX, visible);
+        assert_eq!(state.cursor, state.ranked().len() - 1);
+        state.move_cursor(isize::MIN, visible);
+        assert_eq!(state.cursor, 0);
+
+        let rect = help_rect(screen).unwrap();
+        let rows_y = rect.y + ROWS_TOP_OFFSET;
+        assert_eq!(help_row_at(screen, rect.x + 2, rows_y, 0), Some(0));
+        assert_eq!(help_row_at(screen, rect.x + 2, rows_y + 1, 5), Some(6));
+        assert_eq!(help_row_at(screen, rect.x + 2, rect.y + 1, 0), None);
+        assert!(help_rect(Rect { x: 0, y: 0, width: 50, height: 10 }).is_none());
+    }
+}

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -19,6 +19,7 @@ mod desktop_notify;
 mod finder;
 mod git_info;
 mod grok_hook;
+mod help;
 mod hook_merge;
 mod host_colors;
 mod keys;
@@ -102,6 +103,7 @@ KEYS (prefix: Ctrl-b)
   h/j/k/l or arrows    move focus              d    quit (attach: detach)
   w  next workspace    W    new workspace       s    toggle sidebar
   <  browser back      >    browser forward     r/u  browser reload/edit URL
+  ?  show key binding help
   Ctrl-b  send a literal Ctrl-b
 
 MOUSE

--- a/mux/crates/mux-tui/src/ui/mod.rs
+++ b/mux/crates/mux-tui/src/ui/mod.rs
@@ -38,10 +38,12 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
     overlay::draw_menu(app, frame);
 
     // The dialog owns the terminal cursor while it is open (draw_prompt
-    // sets it on the input row). The fuzzy finder is the next overlay up
-    // in the priority stack and owns the cursor while open.
+    // sets it on the input row). Help is the next overlay, followed by the
+    // fuzzy finder.
     if app.prompt.is_some() {
         overlay::draw_prompt(app, frame);
+    } else if app.help.is_some() {
+        crate::help::draw(app, frame);
     } else if app.finder.is_some() {
         crate::finder::draw(app, frame);
     } else if app.menu.is_none() {


### PR DESCRIPTION
## Summary
Upgrades the `leader ?` help overlay from a static text list to a floating, scrollable pane grouped by category (Window/Workspace/Pane/Tab/Browser/Agent/Misc), one-line description per binding.

- Auto-generated from the real key-bindings registry (`Keys::default()` in `config.rs`) — new bindings appear automatically, no manual catalog.
- Mouse scroll, `j`/`k`, `PgUp`/`PgDn` navigation.
- `/` fuzzy-filters by action name or chord.
- `Esc`/`q` closes, returning focus to where it was.

## Test plan
- [x] `cargo check -p mux-tui --locked` — clean, `Cargo.lock` stayed lockfile v3
- [x] `cargo test -p mux-tui` — 131 unit + 17 integration tests, 0 failed (independently re-run)
- [x] Independent review pass: `lgtm_with_warnings`, 0 critical/warning, 5 minor findings (empty category disclosure, filter-mode UX nuance, fuzzy-match scope, test-assertion strength, magic scroll increment) — all cosmetic, logged as fast-follows
- [x] Independent verify pass: 9/10 claims PASS; the 1 fail is against the spec's own wrong assumption that the registry lives in `keys.rs` (it's actually `config.rs::Keys::default()`) — the functional auto-generation claim passes and proves it reads the real registry correctly

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the Pi Factory fleet