### PR TITLE
fix(ci): pin cargo to rustup +1.97 in scripts/bootstrap.sh

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -73,10 +73,18 @@ jobs:
           ./scripts/bootstrap.sh
           echo "ZIG=$GITHUB_WORKSPACE/.tools/zig-${{ matrix.arch }}-linux-0.15.2/zig" >> "$GITHUB_ENV"
 
+      # Pin cargo to the Rust 1.97 toolchain via rustup's "+toolchain"
+      # syntax. dtolnay/rust-toolchain installs Rust 1.97 under ~/.cargo
+      # but the CI image's PATH may still surface an older system cargo
+      # first (1.74 on ubuntu-22.04, 1.82 on ubuntu-24.04). Older cargo
+      # < 1.78 cannot read Cargo.lock v4, which cargo 1.97+ emits by
+      # default. The "+1.97" prefix routes through rustup regardless of
+      # PATH ordering. See AGENTS.md "Pinned toolchain" for the rust pin
+      # and scripts/bootstrap.sh for the matching local-build fix.
       - name: Cargo check (mux-tui)
         working-directory: mux
-        run: cargo check -p mux-tui
+        run: cargo +1.97 check -p mux-tui
 
       - name: Cargo test (mux-tui)
         working-directory: mux
-        run: cargo test -p mux-tui
+        run: cargo +1.97 test -p mux-tui

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -39,6 +39,20 @@ done
 
 echo "==> building mux-tui (release)"
 cd "$ROOT/mux"
-ZIG="$ZIG_DIR/zig" cargo build --release -p mux-tui
+# Pin cargo to the Rust 1.97 toolchain via rustup's "+toolchain" syntax.
+# The dtolnay/rust-toolchain action installs Rust 1.97 under
+# ~/.cargo but the CI image's PATH may still surface an older
+# system cargo first (1.74 on ubuntu-22.04, 1.82 on ubuntu-24.04).
+# Older cargo < 1.78 cannot read Cargo.lock v4, which we generate
+# by default. The "+1.97" prefix routes through rustup regardless of
+# PATH ordering. See AGENTS.md "Pinned toolchain" for the rust pin.
+if command -v cargo >/dev/null 2>&1; then
+    CARGO_BIN="$(command -v cargo)"
+else
+    echo "error: cargo not found on PATH (dtolnay/rust-toolchain should install it)" >&2
+    exit 1
+fi
+echo "    using: $("$CARGO_BIN" --version)"
+ZIG="$ZIG_DIR/zig" "$CARGO_BIN" "+1.97" build --release -p mux-tui
 
 echo "==> built: $ROOT/mux/target/release/cmux"


### PR DESCRIPTION
## Summary

Two companion fixes for the Rust 1.97 toolchain bump in PR #55. The CI workflow's `cargo check` and `cargo test` steps were running plain `cargo` from PATH, which on the CI images resolves to an older system cargo (1.74 on ubuntu-22.04, 1.82 on ubuntu-24.04) that can't read Cargo.lock v4. PR #56 hit this exact failure mode on first CI run.

## Changes

* **`scripts/bootstrap.sh`** — capture `$(command -v cargo)`, fail fast if missing, echo the resolved version, invoke `"$CARGO_BIN" "+1.97" build --release -p mux-tui`. Fixes local developer builds.

* **`.github/workflows/pr-build.yml`** — add `+1.97` rustup prefix to the `cargo check` and `cargo test` invocations in the build job. Fixes CI builds (which run `cargo` directly and bypass `bootstrap.sh`).

## Why a new PR instead of amending PR #55

PR #55's `ci/bump-rust-197` already has a follow-up commit (`7b19c00 docs(plugins): track wasm32 fixture follow-up for issue #42`) on top of the bump. Force-pushing PR #55's local commit history would clobber that doc. This fresh branch off `origin/ci/bump-rust-197` preserves the wasm32 follow-up and adds the bootstrap.sh fix as a clean, separate commit.

The branch has been rebased onto `origin/main` (post-PR #55 squash), so the diff against main is:
- `scripts/bootstrap.sh`: +15 / −1 (rustup `+1.97` prefix)
- `.github/workflows/pr-build.yml`: +10 / −2 (rustup `+1.97` prefix on cargo invocations)

## Root cause recap

Both fixes target the same failure mode: the `dtolnay/rust-toolchain@1.97.0` action installs Rust 1.97 under `~/.cargo`, but the runner/developer PATH still surfaces an older system cargo first. Older cargo (< 1.78) cannot read Cargo.lock v4, which cargo 1.97+ emits by default. The `+1.97` rustup prefix routes through rustup regardless of PATH ordering.

## Verification

- Both fixes apply cleanly on top of post-#55 main.
- The same `+1.97` fix was already in `feat/plugin-execution-wasm` (PR #56) for `scripts/bootstrap.sh`; #57 is the consolidated, post-rebase version that also covers the CI workflow.

Refs: issue #42, PR #55 (toolchain bump), PR #56 (plugin execution — first CI failure on lockfile v4)