### PR TITLE
feat(mux-tui): cmux attach --session-list interactive picker (issue #63 L1)

### DIFF
--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -869,6 +869,7 @@ pub(crate) fn read_pid_file(path: &std::path::Path) -> Option<u32> {
 /// `socket_path` is the exact path to reconnect to; `mtime` is for the
 /// picker's newest-first sort (pid-file mtime preferred — the socket mtime
 /// can shift on each connect — falling back to socket mtime, then `None`).
+#[derive(Clone)]
 pub(crate) struct DiscoveredSession {
     pub(crate) session: String,
     pub(crate) socket_path: PathBuf,
@@ -981,23 +982,15 @@ pub(crate) fn run_attach_session_list_json(global: &GlobalArgs) -> i32 {
     }
 }
 
-fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
-    let target_session = flags.optional("session").or_else(|| global.session.clone());
-    let Some(session_name) = target_session else {
-        eprintln!("cmux: --session is required");
-        return 2;
-    };
-
-    let dir = get_runtime_dir(global);
-    let sock_path = dir.join(format!("{session_name}.sock"));
-    let pid_p = dir.join(format!("{session_name}.pid"));
-
-    if !sock_path.exists() && !pid_p.exists() {
-        eprintln!("cmux: session {session_name:?} not found");
-        return 1;
-    }
-
-    if let Some(pid) = read_pid_file(&pid_p) {
+/// Kill the cmux process owning `socket_path` (SIGTERM, escalate to SIGKILL
+/// after 2s, reap up to 1s more) and remove its `.sock`/`.pid`. Shared by
+/// `run_kill_session` and the picker's kill-focused (Claim 3). Returns true
+/// if the pidfile named a live cmux process that was signalled (regardless
+/// of whether it died in time); false if there was no pid / no cmux process.
+/// The `.sock`/`.pid` are removed unconditionally, matching the historical
+/// `run_kill_session` behaviour.
+pub(crate) fn kill_session_at(socket_path: &std::path::Path, pid: Option<u32>) -> bool {
+    if let Some(pid) = pid {
         if mux_core::server::is_cmux_process(pid) {
             unsafe {
                 libc::kill(pid as libc::pid_t, libc::SIGTERM);
@@ -1023,9 +1016,30 @@ fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
             }
         }
     }
-
-    let _ = std::fs::remove_file(&sock_path);
+    let pid_p = mux_core::server::pid_path(socket_path);
+    let _ = std::fs::remove_file(socket_path);
     let _ = std::fs::remove_file(&pid_p);
+    pid.is_some()
+}
+
+fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
+    let target_session = flags.optional("session").or_else(|| global.session.clone());
+    let Some(session_name) = target_session else {
+        eprintln!("cmux: --session is required");
+        return 2;
+    };
+
+    let dir = get_runtime_dir(global);
+    let sock_path = dir.join(format!("{session_name}.sock"));
+    let pid_p = dir.join(format!("{session_name}.pid"));
+
+    if !sock_path.exists() && !pid_p.exists() {
+        eprintln!("cmux: session {session_name:?} not found");
+        return 1;
+    }
+
+    let pid = read_pid_file(&pid_p);
+    kill_session_at(&sock_path, pid);
 
     if global.json {
         println!("{}", json!({ "ok": true }));

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -20,10 +20,10 @@ struct CliArgs {
 }
 
 #[derive(Default)]
-struct GlobalArgs {
-    session: Option<String>,
-    socket: Option<PathBuf>,
-    json: bool,
+pub(crate) struct GlobalArgs {
+    pub(crate) session: Option<String>,
+    pub(crate) socket: Option<PathBuf>,
+    pub(crate) json: bool,
 }
 
 #[derive(Default)]
@@ -848,7 +848,7 @@ fn build_kill_session(flags: &FlagMap) -> Result<Value, UsageError> {
     Ok(value)
 }
 
-fn get_runtime_dir(global: &GlobalArgs) -> PathBuf {
+pub(crate) fn get_runtime_dir(global: &GlobalArgs) -> PathBuf {
     global
         .socket
         .as_ref()
@@ -856,7 +856,7 @@ fn get_runtime_dir(global: &GlobalArgs) -> PathBuf {
         .unwrap_or_else(mux_core::platform::runtime_dir)
 }
 
-fn read_pid_file(path: &std::path::Path) -> Option<u32> {
+pub(crate) fn read_pid_file(path: &std::path::Path) -> Option<u32> {
     if let Ok(content) = std::fs::read_to_string(path) {
         content.trim().parse::<u32>().ok()
     } else {
@@ -864,38 +864,64 @@ fn read_pid_file(path: &std::path::Path) -> Option<u32> {
     }
 }
 
-fn run_list_sessions(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
+/// One discovered cmux session (issue #63 L1).
+///
+/// `socket_path` is the exact path to reconnect to; `mtime` is for the
+/// picker's newest-first sort (pid-file mtime preferred — the socket mtime
+/// can shift on each connect — falling back to socket mtime, then `None`).
+pub(crate) struct DiscoveredSession {
+    pub(crate) session: String,
+    pub(crate) socket_path: PathBuf,
+    pub(crate) pid: Option<u32>,
+    pub(crate) live: bool,
+    pub(crate) mtime: Option<std::time::SystemTime>,
+}
+
+/// Socket-centric discovery of cmux sessions in the runtime dir honoured
+/// by `global` (parent of `--socket`, else `platform::runtime_dir()`).
+/// One row per `*.sock`: derive the pid via `server::pid_path`, liveness via
+/// `server::is_session_socket_live`, and an mtime for uptime sort. Shared by
+/// `run_list_sessions`, `run_kill_stale`, `run_attach_session_list_json`,
+/// and the interactive picker. Returned unsorted (read_dir order is
+/// filesystem-dependent); callers sort as needed.
+pub(crate) fn discover_sessions(global: &GlobalArgs) -> Vec<DiscoveredSession> {
     let dir = get_runtime_dir(global);
-    let mut session_names = std::collections::BTreeSet::new();
-
-    if let Ok(entries) = std::fs::read_dir(&dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                if ext == "sock" || ext == "pid" {
-                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                        session_names.insert(stem.to_string());
-                    }
-                }
-            }
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(entries) => entries,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("sock") {
+            continue;
         }
-    }
-
-    struct SessionInfo {
-        session: String,
-        pid: Option<u32>,
-        status: &'static str,
-    }
-
-    let mut sessions = Vec::new();
-    for name in session_names {
-        let sock_path = dir.join(format!("{name}.sock"));
-        let pid_p = dir.join(format!("{name}.pid"));
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let pid_p = mux_core::server::pid_path(&path);
         let pid = read_pid_file(&pid_p);
-        let is_live = mux_core::server::is_session_socket_live(&sock_path);
-        let status = if is_live { "live" } else { "stale" };
-        sessions.push(SessionInfo { session: name, pid, status });
+        let live = mux_core::server::is_session_socket_live(&path);
+        let mtime = std::fs::metadata(&pid_p)
+            .and_then(|m| m.modified())
+            .or_else(|_| std::fs::metadata(&path).and_then(|m| m.modified()))
+            .ok();
+        out.push(DiscoveredSession {
+            session: stem.to_string(),
+            socket_path: path,
+            pid,
+            live,
+            mtime,
+        });
     }
+    out
+}
+
+fn run_list_sessions(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
+    let mut sessions = discover_sessions(global);
+    // Preserve the historical alphabetical order: the old impl built the
+    // name set from a BTreeSet, and read_dir order is filesystem-dependent.
+    sessions.sort_by(|a, b| a.session.cmp(&b.session));
 
     if global.json {
         let json_list: Vec<Value> = sessions
@@ -905,7 +931,7 @@ fn run_list_sessions(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
                     "session": s.session,
                     "name": s.session,
                     "pid": s.pid,
-                    "status": s.status,
+                    "status": if s.live { "live" } else { "stale" },
                 })
             })
             .collect();
@@ -919,9 +945,39 @@ fn run_list_sessions(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
     } else {
         for s in &sessions {
             let pid_str = s.pid.map(|p| p.to_string()).unwrap_or_else(|| "-".to_string());
-            println!("{} {} {}", s.session, pid_str, s.status);
+            let status = if s.live { "live" } else { "stale" };
+            println!("{} {} {}", s.session, pid_str, status);
         }
         0
+    }
+}
+
+/// `cmux attach --session-list --json` (issue #63 L1): non-interactive
+/// discovery dump. Same shape as `run_list_sessions`'s JSON branch PLUS a
+/// `socket_path` per entry, so a caller can reconnect to the exact socket
+/// — important when discovery is scoped by `--socket <parent>/x.sock` and
+/// `runtime_dir()` would resolve elsewhere. Exit 0; 3 on write error.
+pub(crate) fn run_attach_session_list_json(global: &GlobalArgs) -> i32 {
+    let mut sessions = discover_sessions(global);
+    sessions.sort_by(|a, b| a.session.cmp(&b.session));
+    let json_list: Vec<Value> = sessions
+        .iter()
+        .map(|s| {
+            json!({
+                "session": s.session,
+                "name": s.session,
+                "pid": s.pid,
+                "status": if s.live { "live" } else { "stale" },
+                "socket_path": s.socket_path.display().to_string(),
+            })
+        })
+        .collect();
+    let payload = json!({ "sessions": json_list });
+    if serde_json::to_writer(io::stdout(), &payload).is_ok() {
+        println!();
+        0
+    } else {
+        3
     }
 }
 
@@ -978,29 +1034,13 @@ fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
 }
 
 fn run_kill_stale(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
-    let dir = get_runtime_dir(global);
-    let mut session_names = std::collections::BTreeSet::new();
-
-    if let Ok(entries) = std::fs::read_dir(&dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                if ext == "sock" || ext == "pid" {
-                    if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                        session_names.insert(stem.to_string());
-                    }
-                }
-            }
-        }
-    }
-
+    let mut sessions = discover_sessions(global);
+    sessions.sort_by(|a, b| a.session.cmp(&b.session));
     let mut cleaned = 0;
-    for name in session_names {
-        let sock_path = dir.join(format!("{name}.sock"));
-        let pid_p = dir.join(format!("{name}.pid"));
-        if !mux_core::server::is_session_socket_live(&sock_path) {
-            let _ = std::fs::remove_file(&sock_path);
-            let _ = std::fs::remove_file(&pid_p);
+    for s in &sessions {
+        if !s.live {
+            let _ = std::fs::remove_file(&s.socket_path);
+            let _ = std::fs::remove_file(mux_core::server::pid_path(&s.socket_path));
             cleaned += 1;
         }
     }

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -109,6 +109,16 @@ OPTIONS:
   -V, --version      Print the cmux version and exit.
   -h, --help         Show this help.
 
+SESSION PICKER  (cmux attach --session-list, without --json)
+  Lists every discovered cmux session (newest first) and lets you pick one
+  to attach in-process. Stale (unconnectable) sessions are shown grey and
+  labelled [unreachable]. Exit codes: 0 clean quit, 1 after a destructive
+  kill + quit, 2 Ctrl-C, 0 on attach (then the normal attach/detach flow).
+    ↑/↓ or j/k  move focus        Enter  attach to focused (live only)
+    x  kill focused session (y/N)    s  kill every stale session (y/N)
+    n  new session (inline name)     r  rename (stub; L2 will wire it in)
+    q / Esc  quit                    Ctrl-C  abort (exit 2)
+
 KEYS (prefix: Ctrl-b)
   c  new tab in pane   B    new browser tab    n/p  next/prev tab
   1-9  select tab

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -29,6 +29,7 @@ mod pi_hook;
 mod plugin;
 mod plugin_host;
 mod session;
+mod session_picker;
 mod skill_content;
 mod socket_watchdog;
 mod ssh_bootstrap;
@@ -435,7 +436,7 @@ fn main() {
     if cli::is_cli_invocation(&raw_args) {
         std::process::exit(cli::run(&raw_args, USAGE));
     }
-    let args = parse_args(raw_args);
+    let mut args = parse_args(raw_args);
     if args.show_local_config_resolution {
         return show_local_config_resolution(args);
     }
@@ -448,9 +449,26 @@ fn main() {
         if args.json {
             std::process::exit(cli::run_attach_session_list_json(&global));
         }
-        // Interactive picker (Claims 2-7) is wired in the next commit; the
-        // --json short-circuit above is the only L1 path that is headlessly
-        // tested. Without --json we fall through and attach to args.session.
+        // Interactive picker (Claims 2-7). It restores the terminal on every
+        // exit path before returning, so the subsequent app::run (Attach)
+        // starts from a clean screen.
+        match session_picker::run(&global) {
+            Ok(session_picker::PickerOutcome::Attach { socket_path, name }) => {
+                // Use the EXACT discovered socket_path (not a recomputed
+                // default_socket_path(name)) so --socket-scoped discovery
+                // reconnects even if runtime_dir() would resolve elsewhere.
+                args.socket = Some(socket_path);
+                args.session = name;
+            }
+            Ok(session_picker::PickerOutcome::Quit { destructive }) => {
+                std::process::exit(if destructive { 1 } else { 0 });
+            }
+            Ok(session_picker::PickerOutcome::CtrlC) => std::process::exit(2),
+            Err(e) => {
+                eprintln!("cmux: {e}");
+                std::process::exit(1);
+            }
+        }
     }
     let result = if args.attach { run_attach(args) } else { run_server(args) };
     if let Err(e) = result {

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -99,6 +99,12 @@ OPTIONS:
                     --apply-local-config), print the merged chrome as JSON,
                     and exit without starting the TUI. For inspecting
                     overlay layering without a live terminal.
+  --session-list     Attach only: discover sessions and either print them
+                    (--json) or open the interactive picker instead of
+                    attaching directly.
+  --json             With --session-list: print the discovered sessions as
+                    JSON (one object per session, including socket_path)
+                    and exit without attaching.
   -V, --version      Print the cmux version and exit.
   -h, --help         Show this help.
 
@@ -236,6 +242,11 @@ struct Args {
     show_local_config_resolution: bool,
     print_resolved_config: bool,
     config: Option<PathBuf>,
+    // Issue #63 L1: `cmux attach --session-list [--json]` — discover
+    // sessions and either dump them as JSON or open the interactive picker
+    // before attaching. Parsed on the `attach` subcommand in parse_args.
+    session_list: bool,
+    json: bool,
 }
 
 /// cmux version, taken from `crates/mux-tui/Cargo.toml` at compile time.
@@ -253,6 +264,8 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
         show_local_config_resolution: false,
         print_resolved_config: false,
         config: None,
+        session_list: false,
+        json: false,
     };
     let mut args = args.into_iter().peekable();
     if args.peek().map(|s| s.as_str()) == Some("attach") {
@@ -269,6 +282,9 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
                     Some(args.next().unwrap_or_else(|| usage_exit("--socket needs a value")).into())
             }
             "--headless" => out.headless = true,
+            // Issue #63 L1: attach-only session discovery flags.
+            "--session-list" => out.session_list = true,
+            "--json" => out.json = true,
             "--term" => {
                 out.term = Some(args.next().unwrap_or_else(|| usage_exit("--term needs a value")))
             }
@@ -422,6 +438,19 @@ fn main() {
     let args = parse_args(raw_args);
     if args.show_local_config_resolution {
         return show_local_config_resolution(args);
+    }
+    if args.session_list {
+        let global = cli::GlobalArgs {
+            session: Some(args.session.clone()),
+            socket: args.socket.clone(),
+            json: args.json,
+        };
+        if args.json {
+            std::process::exit(cli::run_attach_session_list_json(&global));
+        }
+        // Interactive picker (Claims 2-7) is wired in the next commit; the
+        // --json short-circuit above is the only L1 path that is headlessly
+        // tested. Without --json we fall through and attach to args.session.
     }
     let result = if args.attach { run_attach(args) } else { run_server(args) };
     if let Err(e) = result {

--- a/mux/crates/mux-tui/src/session_picker.rs
+++ b/mux/crates/mux-tui/src/session_picker.rs
@@ -1,0 +1,265 @@
+//! Interactive pre-attach session picker for `cmux attach --session-list`
+//! (issue #63, layer L1).
+//!
+//! Runs BEFORE `run_attach`/`app::run`, so it must not touch `App` or
+//! `Session` (those need an already-chosen socket). It is a self-contained
+//! raw-mode loop mirroring the terminal lifecycle in `app.rs`:
+//! `enable_raw_mode` → `EnterAlternateScreen` → a tiny ratatui
+//! `Terminal<CrosstermBackend>` → `crossterm::event::read()` loop →
+//! `restore_terminal` on EVERY exit path (Enter/q/Esc/Ctrl-C/panic). A
+//! raw-mode or alt-screen leak would corrupt the subsequent `app::run` TUI
+//! or the user's shell, so the panic hook (app.rs:674 pattern) is mandatory.
+
+use std::io;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::ExecutableCommand;
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Terminal as RatatuiTerminal;
+
+use crate::cli::{self, DiscoveredSession, GlobalArgs};
+
+/// What the picker decided. `main()` maps this to an exit code / attach.
+pub(crate) enum PickerOutcome {
+    /// Attach in-process: caller sets `socket`/`session` and falls through
+    /// to the existing `run_attach` path (no fork/exec).
+    Attach { socket_path: PathBuf, name: String },
+    /// User quit (q/Esc). `destructive` is true if a session was killed
+    /// during this run, so `main()` can exit 1 instead of 0 (Claim 3).
+    Quit { destructive: bool },
+    /// Ctrl-C.
+    CtrlC,
+}
+
+/// Interactive modal picker. Restores the terminal on every return path
+/// (including via the panic hook) before yielding control back to `main`,
+/// so the subsequent `app::run` (on Attach) starts from a clean screen.
+pub(crate) fn run(global: &GlobalArgs) -> anyhow::Result<PickerOutcome> {
+    let stdout_lock = Arc::new(Mutex::new(()));
+    enable_raw_mode()?;
+    // Enter the alternate screen under the lock so restore_terminal can't
+    // race a concurrent write (mirrors app.rs:644-651).
+    if let Err(e) = (|| -> anyhow::Result<()> {
+        let _guard = stdout_lock.lock().unwrap();
+        io::stdout().execute(EnterAlternateScreen)?;
+        Ok(())
+    })() {
+        let _ = restore_terminal(Some(&stdout_lock));
+        return Err(e);
+    }
+    // Restore on panic so a mid-frame panic can't strand the terminal in
+    // raw/alt-screen mode (mirrors app.rs:674-680).
+    let default_hook = std::panic::take_hook();
+    let restore_lock = stdout_lock.clone();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = restore_terminal(Some(&restore_lock));
+        default_hook(info);
+    }));
+
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = match RatatuiTerminal::new(backend) {
+        Ok(t) => t,
+        Err(e) => {
+            let _ = std::panic::take_hook();
+            let _ = restore_terminal(Some(&stdout_lock));
+            return Err(e.into());
+        }
+    };
+
+    let outcome = event_loop(&mut terminal, global);
+
+    // Tear down the panic hook and restore the terminal before returning so
+    // app::run (Attach) or the shell (Quit/CtrlC) inherits a clean screen.
+    let _ = std::panic::take_hook();
+    restore_terminal(Some(&stdout_lock))?;
+    outcome
+}
+
+/// Full-screen raw-mode input loop.
+fn event_loop(
+    terminal: &mut RatatuiTerminal<CrosstermBackend<io::Stdout>>,
+    global: &GlobalArgs,
+) -> anyhow::Result<PickerOutcome> {
+    let sessions = refresh(global);
+    let mut state = ListState::default();
+    clamp_selection(&mut state, &sessions);
+    // Claim 3 flips this to true after a kill so Quit exits 1.
+    let destructive = false;
+    let mut status = String::new();
+
+    draw(terminal, &mut state, &sessions, &status)?;
+    loop {
+        // Poll with a short timeout so a future background refresh could
+        // re-run discovery; for L1 we just re-loop and redraw on key/resize.
+        if !event::poll(Duration::from_millis(250))? {
+            continue;
+        }
+        let key = match event::read()? {
+            Event::Key(k) => k,
+            Event::Resize(_, _) => {
+                draw(terminal, &mut state, &sessions, &status)?;
+                continue;
+            }
+            _ => continue,
+        };
+        match handle_key(&key, &mut state, &sessions, &mut status) {
+            Handled::Quit => return Ok(PickerOutcome::Quit { destructive }),
+            Handled::CtrlC => return Ok(PickerOutcome::CtrlC),
+            Handled::Attach(socket_path, name) => {
+                return Ok(PickerOutcome::Attach { socket_path, name });
+            }
+            Handled::Continue => {}
+            Handled::Redraw => draw(terminal, &mut state, &sessions, &status)?,
+        }
+    }
+}
+
+/// Result of dispatching a single key. Claims 3-7 add Kill/KillStale/New/Rename.
+enum Handled {
+    Continue,
+    Redraw,
+    Quit,
+    CtrlC,
+    Attach(PathBuf, String),
+}
+
+/// Pure key dispatch: reads `state`/`sessions`, may mutate `state`/`status`.
+/// Side effects needing `global`/`sessions` mutation (kill, new, refresh) are
+/// returned as `Handled` variants for `event_loop` to apply.
+fn handle_key(
+    key: &KeyEvent,
+    state: &mut ListState,
+    sessions: &[DiscoveredSession],
+    status: &mut String,
+) -> Handled {
+    let len = sessions.len();
+    let selected = state.selected();
+    match key.code {
+        // Navigation. vim j/k matches USAGE "h/j/k/l or arrows move focus".
+        KeyCode::Up | KeyCode::Char('k') => move_cursor(state, selected, len, false),
+        KeyCode::Down | KeyCode::Char('j') => move_cursor(state, selected, len, true),
+        KeyCode::Enter => {
+            if let Some(i) = selected {
+                if let Some(s) = sessions.get(i) {
+                    if s.live {
+                        return Handled::Attach(s.socket_path.clone(), s.session.clone());
+                    }
+                    // Q2 (approved): stale stays focusable but Enter does
+                    // not attach — the socket isn't connectable.
+                    *status = format!(
+                        "{} is unreachable (socket not connectable) — cannot attach",
+                        s.session
+                    );
+                    return Handled::Redraw;
+                }
+            }
+            Handled::Continue
+        }
+        KeyCode::Esc | KeyCode::Char('q') => Handled::Quit,
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => Handled::CtrlC,
+        // Claims 3-7 add x (kill focused), s (kill stale), n (new), r (rename stub).
+        _ => Handled::Continue,
+    }
+}
+
+/// Apply an up/down move, returning Redraw iff the selection changed.
+fn move_cursor(state: &mut ListState, selected: Option<usize>, len: usize, down: bool) -> Handled {
+    if len == 0 {
+        return Handled::Continue;
+    }
+    let i = selected.unwrap_or(0);
+    let next = if down { i + 1 } else { i.saturating_sub(1) };
+    if next >= len || next == i {
+        Handled::Continue
+    } else {
+        state.select(Some(next));
+        Handled::Redraw
+    }
+}
+
+/// Re-run discovery, newest-first (mtime DESC; `None` sorts last), for the
+/// picker's "most recent session on top" ordering.
+fn refresh(global: &GlobalArgs) -> Vec<DiscoveredSession> {
+    let mut sessions = cli::discover_sessions(global);
+    sessions.sort_by(|a, b| b.mtime.cmp(&a.mtime));
+    sessions
+}
+
+fn clamp_selection(state: &mut ListState, sessions: &[DiscoveredSession]) {
+    if sessions.is_empty() {
+        state.select(None);
+    } else if state.selected().map_or(true, |i| i >= sessions.len()) {
+        state.select(Some(0));
+    }
+}
+
+fn draw(
+    terminal: &mut RatatuiTerminal<CrosstermBackend<io::Stdout>>,
+    state: &mut ListState,
+    sessions: &[DiscoveredSession],
+    status: &str,
+) -> io::Result<()> {
+    terminal.draw(|f| {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(3), Constraint::Length(2)])
+            .split(f.area());
+
+        let items: Vec<ListItem> = sessions
+            .iter()
+            .map(|s| {
+                let (label, style) = if s.live {
+                    (s.session.clone(), Style::default())
+                } else {
+                    (
+                        format!("[unreachable] {}", s.session),
+                        Style::default().fg(Color::DarkGray),
+                    )
+                };
+                ListItem::new(Line::from(Span::styled(label, style)))
+            })
+            .collect();
+        let title = if sessions.is_empty() {
+            " cmux sessions — none found (q to quit) "
+        } else {
+            " cmux sessions — pick one to attach "
+        };
+        let list = List::new(items)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+            .highlight_symbol("▶ ");
+        f.render_stateful_widget(list, chunks[0], state);
+
+        // Footer: keymap hints on row 1, transient status (if any) on row 2.
+        let hints = "↑/↓ or j/k move · Enter attach · q/Esc quit · Ctrl-C abort";
+        let mut lines = vec![Line::from(hints)];
+        if !status.is_empty() {
+            lines.push(Line::from(Span::styled(
+                status,
+                Style::default().fg(Color::Yellow),
+            )));
+        }
+        f.render_widget(Paragraph::new(Text::from(lines)), chunks[1]);
+    })?;
+    Ok(())
+}
+
+/// Mirror of app.rs:740 restore_terminal: leave the alternate screen and
+/// disable raw mode. Best-effort on the screen switch so one failure can't
+/// strand the terminal in raw mode.
+fn restore_terminal(stdout_lock: Option<&Arc<Mutex<()>>>) -> anyhow::Result<()> {
+    let _guard = stdout_lock.map(|lock| lock.lock().unwrap());
+    let _ = io::stdout().execute(LeaveAlternateScreen);
+    disable_raw_mode()?;
+    Ok(())
+}

--- a/mux/crates/mux-tui/src/session_picker.rs
+++ b/mux/crates/mux-tui/src/session_picker.rs
@@ -28,6 +28,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
 use ratatui::Terminal as RatatuiTerminal;
 
 use crate::cli::{self, DiscoveredSession, GlobalArgs};
+use crate::ui::input::{InputEvent, TextInput};
 
 /// What the picker decided. `main()` maps this to an exit code / attach.
 pub(crate) enum PickerOutcome {
@@ -39,6 +40,24 @@ pub(crate) enum PickerOutcome {
     Quit { destructive: bool },
     /// Ctrl-C.
     CtrlC,
+}
+
+/// Inline modal the loop can be in. `Browse` is the default list; the others
+/// are transient overlays driven by x/s/n that return to `Browse` on commit
+/// or cancel. Kept in the picker state (not App) since this runs pre-attach.
+enum Mode {
+    Browse,
+    /// Confirm killing the focused session (Claim 3). y/N.
+    ConfirmKill {
+        index: usize,
+        name: String,
+    },
+    /// Confirm killing every stale session (Claim 4). y/N.
+    ConfirmKillStale {
+        count: usize,
+    },
+    /// Inline new-session name prompt (Claim 5). Enter attaches/creates.
+    NewSession(TextInput),
 }
 
 /// Interactive modal picker. Restores the terminal on every return path
@@ -90,14 +109,14 @@ fn event_loop(
     terminal: &mut RatatuiTerminal<CrosstermBackend<io::Stdout>>,
     global: &GlobalArgs,
 ) -> anyhow::Result<PickerOutcome> {
-    let sessions = refresh(global);
+    let mut sessions = refresh(global);
     let mut state = ListState::default();
     clamp_selection(&mut state, &sessions);
-    // Claim 3 flips this to true after a kill so Quit exits 1.
-    let destructive = false;
+    let mut destructive = false;
     let mut status = String::new();
+    let mut mode = Mode::Browse;
 
-    draw(terminal, &mut state, &sessions, &status)?;
+    draw(terminal, &mut state, &sessions, &status, &mut mode)?;
     loop {
         // Poll with a short timeout so a future background refresh could
         // re-run discovery; for L1 we just re-loop and redraw on key/resize.
@@ -107,41 +126,146 @@ fn event_loop(
         let key = match event::read()? {
             Event::Key(k) => k,
             Event::Resize(_, _) => {
-                draw(terminal, &mut state, &sessions, &status)?;
+                draw(terminal, &mut state, &sessions, &status, &mut mode)?;
                 continue;
             }
             _ => continue,
         };
-        match handle_key(&key, &mut state, &sessions, &mut status) {
-            Handled::Quit => return Ok(PickerOutcome::Quit { destructive }),
-            Handled::CtrlC => return Ok(PickerOutcome::CtrlC),
-            Handled::Attach(socket_path, name) => {
+        match dispatch(&key, &mut state, &mut sessions, &mut status, &mut mode, global) {
+            Action::Quit => return Ok(PickerOutcome::Quit { destructive }),
+            Action::CtrlC => return Ok(PickerOutcome::CtrlC),
+            Action::Attach(socket_path, name) => {
                 return Ok(PickerOutcome::Attach { socket_path, name });
             }
-            Handled::Continue => {}
-            Handled::Redraw => draw(terminal, &mut state, &sessions, &status)?,
+            Action::None => {}
+            Action::Killed => {
+                destructive = true;
+                clamp_selection(&mut state, &sessions);
+                draw(terminal, &mut state, &sessions, &status, &mut mode)?;
+            }
+            Action::Redraw => {
+                draw(terminal, &mut state, &sessions, &status, &mut mode)?;
+            }
         }
     }
 }
 
-/// Result of dispatching a single key. Claims 3-7 add Kill/KillStale/New/Rename.
-enum Handled {
-    Continue,
+/// What `dispatch` wants the loop to do after handling a key.
+enum Action {
+    None,
     Redraw,
+    /// A session was killed this keystroke; flip `destructive` then redraw.
+    Killed,
     Quit,
     CtrlC,
     Attach(PathBuf, String),
 }
 
-/// Pure key dispatch: reads `state`/`sessions`, may mutate `state`/`status`.
-/// Side effects needing `global`/`sessions` mutation (kill, new, refresh) are
-/// returned as `Handled` variants for `event_loop` to apply.
-fn handle_key(
+/// Route a key to the current mode. Side-effecting variants (kill, new,
+/// refresh) mutate `sessions`/`status`/`mode` directly so the redraw in
+/// `event_loop` reflects them immediately.
+fn dispatch(
+    key: &KeyEvent,
+    state: &mut ListState,
+    sessions: &mut Vec<DiscoveredSession>,
+    status: &mut String,
+    mode: &mut Mode,
+    global: &GlobalArgs,
+) -> Action {
+    // Ctrl-C works from any mode.
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return Action::CtrlC;
+    }
+    match mode {
+        Mode::Browse => browse_key(key, state, sessions, status, mode),
+        Mode::ConfirmKill { index, name } => {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    let idx = *index;
+                    let nm = name.clone();
+                    if let Some(s) = sessions.get(idx).cloned() {
+                        cli::kill_session_at(&s.socket_path, s.pid);
+                        *status = format!("killed {nm}");
+                        *sessions = refresh(global);
+                        destructive_select(state, &sessions, idx);
+                        *mode = Mode::Browse;
+                        return Action::Killed;
+                    }
+                    *mode = Mode::Browse;
+                    Action::Redraw
+                }
+                // any other key = No (Esc, n, Enter, …): cancel
+                _ => {
+                    *mode = Mode::Browse;
+                    Action::Redraw
+                }
+            }
+        }
+        Mode::ConfirmKillStale { count } => {
+            match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    // Reuse the cli kill-stale path: it is already built on
+                    // discover_sessions, so semantics match `cmux kill-stale`.
+                    let cleaned = kill_stale(global);
+                    *status = format!("cleaned {cleaned} stale session(s)");
+                    *sessions = refresh(global);
+                    let _ = count; // borrowed only for the prompt label
+                    *mode = Mode::Browse;
+                    Action::Killed
+                }
+                _ => {
+                    *mode = Mode::Browse;
+                    Action::Redraw
+                }
+            }
+        }
+        Mode::NewSession(input) => {
+            match input.handle_key(key) {
+                InputEvent::Commit => {
+                    let name = input.as_str().trim().to_string();
+                    if name.is_empty() {
+                        *status = "session name cannot be empty".to_string();
+                        *mode = Mode::Browse;
+                        return Action::Redraw;
+                    }
+                    // Q4 (approved): if the name matches a LIVE session,
+                    // attach to it; if stale, kill-stale then create fresh.
+                    let existing = sessions.iter().find(|s| s.session == name).cloned();
+                    match existing {
+                        Some(s) if s.live => {
+                            Action::Attach(s.socket_path.clone(), s.session.clone())
+                        }
+                        Some(_) => {
+                            // stale同名: clean it, then create fresh below.
+                            kill_stale(global);
+                            *sessions = refresh(global);
+                            let sock = mux_core::server::default_socket_path(&name);
+                            Action::Attach(sock, name)
+                        }
+                        None => {
+                            let sock = mux_core::server::default_socket_path(&name);
+                            Action::Attach(sock, name)
+                        }
+                    }
+                }
+                InputEvent::Cancel => {
+                    *mode = Mode::Browse;
+                    Action::Redraw
+                }
+                InputEvent::None | InputEvent::Changed => Action::Redraw,
+            }
+        }
+    }
+}
+
+/// Keys for the default Browse mode.
+fn browse_key(
     key: &KeyEvent,
     state: &mut ListState,
     sessions: &[DiscoveredSession],
     status: &mut String,
-) -> Handled {
+    mode: &mut Mode,
+) -> Action {
     let len = sessions.len();
     let selected = state.selected();
     match key.code {
@@ -152,7 +276,7 @@ fn handle_key(
             if let Some(i) = selected {
                 if let Some(s) = sessions.get(i) {
                     if s.live {
-                        return Handled::Attach(s.socket_path.clone(), s.session.clone());
+                        return Action::Attach(s.socket_path.clone(), s.session.clone());
                     }
                     // Q2 (approved): stale stays focusable but Enter does
                     // not attach — the socket isn't connectable.
@@ -160,30 +284,70 @@ fn handle_key(
                         "{} is unreachable (socket not connectable) — cannot attach",
                         s.session
                     );
-                    return Handled::Redraw;
+                    return Action::Redraw;
                 }
             }
-            Handled::Continue
+            Action::None
         }
-        KeyCode::Esc | KeyCode::Char('q') => Handled::Quit,
-        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => Handled::CtrlC,
-        // Claims 3-7 add x (kill focused), s (kill stale), n (new), r (rename stub).
-        _ => Handled::Continue,
+        // Claim 3: kill focused. `x` (not `k`) — k is 'navigate up' per
+        // cmux USAGE ("h/j/k/l move focus") and matches the whole codebase.
+        KeyCode::Char('x') => {
+            if let Some(i) = selected {
+                if let Some(s) = sessions.get(i) {
+                    *mode = Mode::ConfirmKill { index: i, name: s.session.clone() };
+                    return Action::Redraw;
+                }
+            }
+            Action::None
+        }
+        // Claim 4: kill all stale.
+        KeyCode::Char('s') => {
+            let count = sessions.iter().filter(|s| !s.live).count();
+            if count == 0 {
+                *status = "no stale sessions to clean".to_string();
+                Action::Redraw
+            } else {
+                *mode = Mode::ConfirmKillStale { count };
+                Action::Redraw
+            }
+        }
+        // Claim 5: new session (inline name prompt).
+        KeyCode::Char('n') => {
+            *mode = Mode::NewSession(TextInput::new(String::new()));
+            Action::Redraw
+        }
+        // Claim 7: rename stub (Q1: stub message; L2 swap-in, no UX change).
+        KeyCode::Char('r') => {
+            *status = "rename not yet available — coming in L2 (rename-session)".to_string();
+            Action::Redraw
+        }
+        KeyCode::Esc | KeyCode::Char('q') => Action::Quit,
+        _ => Action::None,
     }
 }
 
 /// Apply an up/down move, returning Redraw iff the selection changed.
-fn move_cursor(state: &mut ListState, selected: Option<usize>, len: usize, down: bool) -> Handled {
+fn move_cursor(state: &mut ListState, selected: Option<usize>, len: usize, down: bool) -> Action {
     if len == 0 {
-        return Handled::Continue;
+        return Action::None;
     }
     let i = selected.unwrap_or(0);
     let next = if down { i + 1 } else { i.saturating_sub(1) };
     if next >= len || next == i {
-        Handled::Continue
+        Action::None
     } else {
         state.select(Some(next));
-        Handled::Redraw
+        Action::Redraw
+    }
+}
+
+/// After a kill shrinks the list, keep a sensible focus (same index clamped,
+/// or the new last item) so the user isn't dropped to the top every time.
+fn destructive_select(state: &mut ListState, sessions: &[DiscoveredSession], was: usize) {
+    if sessions.is_empty() {
+        state.select(None);
+    } else {
+        state.select(Some(was.min(sessions.len() - 1)));
     }
 }
 
@@ -193,6 +357,22 @@ fn refresh(global: &GlobalArgs) -> Vec<DiscoveredSession> {
     let mut sessions = cli::discover_sessions(global);
     sessions.sort_by(|a, b| b.mtime.cmp(&a.mtime));
     sessions
+}
+
+/// Kill every stale session (reuses the cli kill-stale semantics) and return
+/// how many were cleaned. Mirrors `run_kill_stale` but without JSON output.
+fn kill_stale(global: &GlobalArgs) -> usize {
+    let mut sessions = cli::discover_sessions(global);
+    sessions.sort_by(|a, b| a.session.cmp(&b.session));
+    let mut cleaned = 0;
+    for s in &sessions {
+        if !s.live {
+            let _ = std::fs::remove_file(&s.socket_path);
+            let _ = std::fs::remove_file(mux_core::server::pid_path(&s.socket_path));
+            cleaned += 1;
+        }
+    }
+    cleaned
 }
 
 fn clamp_selection(state: &mut ListState, sessions: &[DiscoveredSession]) {
@@ -208,11 +388,12 @@ fn draw(
     state: &mut ListState,
     sessions: &[DiscoveredSession],
     status: &str,
+    mode: &mut Mode,
 ) -> io::Result<()> {
     terminal.draw(|f| {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Min(3), Constraint::Length(2)])
+            .constraints([Constraint::Min(3), Constraint::Length(3)])
             .split(f.area());
 
         let items: Vec<ListItem> = sessions
@@ -230,7 +411,7 @@ fn draw(
             })
             .collect();
         let title = if sessions.is_empty() {
-            " cmux sessions — none found (q to quit) "
+            " cmux sessions — none found (n new, q to quit) "
         } else {
             " cmux sessions — pick one to attach "
         };
@@ -240,9 +421,40 @@ fn draw(
             .highlight_symbol("▶ ");
         f.render_stateful_widget(list, chunks[0], state);
 
-        // Footer: keymap hints on row 1, transient status (if any) on row 2.
-        let hints = "↑/↓ or j/k move · Enter attach · q/Esc quit · Ctrl-C abort";
-        let mut lines = vec![Line::from(hints)];
+        // Footer: mode prompt (if any) on row 1, keymap hints + status on row 2.
+        let mut lines = Vec::new();
+        match mode {
+            Mode::Browse => {
+                lines.push(Line::from(Span::styled(
+                    "↑/↓ or j/k move · Enter attach · x kill · s kill-stale · n new · r rename · q/Esc quit · Ctrl-C abort",
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
+            Mode::ConfirmKill { name, .. } => {
+                lines.push(Line::from(Span::styled(
+                    format!("Kill {name}?  y/N  (any other key cancels)"),
+                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                )));
+            }
+            Mode::ConfirmKillStale { count } => {
+                lines.push(Line::from(Span::styled(
+                    format!("Kill {count} stale session(s)?  y/N  (any other key cancels)"),
+                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                )));
+            }
+            Mode::NewSession(input) => {
+                // visible_text_and_cursor takes &mut self (it lazily
+                // recomputes scroll); `input` is &mut via the &mut Mode.
+                let (visible, cur) = input.visible_text_and_cursor(chunks[1].width as usize);
+                let mut spans =
+                    vec![Span::styled("new session name: ", Style::default().fg(Color::Cyan))];
+                spans.push(Span::raw(visible.clone()));
+                if cur < visible.len() {
+                    spans.push(Span::raw(visible[cur..].to_string()));
+                }
+                lines.push(Line::from(spans));
+            }
+        }
         if !status.is_empty() {
             lines.push(Line::from(Span::styled(
                 status,

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -1076,6 +1076,144 @@ fn kill_stale_removes_stale_pair_and_leaves_live_untouched() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// `cmux attach --session-list --json` lists discovered sessions with a
+/// `socket_path` per entry (issue #63, layer L1). Same shape as
+/// `list-sessions --json` plus `socket_path`; exit 0. Modelled on
+/// `list_sessions_lists_active_headless_session` (:904).
+#[test]
+fn attach_session_list_json_includes_socket_path() {
+    let dir = unique_temp_dir("attach-sl");
+    fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("test-attach.sock");
+    let mut child = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let pid_file = dir.join("test-attach.pid");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if socket.exists() && pid_file.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(socket.exists(), "socket must exist");
+    assert!(pid_file.exists(), "pid file must exist");
+
+    let output = Command::new(bin())
+        .args(["attach", "--session-list", "--json", "--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let sessions = value["sessions"].as_array().expect("sessions array");
+    let entry = sessions
+        .iter()
+        .find(|s| s["session"] == "test-attach")
+        .expect("sessions should contain test-attach");
+    assert_eq!(entry["status"], "live", "test-attach should be live, got {entry}");
+    let sp = entry["socket_path"].as_str().expect("socket_path field");
+    assert!(
+        sp.ends_with("test-attach.sock"),
+        "socket_path should end with test-attach.sock, got {sp}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Stale entries (dead pidfile, unconnectable socket) appear with
+/// `status == "stale"` and a `socket_path`, alongside live entries.
+#[test]
+fn attach_session_list_json_marks_stale() {
+    let dir = unique_temp_dir("attach-sl-stale");
+    fs::create_dir_all(&dir).unwrap();
+    let live_socket = dir.join("live-att.sock");
+    let mut child = Command::new(bin())
+        .args(["--headless", "--socket"])
+        .arg(&live_socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let live_pid = dir.join("live-att.pid");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if live_socket.exists() && live_pid.exists() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(live_socket.exists());
+    assert!(live_pid.exists());
+
+    // Fake stale pair (nonexistent PID 999999, unconnectable socket).
+    let stale_socket = dir.join("stale-att.sock");
+    let stale_pid = dir.join("stale-att.pid");
+    fs::write(&stale_socket, "fake").unwrap();
+    fs::write(&stale_pid, "999999\n").unwrap();
+
+    let output = Command::new(bin())
+        .args(["attach", "--session-list", "--json", "--socket"])
+        .arg(&live_socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let sessions = value["sessions"].as_array().expect("sessions array");
+    let stale = sessions
+        .iter()
+        .find(|s| s["session"] == "stale-att")
+        .expect("sessions should contain stale-att");
+    assert_eq!(stale["status"], "stale", "stale-att should be stale, got {stale}");
+    let stale_sp = stale["socket_path"].as_str().expect("socket_path field");
+    assert!(stale_sp.ends_with("stale-att.sock"));
+    let live = sessions
+        .iter()
+        .find(|s| s["session"] == "live-att")
+        .expect("sessions should contain live-att");
+    assert_eq!(live["status"], "live");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// An empty runtime dir yields `{"sessions":[]}` and exit 0.
+#[test]
+fn attach_session_list_json_empty() {
+    let dir = unique_temp_dir("attach-sl-empty");
+    fs::create_dir_all(&dir).unwrap();
+    // Point --socket at a path inside the empty dir; discovery scans the
+    // parent (the dir) and finds no *.sock.
+    let socket = dir.join("nothing.sock");
+    let output = Command::new(bin())
+        .args(["attach", "--session-list", "--json", "--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", &dir)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&output);
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let sessions = value["sessions"].as_array().expect("sessions array");
+    assert!(sessions.is_empty(), "expected no sessions, got {sessions:?}");
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn serve_recovers_from_stale_socket() {
     let dir = unique_temp_dir("recover-stale");


### PR DESCRIPTION
## What

Layer 1 of issue #63: interactive session picker via `cmux attach --session-list`.

- New `session_picker.rs` module (477 lines): fzf-style picker over live sessions
- `cmux attach --session-list --json` for scripting
- Kill / stale-sweep / new-session / rename actions in the picker
- 3 new tests in `tests/cli.rs` (scaffold committed first per Rule 5 TDD)

## Chain evidence

- Build: `cargo test -p mux-tui --test cli` → 28 passed / 0 failed (3 new)
- Review: LGTM — 0 P0, 0 P1, 3 P2 follow-ups (cosmetic, filed for later)
- Verify: PASS across 3 specialists, cross-model-family (Kimi K3 256k ×2 + MiniMax M3)
- TDD ordering verified: `6b1ba63` (tests only) precedes `14d07a4` (impl)

## Notes

- DeepSeek tier-C quota exhausted on both routes (~23h reset) — verify station
  substituted B/S-tier models; no code impact
- P2 follow-ups from review: duplicated kill-stale loop, picker exit-code reuse,
  `--json` without `--session-list` silently ignored — all non-blocking

Closes nothing yet — L2 (rename-session) and L3 (in-TUI overlay) ship separately.