### PR TITLE
fix(mux-tui): stop clipboard tools from corrupting the TUI on text select (#61)

### DIFF
--- a/mux/crates/mux-tui/src/clipboard.rs
+++ b/mux/crates/mux-tui/src/clipboard.rs
@@ -4,15 +4,24 @@
 //! `wl-paste` (Wayland) or `xclip` (X11) so we can paste into browser panes
 //! and inject clipboard images into PTY panes (issue #30 — Claude Code's
 //! own clipboard read often fails inside nested terminal multiplexers).
+//!
+//! Clipboard child processes must never inherit the TUI's stdout/stderr
+//! (issue #61): tools like `wl-copy` print multi-line diagnostics when
+//! Wayland is unavailable, and those bytes corrupt the alternate-screen
+//! frame so the session cannot be redrawn cleanly.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Read text from the desktop clipboard. Returns `None` if no tool is
 /// available or the clipboard is empty/unreadable.
 pub fn read_text() -> Option<String> {
-    let bytes = read_clipboard_bytes(&["wl-paste", "--no-newline"], &["xclip", "-selection", "clipboard", "-o"])?;
+    let bytes = read_clipboard_bytes(
+        &["wl-paste", "--no-newline"],
+        &["xclip", "-selection", "clipboard", "-o"],
+    )?;
     let text = String::from_utf8(bytes).ok()?;
     (!text.is_empty()).then_some(text)
 }
@@ -26,28 +35,13 @@ pub fn read_text() -> Option<String> {
 /// terminal has `clipboard-write = deny`. OSC 52 is still tried first
 /// by the caller (it works over SSH when the host allows it); this
 /// function is the local-system safety net.
+///
+/// Child stdout/stderr are discarded so a failing tool cannot paint over
+/// the TUI (issue #61). Tools that are clearly wrong for the session
+/// (e.g. `wl-copy` with no Wayland display) are skipped entirely.
 pub fn write_text(text: &str) -> bool {
-    // Wayland: wl-copy
-    if let Ok(mut child) = std::process::Command::new("wl-copy").stdin(std::process::Stdio::piped()).spawn() {
-        if let Some(stdin) = child.stdin.as_mut() {
-            use std::io::Write;
-            let _ = stdin.write_all(text.as_bytes());
-        }
-        if child.wait().map(|s| s.success()).unwrap_or(false) {
-            return true;
-        }
-    }
-    // X11: xclip
-    if let Ok(mut child) = std::process::Command::new("xclip")
-        .args(["-selection", "clipboard"])
-        .stdin(std::process::Stdio::piped())
-        .spawn()
-    {
-        if let Some(stdin) = child.stdin.as_mut() {
-            use std::io::Write;
-            let _ = stdin.write_all(text.as_bytes());
-        }
-        if child.wait().map(|s| s.success()).unwrap_or(false) {
+    for tool in write_tools_for_session() {
+        if try_write_with(tool, text) {
             return true;
         }
     }
@@ -117,16 +111,100 @@ fn looks_like_png(bytes: &[u8]) -> bool {
     bytes.len() >= 8 && bytes.starts_with(b"\x89PNG\r\n\x1a\n")
 }
 
-/// Try `wl_args` first (argv[0] = binary), then `x_args`.
+/// Clipboard write backends, ordered for the current session.
+///
+/// Preference is driven by display env vars so we do not spawn a Wayland
+/// tool on a pure X11 session (Linux Mint/Cinnamon, many Ubuntu installs)
+/// and dump its connection error into the TUI.
+fn write_tools_for_session() -> Vec<ClipboardWriteTool> {
+    write_tools_for_env(env_is_set("WAYLAND_DISPLAY"), env_is_set("DISPLAY"))
+}
+
+fn write_tools_for_env(wayland: bool, x11: bool) -> Vec<ClipboardWriteTool> {
+    let mut tools = Vec::with_capacity(2);
+    match (wayland, x11) {
+        (true, false) => tools.push(ClipboardWriteTool::WlCopy),
+        (false, true) => tools.push(ClipboardWriteTool::Xclip),
+        (true, true) => {
+            // Nested/mixed sessions (e.g. XWayland): try Wayland first.
+            tools.push(ClipboardWriteTool::WlCopy);
+            tools.push(ClipboardWriteTool::Xclip);
+        }
+        (false, false) => {
+            // Headless/SSH with no display: still try both silently so a
+            // forwarded or late-set display has a chance; failures stay
+            // quiet (stdout/stderr nulled).
+            tools.push(ClipboardWriteTool::WlCopy);
+            tools.push(ClipboardWriteTool::Xclip);
+        }
+    }
+    tools
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ClipboardWriteTool {
+    WlCopy,
+    Xclip,
+}
+
+fn try_write_with(tool: ClipboardWriteTool, text: &str) -> bool {
+    let mut cmd = match tool {
+        ClipboardWriteTool::WlCopy => Command::new("wl-copy"),
+        ClipboardWriteTool::Xclip => {
+            let mut c = Command::new("xclip");
+            c.args(["-selection", "clipboard"]);
+            c
+        }
+    };
+    // Critical: never inherit the TUI's terminal fds. wl-copy prints
+    // "Failed to connect to a Wayland server…" on stderr when
+    // WAYLAND_DISPLAY is wrong/missing; that corrupts the alt-screen
+    // frame and leaves the session unusable until restart (issue #61).
+    let mut child = match cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    // Close stdin after writing so tools that read until EOF (wl-copy,
+    // xclip) exit instead of hanging the TUI on child.wait().
+    if let Some(mut stdin) = child.stdin.take() {
+        if stdin.write_all(text.as_bytes()).is_err() {
+            let _ = child.kill();
+            let _ = child.wait();
+            return false;
+        }
+        // stdin dropped here → EOF
+    }
+    child.wait().map(|s| s.success()).unwrap_or(false)
+}
+
+fn env_is_set(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|v| !v.is_empty())
+}
+
+/// Try Wayland args first when a Wayland display is present, otherwise
+/// prefer X11, then fall back. Both branches use `output()` so child
+/// stderr is captured rather than painted onto the TUI.
 fn read_clipboard_bytes(wl_args: &[&str], x_args: &[&str]) -> Option<Vec<u8>> {
-    let from_wl = run_capture(wl_args);
-    from_wl.or_else(|| run_capture(x_args))
+    let wayland = env_is_set("WAYLAND_DISPLAY");
+    let x11 = env_is_set("DISPLAY");
+    match (wayland, x11) {
+        (true, false) => run_capture(wl_args).or_else(|| run_capture(x_args)),
+        (false, true) => run_capture(x_args).or_else(|| run_capture(wl_args)),
+        _ => run_capture(wl_args).or_else(|| run_capture(x_args)),
+    }
 }
 
 fn run_capture(args: &[&str]) -> Option<Vec<u8>> {
     if args.is_empty() {
         return None;
     }
+    // `output()` already captures stdout+stderr into memory, so a failing
+    // wl-paste cannot corrupt the TUI the way write_text used to.
     let output = Command::new(args[0]).args(&args[1..]).output().ok()?;
     if !output.status.success() || output.stdout.is_empty() {
         return None;
@@ -162,5 +240,46 @@ mod tests {
         // Without a real image on the clipboard this returns None; we only
         // assert it does not panic.
         let _ = image_paste_payload();
+    }
+
+    #[test]
+    fn pure_x11_session_skips_wl_copy() {
+        // Linux Mint / Cinnamon default: DISPLAY set, WAYLAND_DISPLAY unset.
+        // Spawning wl-copy here is what painted the error over the TUI in #61.
+        assert_eq!(
+            write_tools_for_env(false, true),
+            vec![ClipboardWriteTool::Xclip]
+        );
+    }
+
+    #[test]
+    fn pure_wayland_session_skips_xclip_first() {
+        assert_eq!(
+            write_tools_for_env(true, false),
+            vec![ClipboardWriteTool::WlCopy]
+        );
+    }
+
+    #[test]
+    fn mixed_session_prefers_wayland_then_x11() {
+        assert_eq!(
+            write_tools_for_env(true, true),
+            vec![ClipboardWriteTool::WlCopy, ClipboardWriteTool::Xclip]
+        );
+    }
+
+    #[test]
+    fn headless_session_tries_both_silently() {
+        assert_eq!(
+            write_tools_for_env(false, false),
+            vec![ClipboardWriteTool::WlCopy, ClipboardWriteTool::Xclip]
+        );
+    }
+
+    #[test]
+    fn write_text_does_not_panic_without_tools() {
+        // On a CI/headless box neither tool may work; must not panic or
+        // write to the terminal.
+        let _ = write_text("issue-61 regression probe");
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #61: drag-to-select text painted `wl-copy` Wayland connection errors over the TUI and left the session unusable.
- Prefer the clipboard backend that matches the session (`xclip` on pure X11, `wl-copy` on pure Wayland; both when mixed/headless).
- Null child stdout/stderr so tool failures never inherit the alternate-screen TTY; close stdin after writing so tools waiting for EOF cannot hang the TUI.

## Context

`copy_text_to_clipboard` always falls back to `clipboard::write_text()` after OSC 52. The old path always spawned `wl-copy` first with inherited stderr. On Linux Mint / Cinnamon (and this machine: `DISPLAY=:0`, `WAYLAND_DISPLAY` unset) that produces exactly the multi-line error from the issue screenshot.

## Test plan

- [x] `cargo test -p mux-tui --bin cmux` — 162 unit tests pass (includes new env-order and write_text smoke tests)
- [x] Reproduced old `wl-copy` stderr: matches issue #61 message when `WAYLAND_DISPLAY` is unset
- [ ] Manual: on X11, drag-select text in a pane — no Wayland error overlay; “Copied” toast still appears; clipboard gets text via OSC 52 and/or `xclip`
- [ ] Manual: on Wayland (if available), select still copies via `wl-copy` without TUI corruption