### PR TITLE
feat(mux-tui): --version / -V prints the cmux version and exits (fixes #59)

### DIFF
--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -283,9 +283,8 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
                 print!("{USAGE}");
                 std::process::exit(0);
             }
-            // Issue #59: `cmux --version` (and `-V`) should print the
-            // compiled-in version and exit 0 — not the USAGE. Mirrors
-            // the convention used by git, cargo, tmux, and most CLIs.
+            // Issue #59: print version and exit. Sits next to `-h`/`--help`
+            // so it works in any position (e.g. `cmux --headless -V`).
             "-V" | "--version" => {
                 println!("cmux {VERSION}");
                 std::process::exit(0);
@@ -301,14 +300,6 @@ fn main() {
     let raw_args = std::env::args().skip(1).collect::<Vec<_>>();
     if raw_args.first().map(|arg| arg.as_str()) == Some("help") {
         print!("{USAGE}");
-        std::process::exit(0);
-    }
-    // Issue #59: short-circuit `-V` / `--version` as the very first
-    // argument so it works even if the user has somehow shadowed the
-    // flag with a same-named plugin. `parse_args` handles it in any
-    // other position.
-    if matches!(raw_args.first().map(String::as_str), Some("-V" | "--version")) {
-        println!("cmux {VERSION}");
         std::process::exit(0);
     }
     if raw_args.first().map(|arg| arg.as_str()) == Some("claude") {

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -99,6 +99,7 @@ OPTIONS:
                     --apply-local-config), print the merged chrome as JSON,
                     and exit without starting the TUI. For inspecting
                     overlay layering without a live terminal.
+  -V, --version      Print the cmux version and exit.
   -h, --help         Show this help.
 
 KEYS (prefix: Ctrl-b)
@@ -237,6 +238,10 @@ struct Args {
     config: Option<PathBuf>,
 }
 
+/// cmux version, taken from `crates/mux-tui/Cargo.toml` at compile time.
+/// Surfaced by `cmux --version` / `cmux -V` (issue #59).
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
     let mut out = Args {
         attach: false,
@@ -278,6 +283,13 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
                 print!("{USAGE}");
                 std::process::exit(0);
             }
+            // Issue #59: `cmux --version` (and `-V`) should print the
+            // compiled-in version and exit 0 — not the USAGE. Mirrors
+            // the convention used by git, cargo, tmux, and most CLIs.
+            "-V" | "--version" => {
+                println!("cmux {VERSION}");
+                std::process::exit(0);
+            }
             other => usage_exit(&format!("unknown argument {other:?}")),
         }
     }
@@ -289,6 +301,14 @@ fn main() {
     let raw_args = std::env::args().skip(1).collect::<Vec<_>>();
     if raw_args.first().map(|arg| arg.as_str()) == Some("help") {
         print!("{USAGE}");
+        std::process::exit(0);
+    }
+    // Issue #59: short-circuit `-V` / `--version` as the very first
+    // argument so it works even if the user has somehow shadowed the
+    // flag with a same-named plugin. `parse_args` handles it in any
+    // other position.
+    if matches!(raw_args.first().map(String::as_str), Some("-V" | "--version")) {
+        println!("cmux {VERSION}");
         std::process::exit(0);
     }
     if raw_args.first().map(|arg| arg.as_str()) == Some("claude") {

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -1540,3 +1540,58 @@ fn plugin_shipped_example_manifest_installs() {
         "verb allowlist should include cmux_call: {list_out}"
     );
 }
+
+/// Issue #59: `cmux --version` (and `cmux -V`) should print the
+/// compiled-in version and exit 0 — not the USAGE. The output must
+/// match `env!("CARGO_PKG_VERSION")` from the cmux binary's manifest
+/// so a stale in-source version constant can't drift from the Cargo
+/// version.
+#[test]
+fn version_flag_prints_cargo_version_and_exits_zero() {
+    let expected_version = env!("CARGO_PKG_VERSION");
+
+    let run = |args: &[&str]| {
+        Command::new(bin())
+            .args(args)
+            .env_remove("CMUX_MUX_SOCKET")
+            .output()
+            .unwrap()
+    };
+
+    // Long form.
+    let long = run(&["--version"]);
+    assert_success(&long);
+    let long_out = String::from_utf8_lossy(&long.stdout).trim_end().to_string();
+    assert_eq!(
+        long_out,
+        format!("cmux {expected_version}"),
+        "--version should print `cmux <CARGO_PKG_VERSION>` exactly"
+    );
+    assert!(
+        long.stderr.is_empty(),
+        "--version should not write to stderr; got: {}",
+        String::from_utf8_lossy(&long.stderr)
+    );
+
+    // Short form.
+    let short = run(&["-V"]);
+    assert_success(&short);
+    let short_out = String::from_utf8_lossy(&short.stdout).trim_end().to_string();
+    assert_eq!(
+        short_out,
+        format!("cmux {expected_version}"),
+        "-V should print the same `cmux <CARGO_PKG_VERSION>` line as --version"
+    );
+
+    // `--version` after another flag should still short-circuit (we
+    // exit before consuming further args), proving the handler sits
+    // inside the parse loop and not just as a subcommand dispatch.
+    let mixed = run(&["--headless", "--version"]);
+    assert_success(&mixed);
+    let mixed_out = String::from_utf8_lossy(&mixed.stdout).trim_end().to_string();
+    assert_eq!(
+        mixed_out,
+        format!("cmux {expected_version}"),
+        "--version after another flag should still print the version"
+    );
+}

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -1541,14 +1541,12 @@ fn plugin_shipped_example_manifest_installs() {
     );
 }
 
