### PR TITLE
fix(mux-tui): do not fall back to wl-paste on pure X11 clipboard read

### DIFF
--- a/mux/crates/mux-tui/src/clipboard.rs
+++ b/mux/crates/mux-tui/src/clipboard.rs
@@ -194,7 +194,7 @@ fn read_clipboard_bytes(wl_args: &[&str], x_args: &[&str]) -> Option<Vec<u8>> {
     let x11 = env_is_set("DISPLAY");
     match (wayland, x11) {
         (true, false) => run_capture(wl_args).or_else(|| run_capture(x_args)),
-        (false, true) => run_capture(x_args).or_else(|| run_capture(wl_args)),
+        (false, true) => run_capture(x_args),
         _ => run_capture(wl_args).or_else(|| run_capture(x_args)),
     }
 }


### PR DESCRIPTION
On pure X11 sessions (DISPLAY set, WAYLAND_DISPLAY unset), read_clipboard_bytes should not fall back to attempting wl-paste if xclip returns no output or fails, matching the behavior of write_tools_for_env.