-/// Issue #59: `cmux --version` (and `cmux -V`) should print the
-/// compiled-in version and exit 0 — not the USAGE. The output must
-/// match `env!("CARGO_PKG_VERSION")` from the cmux binary's manifest
-/// so a stale in-source version constant can't drift from the Cargo
-/// version.
+/// Issue #59: `cmux --version` / `-V` print `cmux <CARGO_PKG_VERSION>`
+/// and exit 0. Output is pinned to the package version so a stale
+/// hard-coded string cannot drift from Cargo.toml.
 #[test]
 fn version_flag_prints_cargo_version_and_exits_zero() {
-    let expected_version = env!("CARGO_PKG_VERSION");
+    let expected = format!("cmux {}", env!("CARGO_PKG_VERSION"));
 
     let run = |args: &[&str]| {
         Command::new(bin())
@@ -1558,40 +1556,18 @@ fn version_flag_prints_cargo_version_and_exits_zero() {
             .unwrap()
     };
 
-    // Long form.
-    let long = run(&["--version"]);
-    assert_success(&long);
-    let long_out = String::from_utf8_lossy(&long.stdout).trim_end().to_string();
-    assert_eq!(
-        long_out,
-        format!("cmux {expected_version}"),
-        "--version should print `cmux <CARGO_PKG_VERSION>` exactly"
-    );
-    assert!(
-        long.stderr.is_empty(),
-        "--version should not write to stderr; got: {}",
-        String::from_utf8_lossy(&long.stderr)
-    );
-
-    // Short form.
-    let short = run(&["-V"]);
-    assert_success(&short);
-    let short_out = String::from_utf8_lossy(&short.stdout).trim_end().to_string();
-    assert_eq!(
-        short_out,
-        format!("cmux {expected_version}"),
-        "-V should print the same `cmux <CARGO_PKG_VERSION>` line as --version"
-    );
-
-    // `--version` after another flag should still short-circuit (we
-    // exit before consuming further args), proving the handler sits
-    // inside the parse loop and not just as a subcommand dispatch.
-    let mixed = run(&["--headless", "--version"]);
-    assert_success(&mixed);
-    let mixed_out = String::from_utf8_lossy(&mixed.stdout).trim_end().to_string();
-    assert_eq!(
-        mixed_out,
-        format!("cmux {expected_version}"),
-        "--version after another flag should still print the version"
-    );
+    for args in [&["--version"][..], &["-V"][..], &["--headless", "--version"][..]] {
+        let out = run(args);
+        assert_success(&out);
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout).trim_end(),
+            expected,
+            "args {args:?} should print `{expected}`"
+        );
+        assert!(
+            out.stderr.is_empty(),
+            "args {args:?} should write nothing to stderr; got: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
 }


### PR DESCRIPTION
Fixes #59.

## Problem
`cmux --version` (and `cmux -V`) currently fall through to `parse_args`, which has no handler for the flag, so the binary exits 2 with `unknown argument "--version"` followed by the full USAGE. There is no way for a user to inspect the installed cmux version without grepping the binary itself.

## Fix
Add a `-V` / `--version` flag that prints `cmux <version>` and exits 0.

- New `const VERSION: &str = env!("CARGO_PKG_VERSION")` in `main.rs` keeps the runtime string in lock-step with `crates/mux-tui/Cargo.toml` so it cannot drift.
- Handler lives next to `-h`/`--help` in `parse_args`, so it works in any position (e.g. `cmux --headless --version`).
- Unknown `--*` flags are already treated as non-CLI by `first_command_arg`, so `--version` falls through to `parse_args` without needing a separate early path in `main()`.
- `-V` is the standard short alias (matches git, cargo, tmux).
- Exit code is 0 on success; no stderr; just `cmux <version>\n`.
- USAGE block is updated to document the new flag.

## Verification
```
$ cmux --version
cmux 0.1.0

$ cmux -V
cmux 0.1.0

$ cmux --headless --version
cmux 0.1.0

$ echo $?
0
```

Added an integration test (`version_flag_prints_cargo_version_and_exits_zero`) that exercises `--version`, `-V`, and `--headless --version`, pinning the output to `env!("CARGO_PKG_VERSION")` so the assertion is robust to version bumps. All 25 CLI tests pass.