### PR TITLE
feat(mux-tui): cmux rename-session (issue #63 L2)

### DIFF
--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -2,6 +2,7 @@
 //! and broadcasts [`MuxEvent`]s to subscribed frontends.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
@@ -83,7 +84,16 @@ pub struct Mux {
     /// `Mux` a test or one-shot CLI invocation creates would write a
     /// session file to the real `$XDG_STATE_HOME`.
     persistence_enabled: std::sync::atomic::AtomicBool,
-    pub session: String,
+    /// Logical session name. Interior-mutable because a running daemon is
+    /// shared across the accept/conn/persist threads (`Arc<Mux>`) and can
+    /// be renamed in place by the `rename-session` command (issue #63).
+    /// Use [`session_name`](Self::session_name) to read it.
+    session: Mutex<String>,
+    /// The daemon's currently-bound control-socket path: the single source
+    /// of truth read at shutdown (`cleanup`) and at every surface spawn
+    /// (so panes spawned after a rename inherit the new `CMUX_MUX_SOCKET`).
+    /// `None` until `server::serve` calls [`set_socket_path`](Self::set_socket_path).
+    socket_path: Mutex<Option<PathBuf>>,
 }
 
 impl Mux {
@@ -107,8 +117,40 @@ impl Mux {
             default_colors: Mutex::new(DefaultColors::default()),
             resolved_chrome: Mutex::new(None),
             persistence_enabled: std::sync::atomic::AtomicBool::new(false),
-            session,
+            session: Mutex::new(session),
+            socket_path: Mutex::new(None),
         })
+    }
+
+    /// The logical session name (cloned; cheap vs. a JSON encode). Renamed
+    /// in place by `rename-session` (issue #63).
+    pub fn session_name(&self) -> String {
+        self.session.lock().unwrap().clone()
+    }
+
+    /// The daemon's currently-bound control-socket path, or `None` before
+    /// `server::serve` has bound. The single source of truth for the live
+    /// socket location (moves on rename).
+    pub fn socket_path(&self) -> Option<PathBuf> {
+        self.socket_path.lock().unwrap().clone()
+    }
+
+    /// Record the bound socket path. Called by `server::serve` immediately
+    /// after a successful `transport::listen` (before the accept thread
+    /// spawns, so the value is set before any client can connect).
+    pub(crate) fn set_socket_path(&self, path: PathBuf) {
+        *self.socket_path.lock().unwrap() = Some(path);
+    }
+
+    /// Update the `CMUX_MUX_SOCKET` entry in a cloned `SurfaceOptions` so a
+    /// newly-spawned pane inherits the daemon's *current* live socket path
+    /// (not the stale startup path). Existing panes keep whatever they
+    /// inherited at spawn — this is the AC4 lifetime guarantee (issue #63).
+    fn refresh_socket_env(&self, opts: &mut SurfaceOptions) {
+        if let Some(p) = self.socket_path() {
+            opts.extra_env.retain(|(k, _)| k != "CMUX_MUX_SOCKET");
+            opts.extra_env.push(("CMUX_MUX_SOCKET".into(), p.display().to_string()));
+        }
     }
 
     fn next_id(&self) -> u64 {
@@ -175,7 +217,8 @@ impl Mux {
         size: Option<(u16, u16)>,
     ) -> Arc<Surface> {
         let id = self.next_id();
-        let opts = self.surface_options.clone();
+        let mut opts = self.surface_options.clone();
+        self.refresh_socket_env(&mut opts);
         let size = size.unwrap_or((opts.cols, opts.rows));
         let cell_pixels = *self.cell_pixels.lock().unwrap();
         let surface = browser::new_surface(id, url.clone(), size, cell_pixels, &opts);
@@ -274,7 +317,7 @@ impl Mux {
     }
 
     fn snapshot_path(&self) -> std::path::PathBuf {
-        crate::platform::session_snapshot_path(&self.session)
+        crate::platform::session_snapshot_path(&self.session_name())
     }
 
     fn write_snapshot(&self) {
@@ -817,7 +860,8 @@ impl Mux {
             (pane_id, size)
         };
         let id = self.next_id();
-        let opts = self.surface_options.clone();
+        let mut opts = self.surface_options.clone();
+        self.refresh_socket_env(&mut opts);
         let size = size.unwrap_or((opts.cols, opts.rows));
         let cell_pixels = *self.cell_pixels.lock().unwrap();
         let surface = browser::new_surface(id, url.clone(), size, cell_pixels, &opts);

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -142,6 +142,12 @@ impl Mux {
         *self.socket_path.lock().unwrap() = Some(path);
     }
 
+    /// Update the logical session name. Called by the `rename-session`
+    /// handler after the socket/pid files have moved (issue #63).
+    pub(crate) fn set_session_name(&self, name: String) {
+        *self.session.lock().unwrap() = name;
+    }
+
     /// Update the `CMUX_MUX_SOCKET` entry in a cloned `SurfaceOptions` so a
     /// newly-spawned pane inherits the daemon's *current* live socket path
     /// (not the stale startup path). Existing panes keep whatever they

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -185,6 +185,10 @@ impl Mux {
     ) -> anyhow::Result<Arc<Surface>> {
         let id = self.next_id();
         let mut opts = self.surface_options.clone();
+        // New panes inherit the daemon's *current* live socket path (issue #63
+        // AC4): existing panes keep what they got at spawn; panes spawned
+        // after a rename get the new path.
+        self.refresh_socket_env(&mut opts);
         if cwd.is_some() {
             opts.cwd = cwd;
         }
@@ -207,6 +211,7 @@ impl Mux {
     ) -> anyhow::Result<Arc<Surface>> {
         let id = self.next_id();
         let mut opts = self.surface_options.clone();
+        self.refresh_socket_env(&mut opts);
         opts.remote = Some(remote);
         if let Some((cols, rows)) = size {
             opts.cols = cols.max(1);

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -545,7 +545,7 @@ pub fn serve(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     // handler mutates and that cleanup/spawn read (issue #63). Set before
     // the accept thread spawns so it is visible to any client connection.
     mux.set_socket_path(path.clone());
-    platform::restrict_file(&path)?;;
+    platform::restrict_file(&path)?;
 
     std::fs::write(&pid_p, format!("{}\n", std::process::id()))?;
     platform::restrict_file(&pid_p)?;
@@ -1322,9 +1322,9 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             validate_session_name(&new_name)?;
 
             let old_name = mux.session_name();
-            let old_sock = mux
-                .socket_path()
-                .ok_or_else(|| anyhow::anyhow!("rename-session issued before the socket was bound"))?;
+            let old_sock = mux.socket_path().ok_or_else(|| {
+                anyhow::anyhow!("rename-session issued before the socket was bound")
+            })?;
             let parent = old_sock
                 .parent()
                 .ok_or_else(|| anyhow::anyhow!("socket path has no parent directory"))?;
@@ -1528,12 +1528,10 @@ mod tests {
     #[test]
     fn unix_socket_survives_rename() {
         use std::os::unix::net::{UnixListener, UnixStream};
-        let stamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let dir = std::env::temp_dir()
-            .join(format!("cmux-t0-rename-{}-{stamp}", std::process::id()));
+        let stamp =
+            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("cmux-t0-rename-{}-{stamp}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let old = dir.join("old.sock");
         let new = dir.join("new.sock");
@@ -1547,13 +1545,12 @@ mod tests {
             "old socket path should not be connectable after rename"
         );
         // The new dirent resolves to the same bound inode -> connectable.
-        let client = UnixStream::connect(&new)
-            .expect("new socket path should be connectable after rename");
+        let client =
+            UnixStream::connect(&new).expect("new socket path should be connectable after rename");
         // The listener (bound to the inode, not the dirent) still accepts
         // the connection that arrived at the new path.
-        let (_accepted, _addr) = listener
-            .accept()
-            .expect("listener must accept a connection after the rename");
+        let (_accepted, _addr) =
+            listener.accept().expect("listener must accept a connection after the rename");
 
         drop(client);
         drop(listener);
@@ -1567,25 +1564,11 @@ mod tests {
         // chars, `.`, `..`, leading/trailing whitespace and overlong names
         // must be rejected; ordinary names (incl. unicode) accepted.
         for good in ["main", "foo-bar", "a_b", "café", "session.number"] {
-            assert!(
-                validate_session_name(good).is_ok(),
-                "{good:?} should be a valid session name"
-            );
+            assert!(validate_session_name(good).is_ok(), "{good:?} should be a valid session name");
         }
         let overlong = "a".repeat(256);
-        for bad in [
-            "",
-            "a/b",
-            "a\\b",
-            "..",
-            ".",
-            " foo",
-            "foo ",
-            "\0",
-            "a\u{1}b",
-            "\t",
-            &overlong,
-        ] {
+        for bad in ["", "a/b", "a\\b", "..", ".", " foo", "foo ", "\0", "a\u{1}b", "\t", &overlong]
+        {
             assert!(
                 validate_session_name(bad).is_err(),
                 "{bad:?} should be rejected as a session name"

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -1350,9 +1350,14 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                 .map_err(|e| anyhow::anyhow!("rename failed: {e}"))?;
             // Q4.4: rename the socket — the COMMIT point. From here the daemon
             // is reachable only at new_sock (the listener, bound to the inode,
-            // keeps accepting there: see unix_socket_survives_rename).
-            std::fs::rename(&old_sock, &new_sock)
-                .map_err(|e| anyhow::anyhow!("rename failed: {e}"))?;
+            // keeps accepting there: see unix_socket_survives_rename). If this
+            // rename fails (near-impossible: same FS, adjacent syscalls) we
+            // undo the pid move above so the pre-rename fs state is exactly
+            // restored (old.sock bound, old.pid present, no `new.*` artefacts).
+            if let Err(e) = std::fs::rename(&old_sock, &new_sock) {
+                let _ = std::fs::rename(&new_pid, &old_pid);
+                return Err(anyhow::anyhow!("rename failed: {e}"));
+            }
 
             // Q4.5: update state (logical name + canonical socket path).
             mux.set_session_name(new_name.clone());

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -17,6 +17,31 @@
 //! {"id":1,"cmd":"identify"}
 //! {"id":1,"ok":true,"data":{"app":"cmux","session":"main",...}}
 //! ```
+//!
+//! ## `rename-session` (issue #63)
+//!
+//! `cmux rename-session --old X --new Y` connects to the `X` socket and
+//! sends `{"cmd":"rename-session","new_name":"Y"}`. The daemon renames
+//! THIS session in place: `rename(2)` the `.sock` and `.pid` to the new
+//! names, flip `Mux.session`, reparent the snapshot file, and keep serving.
+//! The listener **never rebinds**: on a bound `AF_UNIX` `SOCK_STREAM`
+//! socket, `rename(2)` reparents the dirent while the kernel keeps the
+//! listener bound to the inode (pinned by `unix_socket_survives_rename`),
+//! so the daemon stays reachable only at the new path.
+//!
+//! Ordering: pid file moves first; the socket rename is the commit point
+//! (only it changes reachability), so a pid-rename failure bails before
+//! anything is committed. Partial failure is self-healing. A LIVE target
+//! is refused (`session "Y" already exists`); a STALE target is cleared.
+//!
+//! **Lifetime guarantee (AC4):** existing panes keep the `CMUX_MUX_SOCKET`
+//! they inherited at spawn (the old path) for their lifetime — this is
+//! intentional, not a bug. Panes spawned AFTER the rename inherit the new
+//! path (`Mux::refresh_socket_env` rewrites the env on every spawn from
+//! `socket_path()`, the single source of truth). The startup-path socket
+//! watchdog still points at the original path; a SIGKILL after rename is
+//! handled by the next `serve()` stale-clear / `kill-stale` (an L3
+//! follow-up can respawn the watchdog for the new path).
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
@@ -107,15 +132,34 @@ pub fn is_session_socket_live(socket_path: &Path) -> bool {
     true
 }
 
-/// Reject session names that are unsafe as filesystem path components
-/// (the name becomes `<name>.sock` / `<name>.pid` /
-/// `<name>.json`). SECURITY: a `/` or `\0` is a path-traversal /
-/// NUL-injection vector (AGENTS.md review checklist).
-///
-/// RED-suite compile scaffolding (issue #63 L2, commit 2): this stub
-/// accepts everything so the T12 table test is RED. The real
-/// validation lands in the `feat(mux-core)` commit and turns T12 green.
-pub fn validate_session_name(_name: &str) -> anyhow::Result<()> {
+/// Reject session names that are unsafe as filesystem path components.
+/// The name becomes `<name>.sock` / `<name>.pid` /
+/// `$XDG_STATE_HOME/cmux/sessions/<name>.json`, so a `/` or `\0` is a
+/// path-traversal / NUL-injection vector (AGENTS.md review checklist).
+/// Called from BOTH the CLI (`run_rename_session`, client-side defence)
+/// and the server (`RenameSession` handler, the security authority).
+pub fn validate_session_name(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() {
+        anyhow::bail!("session name cannot be empty");
+    }
+    if name.contains('/') || name.contains('\\') {
+        anyhow::bail!("session name cannot contain a path separator");
+    }
+    if name.contains('\0') {
+        anyhow::bail!("session name cannot contain NUL");
+    }
+    if name.chars().any(|c| c.is_control()) {
+        anyhow::bail!("session name cannot contain control characters");
+    }
+    if name != name.trim() {
+        anyhow::bail!("session name cannot have leading/trailing whitespace");
+    }
+    if matches!(name, "." | "..") {
+        anyhow::bail!("session name cannot be \".\" or \"..\"");
+    }
+    if name.len() > 255 {
+        anyhow::bail!("session name too long (max 255)");
+    }
     Ok(())
 }
 
@@ -433,6 +477,22 @@ enum Command {
         surface: Option<SurfaceId>,
         #[serde(default)]
         state: Option<String>,
+    },
+    /// Rename THIS daemon's session (issue #63): atomically move its
+    /// `.sock`/`.pid` to the new name, update the logical session name,
+    /// and best-effort reparent the persisted snapshot file. The listener
+    /// keeps accepting at the NEW path — `rename(2)` on a bound `AF_UNIX`
+    /// socket reparents the dirent while the kernel keeps the listener
+    /// bound to the inode (pinned by the `unix_socket_survives_rename`
+    /// unit test), so the daemon never rebinds. Carries only `new_name`:
+    /// the daemon is authoritative about its own identity. Issued by
+    /// `cmux rename-session --old X --new Y` after the CLI has connected
+    /// to the old socket. Backward compatible (no protocol-version bump):
+    /// old servers hit serde's unknown-variant path; the attach client
+    /// never emits it. Response:
+    /// `{"session":"bar","socket_path":"...","pid":<daemon-pid>}`.
+    RenameSession {
+        new_name: String,
     },
 }
 
@@ -1250,6 +1310,74 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                 .map(|(id, report)| agent_report_json(*id, report))
                 .collect::<Vec<_>>();
             Ok(json!({ "agents": agents }))
+        }
+        Command::RenameSession { new_name } => {
+            // Issue #63. Scout-plan Q4 ordering: the socket rename is the
+            // commit point (only it changes reachability), so the pid moves
+            // FIRST — if that fails we bail before touching the socket and
+            // nothing is committed. Partial failure is self-healing (Q4).
+            //
+            // Q4.1: validate (server is the security authority; the CLI also
+            // pre-validates for defence in depth).
+            validate_session_name(&new_name)?;
+
+            let old_name = mux.session_name();
+            let old_sock = mux
+                .socket_path()
+                .ok_or_else(|| anyhow::anyhow!("rename-session issued before the socket was bound"))?;
+            let parent = old_sock
+                .parent()
+                .ok_or_else(|| anyhow::anyhow!("socket path has no parent directory"))?;
+            let new_sock = parent.join(format!("{new_name}.sock"));
+            let old_pid = pid_path(&old_sock);
+            let new_pid = pid_path(&new_sock);
+
+            // Q4.2: resolve + clear target. Refuse a LIVE target; clobber a
+            // stale one (mirrors serve()'s stale-clear policy).
+            if is_session_socket_live(&new_sock) {
+                anyhow::bail!("session {new_name:?} already exists");
+            }
+            if new_sock.exists() {
+                let _ = std::fs::remove_file(&new_sock);
+            }
+            if new_pid.exists() {
+                let _ = std::fs::remove_file(&new_pid);
+            }
+
+            // Q4.3: rename the pid file first. If this fails, bail before the
+            // socket rename commits — old state stays fully intact.
+            std::fs::rename(&old_pid, &new_pid)
+                .map_err(|e| anyhow::anyhow!("rename failed: {e}"))?;
+            // Q4.4: rename the socket — the COMMIT point. From here the daemon
+            // is reachable only at new_sock (the listener, bound to the inode,
+            // keeps accepting there: see unix_socket_survives_rename).
+            std::fs::rename(&old_sock, &new_sock)
+                .map_err(|e| anyhow::anyhow!("rename failed: {e}"))?;
+
+            // Q4.5: update state (logical name + canonical socket path).
+            mux.set_session_name(new_name.clone());
+            mux.set_socket_path(new_sock.clone());
+
+            // Q4.6: best-effort reparent of the persisted snapshot. If we only
+            // flipped Mux.session, the next write_snapshot would target the
+            // new path while the old file orphaned, and restore_session on a
+            // fresh `bar` start would find nothing (silent data loss across
+            // rename+restart). Benign race with the debounced persist writer
+            // (it reads Mux.session post-update, so at worst rewrites the new
+            // file with the same tree).
+            let old_snap = platform::session_snapshot_path(&old_name);
+            let new_snap = platform::session_snapshot_path(&new_name);
+            if old_snap.exists() {
+                let _ = std::fs::remove_file(&new_snap);
+                let _ = std::fs::rename(&old_snap, &new_snap);
+            }
+
+            // Q4.7/Q2: response. `pid` proves the same daemon keeps serving.
+            Ok(json!({
+                "session": new_name,
+                "socket_path": new_sock,
+                "pid": std::process::id(),
+            }))
         }
         Command::Subscribe => {
             let events = mux.subscribe();

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -463,7 +463,7 @@ impl LineWriter {
 
 /// Bind the socket and serve connections on background threads.
 pub fn serve(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
-    let path = path.unwrap_or_else(|| default_socket_path(&mux.session));
+    let path = path.unwrap_or_else(|| default_socket_path(&mux.session_name()));
     if let Some(dir) = path.parent() {
         std::fs::create_dir_all(dir)?;
         platform::restrict_directory(dir)?;
@@ -481,7 +481,11 @@ pub fn serve(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
         let _ = std::fs::remove_file(&pid_p);
     }
     let listener = transport::listen(&path)?;
-    platform::restrict_file(&path)?;
+    // Record the bound socket path as the single source of truth the rename
+    // handler mutates and that cleanup/spawn read (issue #63). Set before
+    // the accept thread spawns so it is visible to any client connection.
+    mux.set_socket_path(path.clone());
+    platform::restrict_file(&path)?;;
 
     std::fs::write(&pid_p, format!("{}\n", std::process::id()))?;
     platform::restrict_file(&pid_p)?;
@@ -887,7 +891,7 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             "app": "cmux",
             "version": env!("CARGO_PKG_VERSION"),
             "protocol": PROTOCOL_VERSION,
-            "session": mux.session,
+            "session": mux.session_name(),
             "pid": std::process::id(),
         })),
         Command::ListWorkspaces => Ok(mux.with_state(workspaces_json)),

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -1372,6 +1372,50 @@ pub fn cleanup(path: &Path) {
 mod tests {
     use super::*;
 
+    /// Foundation pin for `cmux rename-session` (issue #63 L2, scout-plan
+    /// Q1). On a bound `AF_UNIX` `SOCK_STREAM` listener, `rename(2)`
+    /// reparents the dirent while the kernel keeps the listener bound to
+    /// the inode. The listener therefore keeps accepting at the NEW path
+    /// and the OLD path ceases to be connectable. The rename-session
+    /// daemon mechanism relies on this — it never rebinds, it just
+    /// `rename(2)`s the `.sock`. This test pins the kernel property so a
+    /// future platform or libc quirk can't silently regress the whole
+    /// feature.
+    #[test]
+    fn unix_socket_survives_rename() {
+        use std::os::unix::net::{UnixListener, UnixStream};
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir()
+            .join(format!("cmux-t0-rename-{}-{stamp}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let old = dir.join("old.sock");
+        let new = dir.join("new.sock");
+
+        let listener = UnixListener::bind(&old).unwrap();
+        std::fs::rename(&old, &new).unwrap();
+
+        // The old dirent is gone -> connecting there must fail.
+        assert!(
+            UnixStream::connect(&old).is_err(),
+            "old socket path should not be connectable after rename"
+        );
+        // The new dirent resolves to the same bound inode -> connectable.
+        let client = UnixStream::connect(&new)
+            .expect("new socket path should be connectable after rename");
+        // The listener (bound to the inode, not the dirent) still accepts
+        // the connection that arrived at the new path.
+        let (_accepted, _addr) = listener
+            .accept()
+            .expect("listener must accept a connection after the rename");
+
+        drop(client);
+        drop(listener);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     #[test]
     fn workspace_color_accepts_hex_and_named_presets() {
         assert_eq!(parse_workspace_color("#1234ab").unwrap(), Rgb { r: 0x12, g: 0x34, b: 0xab });

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -107,6 +107,18 @@ pub fn is_session_socket_live(socket_path: &Path) -> bool {
     true
 }
 
+/// Reject session names that are unsafe as filesystem path components
+/// (the name becomes `<name>.sock` / `<name>.pid` /
+/// `<name>.json`). SECURITY: a `/` or `\0` is a path-traversal /
+/// NUL-injection vector (AGENTS.md review checklist).
+///
+/// RED-suite compile scaffolding (issue #63 L2, commit 2): this stub
+/// accepts everything so the T12 table test is RED. The real
+/// validation lands in the `feat(mux-core)` commit and turns T12 green.
+pub fn validate_session_name(_name: &str) -> anyhow::Result<()> {
+    Ok(())
+}
+
 #[derive(Deserialize)]
 struct Request {
     id: Option<Value>,
@@ -1414,6 +1426,39 @@ mod tests {
         drop(client);
         drop(listener);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn validate_session_name_table() {
+        // Issue #63 L2 (scout-plan Q6/T12): names become filesystem paths
+        // (`<name>.sock`/`<name>.pid`/`<name>.json`), so `/`, `\0`, control
+        // chars, `.`, `..`, leading/trailing whitespace and overlong names
+        // must be rejected; ordinary names (incl. unicode) accepted.
+        for good in ["main", "foo-bar", "a_b", "café", "session.number"] {
+            assert!(
+                validate_session_name(good).is_ok(),
+                "{good:?} should be a valid session name"
+            );
+        }
+        let overlong = "a".repeat(256);
+        for bad in [
+            "",
+            "a/b",
+            "a\\b",
+            "..",
+            ".",
+            " foo",
+            "foo ",
+            "\0",
+            "a\u{1}b",
+            "\t",
+            &overlong,
+        ] {
+            assert!(
+                validate_session_name(bad).is_err(),
+                "{bad:?} should be rejected as a session name"
+            );
+        }
     }
 
     #[test]

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -1124,7 +1124,6 @@ fn rename_rpc(socket: &std::path::Path, new_name: &str) -> RenameOutcome {
 /// Send `rename-session` to the daemon bound at `socket_path` and return
 /// the new socket path on success. Shared by the picker's `r` flow so the
 /// TUI keybinding and the CLI verb exercise one code path (`rename_rpc`).
-#[allow(dead_code)] // wired by the picker 'r' flow (next commit); unused until then.
 pub(crate) fn rename_session_at(
     socket_path: &std::path::Path,
     new_name: &str,

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -1102,16 +1102,13 @@ fn rename_rpc(socket: &std::path::Path, new_name: &str) -> RenameOutcome {
         }
         if value.get("ok").and_then(Value::as_bool) == Some(true) {
             let data = value.get("data").unwrap_or(&Value::Null);
-            let socket_path = data
-                .get("socket_path")
-                .and_then(Value::as_str)
-                .map(PathBuf::from);
+            let socket_path = data.get("socket_path").and_then(Value::as_str).map(PathBuf::from);
             let pid = data.get("pid").and_then(Value::as_u64);
             match (socket_path, pid) {
                 (Some(p), Some(pid)) => return RenameOutcome::Ok { socket_path: p, pid },
                 _ => {
                     return RenameOutcome::ServerErr(
-                        "rename response missing socket_path/pid".into()
+                        "rename response missing socket_path/pid".into(),
                     )
                 }
             }
@@ -1530,8 +1527,7 @@ mod tests {
     #[test]
     fn rename_session_at_renames_via_socket() {
         let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        let dir = PathBuf::from("/tmp")
-            .join(format!("cmux-t11-{}-{stamp}", std::process::id()));
+        let dir = PathBuf::from("/tmp").join(format!("cmux-t11-{}-{stamp}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let old_sock = dir.join("old.sock");
 

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -336,6 +336,17 @@ const VERBS: &[VerbSpec] = &[
         print: print_empty,
         stream: false,
     },
+    // `rename-session` is special-cased in `run_command` (it does its own
+    // socket discovery + connect + exit-code map, like list/kill-session).
+    // The VerbSpec exists so `verb_by_name` recognises it during arg
+    // parsing; `build_rename_session` only carries the flags.
+    VerbSpec {
+        name: "rename-session",
+        allowed: &["old", "new"],
+        build: build_rename_session,
+        print: print_empty,
+        stream: false,
+    },
 ];
 
 pub fn is_cli_invocation(args: &[String]) -> bool {
@@ -450,6 +461,7 @@ fn run_command(args: CliArgs) -> i32 {
         "list-sessions" => return run_list_sessions(&args.global, &args.flags),
         "kill-session" => return run_kill_session(&args.global, &args.flags),
         "kill-stale" => return run_kill_stale(&args.global, &args.flags),
+        "rename-session" => return run_rename_session(&args.global, &args.flags),
         _ => {}
     }
     let request = match (args.verb.build)(&args.flags) {
@@ -848,6 +860,17 @@ fn build_kill_session(flags: &FlagMap) -> Result<Value, UsageError> {
     Ok(value)
 }
 
+/// `rename-session` parser: carry the `--old`/`--new` flags. The real
+/// connect/send (and CLI-side name validation + exit-code map) live in
+/// `run_rename_session`, which is special-cased in `run_command` like
+/// the other name-keyed verbs (list/kill-session/kill-stale).
+fn build_rename_session(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_string(&mut value, "old");
+    flags.insert_optional_string(&mut value, "new");
+    Ok(value)
+}
+
 pub(crate) fn get_runtime_dir(global: &GlobalArgs) -> PathBuf {
     global
         .socket
@@ -1022,19 +1045,94 @@ pub(crate) fn kill_session_at(socket_path: &std::path::Path, pid: Option<u32>) -
     pid.is_some()
 }
 
+/// Outcome of a `rename-session` RPC. Distinguishes a transport failure
+/// (CLI exit 3) from a server-reported error (CLI exit 1) so the verb's
+/// exit-code table (scout-plan Q5) can map them separately. Shared by the
+/// CLI verb (`run_rename_session`) and the picker helper.
+enum RenameOutcome {
+    /// Server reported ok:true. Carries the new socket path and the
+    /// (unchanged) daemon pid from the response.
+    Ok { socket_path: PathBuf, pid: u64 },
+    /// Server reported ok:false (rename refused/failed) or a malformed reply.
+    ServerErr(String),
+    /// Could not (re)establish the socket connection or the transport died.
+    ConnectErr(String),
+}
+
+/// Connect to the daemon at `socket`, send `{"cmd":"rename-session",
+/// "new_name":new_name}`, and read one response (skipping any pushed
+/// events). Returns the parsed outcome. Used by both `run_rename_session`
+/// (CLI verb) and `rename_session_at` (picker helper) so they share one
+/// code path.
+fn rename_rpc(socket: &std::path::Path, new_name: &str) -> RenameOutcome {
+    let mut stream = match transport::connect(socket) {
+        Ok(stream) => stream,
+        Err(err) => {
+            return RenameOutcome::ConnectErr(format!(
+                "cannot connect to session socket {}: {err}",
+                socket.display()
+            ))
+        }
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+    let request = json!({ "cmd": "rename-session", "new_name": new_name, "id": REQUEST_ID });
+    let mut line = match serde_json::to_vec(&request) {
+        Ok(line) => line,
+        Err(err) => return RenameOutcome::ServerErr(format!("failed to encode request: {err}")),
+    };
+    line.push(b'\n');
+    if let Err(err) = stream.write_all(&line) {
+        return RenameOutcome::ConnectErr(format!("transport error: {err}"));
+    }
+    let mut reader = BufReader::new(stream);
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        match reader.read_line(&mut buf) {
+            Ok(0) => return RenameOutcome::ServerErr("transport closed before response".into()),
+            Ok(_) => {}
+            Err(err) => return RenameOutcome::ConnectErr(format!("transport error: {err}")),
+        }
+        let value: Value = match serde_json::from_str(&buf) {
+            Ok(value) => value,
+            Err(err) => return RenameOutcome::ServerErr(format!("bad response: {err}")),
+        };
+        if value.get("event").is_some() {
+            continue;
+        }
+        if value.get("ok").and_then(Value::as_bool) == Some(true) {
+            let data = value.get("data").unwrap_or(&Value::Null);
+            let socket_path = data
+                .get("socket_path")
+                .and_then(Value::as_str)
+                .map(PathBuf::from);
+            let pid = data.get("pid").and_then(Value::as_u64);
+            match (socket_path, pid) {
+                (Some(p), Some(pid)) => return RenameOutcome::Ok { socket_path: p, pid },
+                _ => {
+                    return RenameOutcome::ServerErr(
+                        "rename response missing socket_path/pid".into()
+                    )
+                }
+            }
+        }
+        let err = value.get("error").and_then(Value::as_str).unwrap_or("rename failed");
+        return RenameOutcome::ServerErr(err.to_string());
+    }
+}
+
 /// Send `rename-session` to the daemon bound at `socket_path` and return
 /// the new socket path on success. Shared by the picker's `r` flow so the
-/// TUI keybinding and the CLI verb exercise one code path.
-///
-/// RED-suite compile scaffolding (issue #63 L2, commit 2): this stub
-/// always errors so the T11 helper test is RED. The real connect/send
-/// lands in the `feat(mux-tui)` commit and turns T11 green.
-#[allow(dead_code)] // wired by the picker 'r' flow (commit 6); unused until then.
+/// TUI keybinding and the CLI verb exercise one code path (`rename_rpc`).
+#[allow(dead_code)] // wired by the picker 'r' flow (next commit); unused until then.
 pub(crate) fn rename_session_at(
-    _socket_path: &std::path::Path,
-    _new_name: &str,
+    socket_path: &std::path::Path,
+    new_name: &str,
 ) -> Result<PathBuf, String> {
-    Err("rename-session not yet implemented".to_string())
+    match rename_rpc(socket_path, new_name) {
+        RenameOutcome::Ok { socket_path, .. } => Ok(socket_path),
+        RenameOutcome::ServerErr(e) | RenameOutcome::ConnectErr(e) => Err(e),
+    }
 }
 
 fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
@@ -1078,6 +1176,79 @@ fn run_kill_stale(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
         println!("{}", json!({ "ok": true, "cleaned": cleaned }));
     }
     0
+}
+
+/// `cmux rename-session --old <name> --new <name>` (issue #63). Resolves
+/// the old session's socket the same way `kill-session` does (parent of
+/// `--socket`, else `runtime_dir()`), pre-checks the target, then connects
+/// and issues `rename-session`. Exit-code table (scout-plan Q5):
+///   0 success · 1 old not found / server ok:false · 2 bad/missing flags,
+///     invalid name, or target already live · 3 connect/transport failure.
+fn run_rename_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
+    // Parse --old/--new (UsageError -> exit 2).
+    let old = match flags.required("old") {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("cmux: {}", err.0);
+            return 2;
+        }
+    };
+    let new = match flags.required("new") {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("cmux: {}", err.0);
+            return 2;
+        }
+    };
+    // CLI-side name validation (defence in depth; exit 2 before connecting).
+    // The server re-validates as the security authority.
+    if let Err(err) = mux_core::server::validate_session_name(&new) {
+        eprintln!("cmux: {err}");
+        return 2;
+    }
+
+    let dir = get_runtime_dir(global);
+    let old_sock = dir.join(format!("{old}.sock"));
+    let old_pid = dir.join(format!("{old}.pid"));
+    let new_sock = dir.join(format!("{new}.sock"));
+
+    // Old session must be present (mirrors kill-session's not-found exit 1).
+    if !old_sock.exists() && !old_pid.exists() {
+        eprintln!("cmux: session {old:?} not found");
+        return 1;
+    }
+    // Criterion 5: refuse a LIVE target BEFORE connecting (exit 2). The
+    // server re-checks inside the handler to cover direct API use and the
+    // connect-vs-precheck race.
+    if mux_core::server::is_session_socket_live(&new_sock) {
+        eprintln!("cmux: session {new:?} already exists");
+        return 2;
+    }
+
+    match rename_rpc(&old_sock, &new) {
+        RenameOutcome::Ok { socket_path, pid } => {
+            if global.json {
+                println!(
+                    "{}",
+                    json!({
+                        "session": new,
+                        "socket_path": socket_path.display().to_string(),
+                        "pid": pid,
+                    })
+                );
+            }
+            // Plain mode is quiet, consistent with kill-session/rename-workspace.
+            0
+        }
+        RenameOutcome::ServerErr(err) => {
+            eprintln!("cmux: {err}");
+            1
+        }
+        RenameOutcome::ConnectErr(err) => {
+            eprintln!("{err}");
+            3
+        }
+    }
 }
 
 fn selector_request(flags: &FlagMap) -> Result<Value, UsageError> {

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -1197,10 +1197,14 @@ fn run_rename_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
         }
     };
     // CLI-side name validation (defence in depth; exit 2 before connecting).
-    // The server re-validates as the security authority.
-    if let Err(err) = mux_core::server::validate_session_name(&new) {
-        eprintln!("cmux: {err}");
-        return 2;
+    // The server re-validates as the security authority. Validate both the
+    // source (`--old`) and destination (`--new`) so a bad `--old` yields a
+    // clean "session name …" error instead of a cryptic "session not found".
+    for name in [&old, &new] {
+        if let Err(err) = mux_core::server::validate_session_name(name) {
+            eprintln!("cmux: {err}");
+            return 2;
+        }
     }
 
     let dir = get_runtime_dir(global);

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -1022,6 +1022,21 @@ pub(crate) fn kill_session_at(socket_path: &std::path::Path, pid: Option<u32>) -
     pid.is_some()
 }
 
+/// Send `rename-session` to the daemon bound at `socket_path` and return
+/// the new socket path on success. Shared by the picker's `r` flow so the
+/// TUI keybinding and the CLI verb exercise one code path.
+///
+/// RED-suite compile scaffolding (issue #63 L2, commit 2): this stub
+/// always errors so the T11 helper test is RED. The real connect/send
+/// lands in the `feat(mux-tui)` commit and turns T11 green.
+#[allow(dead_code)] // wired by the picker 'r' flow (commit 6); unused until then.
+pub(crate) fn rename_session_at(
+    _socket_path: &std::path::Path,
+    _new_name: &str,
+) -> Result<PathBuf, String> {
+    Err("rename-session not yet implemented".to_string())
+}
+
 fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
     let target_session = flags.optional("session").or_else(|| global.session.clone());
     let Some(session_name) = target_session else {
@@ -1322,5 +1337,53 @@ fn atom(value: Option<&Value>) -> String {
         Some(Value::String(text)) => serde_json::to_string(text).unwrap_or_default(),
         Some(Value::Null) | None => "null".to_string(),
         Some(value) => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for `cli` internals that a bin-only crate cannot expose to its
+    //! integration-test file (`tests/cli.rs` links only against `mux-core`
+    //! + the `cmux` binary, not `mux-tui`'s private modules). These unit
+    //! tests can call `pub(crate)` helpers directly and drive an in-process
+    //! `mux-core` server — no subprocess spawn needed.
+    use super::*;
+    use mux_core::{server, Mux, SurfaceOptions};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// AC7/picker (scout-plan T11): the non-TUI helper the picker's `r` flow
+    /// uses (`rename_session_at`) renames a live session over a direct socket
+    /// connection. Driven against an in-process `mux-core` server so no
+    // `CARGO_BIN_EXE_cmux` (unavailable to in-source unit tests of a bin
+    // crate) is needed. The accept thread outlives the assertion but dies
+    // with the test process; the temp socket is unique per run.
+    #[test]
+    fn rename_session_at_renames_via_socket() {
+        let stamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = PathBuf::from("/tmp")
+            .join(format!("cmux-t11-{}-{stamp}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let old_sock = dir.join("old.sock");
+
+        // In-process daemon on old.sock (session "old").
+        let mux = Mux::new("old", SurfaceOptions::default());
+        server::serve(mux, Some(old_sock.clone())).expect("serve should bind old.sock");
+
+        let new_sock =
+            rename_session_at(&old_sock, "bar").expect("rename_session_at should succeed");
+        assert!(new_sock.exists(), "returned new socket path should exist");
+        assert_eq!(
+            new_sock.file_name().and_then(|n| n.to_str()),
+            Some("bar.sock"),
+            "helper should return the new socket path"
+        );
+        assert!(server::is_session_socket_live(&new_sock));
+        assert!(!old_sock.exists(), "old socket should be gone after helper rename");
+
+        // Best-effort cleanup of the (now-renamed) files; the leaked accept
+        // thread is reaped when the test process exits.
+        let _ = std::fs::remove_file(&new_sock);
+        let _ = std::fs::remove_file(server::pid_path(&new_sock));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -641,7 +641,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     {
         mux_core::process::kill_remaining_children();
     }
-    mux_core::server::cleanup(&socket_path);
+    mux_core::server::cleanup(&mux.socket_path().unwrap_or_else(|| socket_path.clone()));
     result
 }
 

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -116,7 +116,7 @@ SESSION PICKER  (cmux attach --session-list, without --json)
   kill + quit, 2 Ctrl-C, 0 on attach (then the normal attach/detach flow).
     ↑/↓ or j/k  move focus        Enter  attach to focused (live only)
     x  kill focused session (y/N)    s  kill every stale session (y/N)
-    n  new session (inline name)     r  rename (stub; L2 will wire it in)
+    n  new session (inline name)     r  rename focused session (inline)
     q / Esc  quit                    Ctrl-C  abort (exit 2)
 
 KEYS (prefix: Ctrl-b)
@@ -147,7 +147,7 @@ CLI VERBS
   focus-pane, select-tab, select-screen, select-workspace, move-tab,
   move-workspace, scroll-surface, subscribe, attach-surface, report-agent,
   list-agents, browser-reload, list-sessions, kill-session, kill-stale,
-  theme list
+  rename-session, theme list
 
 SEND
   cmux send --surface <id> --text <text> [--shell auto|fish|bash|zsh|sh|nu|raw]
@@ -159,6 +159,21 @@ SEND
       instead of being interpreted by the shell's line editor. auto
       resolves the pane's shell from /proc on Linux. Default: raw
       (verbatim passthrough, unchanged from before).
+
+RENAME-SESSION
+  cmux rename-session --old <name> --new <name> [--json]
+      Renames a live cmux session in place: moves its .sock/.pid to the new
+      name, updates the session name, reparents the snapshot file, and keeps
+      the SAME daemon serving at the new path (the listener is never rebound
+      — rename(2) reparents the socket dirent while the kernel keeps it
+      bound). A live target is refused; a stale target is cleared first.
+      Exit codes: 0 success · 1 source not found / server error · 2 bad/missing
+      flags, invalid name, or target already live · 3 connect failure.
+      Lifetime guarantee (AC4): EXISTING panes keep the CMUX_MUX_SOCKET they
+      inherited at spawn (the old path) for their lifetime — this is
+      intentional, not a bug. Panes spawned AFTER the rename inherit the new
+      path. See the server.rs docstring for the mechanism and the watchdog
+      caveat (a SIGKILL after rename is cleaned by the next serve()/kill-stale).
 
 CLAUDE CODE HOOK INTEGRATION
   cmux claude install-hooks [--uninstall]
@@ -380,9 +395,8 @@ fn main() {
                 // Resolve the session's control-socket path the same
                 // way cli::list does. The plugin's cmux_call host
                 // imports write back to this socket.
-                let raw_socket: Option<PathBuf> = std::env::var_os("CMUX_MUX_SOCKET")
-                    .map(PathBuf::from)
-                    .or_else(|| {
+                let raw_socket: Option<PathBuf> =
+                    std::env::var_os("CMUX_MUX_SOCKET").map(PathBuf::from).or_else(|| {
                         let mut idx = 0;
                         while idx + 1 < raw_args.len() {
                             if raw_args[idx] == "--socket" {
@@ -492,8 +506,9 @@ fn run_attach(args: Args) -> anyhow::Result<()> {
         if args.apply_local_config { resolve_local_overlay(args.config.as_deref()) } else { None };
     let socket_path =
         args.socket.unwrap_or_else(|| mux_core::server::default_socket_path(&args.session));
-    let remote = RemoteSession::connect(&socket_path)
-        .with_context(|| format!("attaching to cmux session socket at {}", socket_path.display()))?;
+    let remote = RemoteSession::connect(&socket_path).with_context(|| {
+        format!("attaching to cmux session socket at {}", socket_path.display())
+    })?;
     // `--print-resolved-config` is an inspection escape for thin-client
     // attaches (issue #40 blocker 1): fetch the server's resolved chrome,
     // layer the local overlay on top, print the merged chrome as JSON,

--- a/mux/crates/mux-tui/src/session_picker.rs
+++ b/mux/crates/mux-tui/src/session_picker.rs
@@ -58,6 +58,15 @@ enum Mode {
     },
     /// Inline new-session name prompt (Claim 5). Enter attaches/creates.
     NewSession(TextInput),
+    /// Inline rename of the focused LIVE session (issue #63 L2, Q7).
+    /// `socket_path` is the session's current socket (commit sends
+    /// rename-session over it); `old_name` is shown in the prompt and
+    /// pre-fills the input.
+    RenameSession {
+        socket_path: PathBuf,
+        old_name: String,
+        input: TextInput,
+    },
 }
 
 /// Interactive modal picker. Restores the terminal on every return path
@@ -255,6 +264,66 @@ fn dispatch(
                 InputEvent::None | InputEvent::Changed => Action::Redraw,
             }
         }
+        Mode::RenameSession { socket_path, old_name, input } => {
+            match input.handle_key(key) {
+                InputEvent::Commit => {
+                    let new_name = input.as_str().trim().to_string();
+                    let socket_path = socket_path.clone();
+                    let old_name = old_name.clone();
+                    if new_name.is_empty() {
+                        *status = "session name cannot be empty".to_string();
+                        *mode = Mode::Browse;
+                        return Action::Redraw;
+                    }
+                    // Unchanged name = cancel (no-op).
+                    if new_name == old_name {
+                        *status = format!("unchanged ({old_name})");
+                        *mode = Mode::Browse;
+                        return Action::Redraw;
+                    }
+                    // Server-side validation (defence in depth; the CLI verb
+                    // also validates, but the picker talks to the helper
+                    // directly, so check here too).
+                    if let Err(e) = mux_core::server::validate_session_name(&new_name) {
+                        *status = e.to_string();
+                        *mode = Mode::Browse;
+                        return Action::Redraw;
+                    }
+                    // Refuse if another LIVE session already has the name.
+                    if sessions.iter().any(|s| s.session == new_name && s.live) {
+                        *status = format!("session {new_name:?} already exists");
+                        *mode = Mode::Browse;
+                        return Action::Redraw;
+                    }
+                    match cli::rename_session_at(&socket_path, &new_name) {
+                        Ok(_) => {
+                            *sessions = refresh(global);
+                            // Keep focus on the renamed row (now listed under
+                            // its new name, newest-first).
+                            if let Some(i) = sessions
+                                .iter()
+                                .position(|s| s.session == new_name && s.live)
+                            {
+                                state.select(Some(i));
+                            }
+                            *status = format!("renamed {old_name} → {new_name}");
+                            *mode = Mode::Browse;
+                            Action::Redraw
+                        }
+                        Err(e) => {
+                            *status = format!("rename failed: {e}");
+                            *mode = Mode::Browse;
+                            Action::Redraw
+                        }
+                    }
+                }
+                InputEvent::Cancel => {
+                    *mode = Mode::Browse;
+                    Action::Redraw
+                }
+                InputEvent::None | InputEvent::Changed => Action::Redraw,
+            }
+        }
     }
 }
 
@@ -316,9 +385,22 @@ fn browse_key(
             *mode = Mode::NewSession(TextInput::new(String::new()));
             Action::Redraw
         }
-        // Claim 7: rename stub (Q1: stub message; L2 swap-in, no UX change).
+        // Issue #63 L2 (Q7): rename the focused LIVE session inline. A
+        // stale/unfocused row gets a hint (nothing to rename).
         KeyCode::Char('r') => {
-            *status = "rename not yet available — coming in L2 (rename-session)".to_string();
+            if let Some(i) = state.selected() {
+                if let Some(s) = sessions.get(i) {
+                    if s.live {
+                        *mode = Mode::RenameSession {
+                            socket_path: s.socket_path.clone(),
+                            old_name: s.session.clone(),
+                            input: TextInput::new(s.session.clone()),
+                        };
+                        return Action::Redraw;
+                    }
+                }
+            }
+            *status = "no live session focused to rename (move to a live row)".to_string();
             Action::Redraw
         }
         KeyCode::Esc | KeyCode::Char('q') => Action::Quit,
@@ -426,7 +508,7 @@ fn draw(
         match mode {
             Mode::Browse => {
                 lines.push(Line::from(Span::styled(
-                    "↑/↓ or j/k move · Enter attach · x kill · s kill-stale · n new · r rename · q/Esc quit · Ctrl-C abort",
+                    "↑/↓ or j/k move · Enter attach · x kill · s kill-stale · n new · r rename focused · q/Esc quit · Ctrl-C abort",
                     Style::default().fg(Color::DarkGray),
                 )));
             }
@@ -448,6 +530,18 @@ fn draw(
                 let (visible, cur) = input.visible_text_and_cursor(chunks[1].width as usize);
                 let mut spans =
                     vec![Span::styled("new session name: ", Style::default().fg(Color::Cyan))];
+                spans.push(Span::raw(visible.clone()));
+                if cur < visible.len() {
+                    spans.push(Span::raw(visible[cur..].to_string()));
+                }
+                lines.push(Line::from(spans));
+            }
+            Mode::RenameSession { old_name, input, .. } => {
+                let (visible, cur) = input.visible_text_and_cursor(chunks[1].width as usize);
+                let mut spans = vec![Span::styled(
+                    format!("rename {old_name} → "),
+                    Style::default().fg(Color::Cyan),
+                )];
                 spans.push(Span::raw(visible.clone()));
                 if cur < visible.len() {
                     spans.push(Span::raw(visible[cur..].to_string()));

--- a/mux/crates/mux-tui/src/session_picker.rs
+++ b/mux/crates/mux-tui/src/session_picker.rs
@@ -300,9 +300,8 @@ fn dispatch(
                             *sessions = refresh(global);
                             // Keep focus on the renamed row (now listed under
                             // its new name, newest-first).
-                            if let Some(i) = sessions
-                                .iter()
-                                .position(|s| s.session == new_name && s.live)
+                            if let Some(i) =
+                                sessions.iter().position(|s| s.session == new_name && s.live)
                             {
                                 state.select(Some(i));
                             }

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -1709,3 +1709,507 @@ fn version_flag_prints_cargo_version_and_exits_zero() {
         );
     }
 }
+
+// =====================================================================
+// cmux rename-session (issue #63 L2) — full TDD acceptance suite.
+//
+// These tests are written RED (cookbook Rule 5) before the feature is
+// implemented. At this commit the `rename-session` verb does not exist
+// yet, so every end-to-end test fails because the invocation is rejected
+// (unknown verb) rather than performing the rename; the helper/unit tests
+// fail against compile-scaffolding stubs. The implementation commits turn
+// them green. The manual-spawn + `XDG_RUNTIME_DIR` harness mirrors
+// `list_sessions_lists_active_headless_session` / `kill_session_*`.
+// =====================================================================
+
+/// Spawn a headless daemon as `--session <name>` on `<dir>/<name>.sock` in
+/// an isolated `XDG_RUNTIME_DIR`, wait for `.sock`+`.pid`, return the child.
+fn spawn_named_headless(dir: &std::path::Path, name: &str) -> Child {
+    let socket = dir.join(format!("{name}.sock"));
+    let mut child = Command::new(bin())
+        .args(["--headless", "--session"])
+        .arg(name)
+        .args(["--socket"])
+        .arg(&socket)
+        .env("XDG_RUNTIME_DIR", dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let pid_file = dir.join(format!("{name}.pid"));
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if socket.exists() && pid_file.exists() {
+            return child;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    panic!("daemon {name:?} did not come up at {}", socket.display());
+}
+
+/// Read the daemon pid recorded in `<dir>/<name>.pid`.
+fn read_pid_file(path: &std::path::Path) -> u32 {
+    fs::read_to_string(path)
+        .unwrap_or_else(|_| panic!("pid file {} should exist", path.display()))
+        .trim()
+        .parse::<u32>()
+        .unwrap()
+}
+
+/// Run a cmux CLI subcommand against `--socket <socket>` with CMUX_MUX_SOCKET
+/// unset (so resolution is deterministic) and return its output.
+fn run_against(socket: &std::path::Path, xdg: &std::path::Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new(bin());
+    cmd.args(["--socket"]).arg(socket).args(args);
+    cmd.env("XDG_RUNTIME_DIR", xdg).env_remove("CMUX_MUX_SOCKET");
+    cmd.output().unwrap()
+}
+
+/// Poll `read-screen` until `needle` appears on the surface (or timeout).
+fn wait_for_screen_at(socket: &std::path::Path, surface: u64, needle: &str) -> String {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut last = String::new();
+    while Instant::now() < deadline {
+        let out = run_against(socket, std::path::Path::new("/tmp"), &[
+            "read-screen",
+            "--surface",
+            &surface.to_string(),
+        ]);
+        last = String::from_utf8_lossy(&out.stdout).to_string();
+        if last.contains(needle) {
+            return last;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    last
+}
+
+/// AC1: rename moves `.sock`+`.pid` to the new name and the SAME daemon
+/// keeps serving at the new path (pid unchanged).
+#[test]
+fn rename_session_moves_socket_and_pid_and_keeps_serving() {
+    let dir = unique_temp_dir("rename-t1");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_sock = dir.join("old.sock");
+    let old_pid = dir.join("old.pid");
+    let daemon_pid = read_pid_file(&old_pid);
+
+    let rename = run_against(
+        &old_sock,
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_success(&rename);
+
+    let new_sock = dir.join("bar.sock");
+    let new_pid = dir.join("bar.pid");
+    assert!(new_sock.exists(), "new socket should exist after rename");
+    assert!(new_pid.exists(), "new pid file should exist after rename");
+    assert!(!old_sock.exists(), "old socket should be gone after rename");
+    assert!(!old_pid.exists(), "old pid file should be gone after rename");
+
+    // Same daemon keeps serving at the new path.
+    let identify = run_against(&new_sock, &dir, &["--json", "identify"]);
+    assert_success(&identify);
+    let v: serde_json::Value = serde_json::from_slice(&identify.stdout).unwrap();
+    assert_eq!(v["session"].as_str(), Some("bar"), "identify should report the new name");
+    assert_eq!(
+        v["pid"].as_u64(),
+        Some(daemon_pid as u64),
+        "same daemon pid should serve after rename"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// AC2: after rename, the old socket is no longer connectable (exit 3)
+/// while the new path serves the same daemon; protocol version unchanged.
+#[test]
+fn rename_makes_old_socket_unreachable_and_keeps_protocol() {
+    let dir = unique_temp_dir("rename-t2");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_sock = dir.join("old.sock");
+    let daemon_pid = read_pid_file(&dir.join("old.pid"));
+
+    let rename = run_against(
+        &old_sock,
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_success(&rename);
+
+    // New path serves the same daemon; protocol must NOT bump (scout Q2).
+    let new_sock = dir.join("bar.sock");
+    let id_new = run_against(&new_sock, &dir, &["--json", "identify"]);
+    assert_success(&id_new);
+    let v: serde_json::Value = serde_json::from_slice(&id_new.stdout).unwrap();
+    assert_eq!(v["session"].as_str(), Some("bar"));
+    assert_eq!(v["pid"].as_u64(), Some(daemon_pid as u64));
+    assert_eq!(v["protocol"].as_u64(), Some(6), "rename must not bump the protocol version");
+
+    // Old path is gone -> connect fails with exit 3 (transport convention).
+    let id_old = run_against(&old_sock, &dir, &["identify"]);
+    assert_eq!(id_old.status.code(), Some(3));
+    assert!(String::from_utf8_lossy(&id_old.stderr).contains("cannot connect"));
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// AC3: after rename, the old session name is gone from discovery and the
+/// new name is listed as live.
+#[test]
+fn old_session_name_gone_after_rename() {
+    let dir = unique_temp_dir("rename-t3");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_sock = dir.join("old.sock");
+
+    let rename = run_against(
+        &old_sock,
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_success(&rename);
+
+    let list = run_against(&old_sock, &dir, &["--json", "list-sessions"]);
+    // old.sock is gone, so list-sessions resolves its runtime dir from
+    // XDG_RUNTIME_DIR and discovers bar.sock live, old.sock absent.
+    // (list-sessions does not need a connectable --socket.)
+    let v: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap_or_else(|_| {
+        let s = String::from_utf8_lossy(&list.stdout);
+        panic!("list-sessions produced non-JSON output: {s}\nstderr: {}",
+            String::from_utf8_lossy(&list.stderr))
+    });
+    let sessions = v["sessions"].as_array().expect("sessions array");
+    assert!(
+        sessions.iter().any(|s| s["session"] == "bar" && s["status"] == "live"),
+        "bar should be listed live after rename, got {v}"
+    );
+    assert!(
+        !sessions.iter().any(|s| s["session"] == "old"),
+        "old should be absent after rename, got {v}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// AC4: existing panes keep the `CMUX_MUX_SOCKET` they inherited at spawn
+/// (the old path) for their lifetime; panes spawned AFTER the rename
+/// inherit the new path. This is the lifetime guarantee (intentional, not
+/// a bug) documented in USAGE and the server.rs docstring.
+#[test]
+fn rename_preserves_inherited_cmux_socket_in_existing_panes() {
+    let dir = unique_temp_dir("rename-t4");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_sock = dir.join("old.sock");
+
+    // Existing pane (spawned before the rename).
+    let ws = run_against(&old_sock, &dir, &["new-workspace", "--name", "pre"]);
+    assert_success(&ws);
+    let surface_pre: u64 =
+        String::from_utf8(ws.stdout).unwrap().trim().parse().unwrap();
+    let probe = "printf 'E=%s\\n' \"$CMUX_MUX_SOCKET\"\\n";
+    let send = run_against(
+        &old_sock,
+        &dir,
+        &["send", "--surface", &surface_pre.to_string(), "--text", probe],
+    );
+    assert_success(&send);
+    let before = wait_for_screen_at(&old_sock, surface_pre, "E=");
+    let old_sock_str = old_sock.display().to_string();
+    assert!(
+        before.contains(&old_sock_str),
+        "pre-rename pane should carry the old socket path; screen was {before:?}"
+    );
+
+    // Rename old -> bar.
+    let rename = run_against(
+        &old_sock,
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_success(&rename);
+    let new_sock = dir.join("bar.sock");
+
+    // Existing pane: env is unchanged for its lifetime (AC4 first half).
+    let send2 = run_against(
+        &new_sock,
+        &dir,
+        &["send", "--surface", &surface_pre.to_string(), "--text", probe],
+    );
+    assert_success(&send2);
+    let after = wait_for_screen_at(&new_sock, surface_pre, "E=");
+    assert!(
+        after.contains(&old_sock_str) && !after.contains(&new_sock.display().to_string().split('/').last().unwrap()),
+        "existing pane must keep the old CMUX_MUX_SOCKET after rename; screen was {after:?}"
+    );
+
+    // New pane spawned after the rename inherits the refreshed path.
+    let ws2 = run_against(&new_sock, &dir, &["new-workspace", "--name", "post"]);
+    assert_success(&ws2);
+    let surface_post: u64 =
+        String::from_utf8(ws2.stdout).unwrap().trim().parse().unwrap();
+    let send3 = run_against(
+        &new_sock,
+        &dir,
+        &["send", "--surface", &surface_post.to_string(), "--text", probe],
+    );
+    assert_success(&send3);
+    let post = wait_for_screen_at(&new_sock, surface_post, "E=");
+    assert!(
+        post.contains(&new_sock.display().to_string()),
+        "post-rename pane should carry the new socket path; screen was {post:?}"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// AC5: renaming onto a LIVE target session fails with exit 2
+/// ("already exists") and leaves the source untouched.
+#[test]
+fn rename_to_existing_live_session_fails_exit_2() {
+    let dir = unique_temp_dir("rename-t5");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child_old = spawn_named_headless(&dir, "old");
+    let mut child_bar = spawn_named_headless(&dir, "bar");
+    let old_sock = dir.join("old.sock");
+
+    let rename = run_against(
+        &old_sock,
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_eq!(
+        rename.status.code(),
+        Some(2),
+        "rename onto a live session must exit 2; stderr: {}",
+        String::from_utf8_lossy(&rename.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&rename.stderr).to_lowercase().contains("already exists"),
+        "stderr should explain the target is in use; got {}",
+        String::from_utf8_lossy(&rename.stderr)
+    );
+
+    // Source must be untouched (nothing moved).
+    assert!(old_sock.exists(), "old socket must survive a refused rename");
+    assert!(
+        mux_core::server::is_session_socket_live(&old_sock),
+        "old session must still be live after a refused rename"
+    );
+
+    let _ = child_old.kill();
+    let _ = child_old.wait();
+    let _ = child_bar.kill();
+    let _ = child_bar.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// Target policy (mirrors `serve()`'s stale-clear): a STALE target
+/// (dead pid) is cleared and the rename succeeds.
+#[test]
+fn rename_to_stale_target_clears_and_succeeds() {
+    let dir = unique_temp_dir("rename-t6");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_sock = dir.join("old.sock");
+
+    // Synthetic stale target pair (dead pid).
+    let stale_sock = dir.join("bar.sock");
+    let stale_pid = dir.join("bar.pid");
+    fs::write(&stale_sock, b"").unwrap();
+    fs::write(&stale_pid, "999999\n").unwrap();
+
+    let rename = run_against(
+        &old_sock,
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_success(&rename);
+
+    // bar.sock is now live under the daemon's pid; old.sock is gone.
+    assert!(mux_core::server::is_session_socket_live(&stale_sock));
+    assert_eq!(
+        read_pid_file(&stale_pid),
+        child.id(),
+        "bar.pid should now record the (live) daemon pid"
+    );
+    assert!(!old_sock.exists(), "old socket should be gone after rename");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// AC6 (defence in depth): invalid `--new` names are rejected CLIENT-side
+/// (exit 2, "session name") and never reach the socket. A literal NUL
+/// cannot be carried by execve, so it is covered by the unit test T12
+/// (`validate_session_name_table`) rather than here.
+#[test]
+fn rename_rejects_invalid_names() {
+    let dir = unique_temp_dir("rename-t7");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_sock = dir.join("old.sock");
+
+    let overlong = "a".repeat(256);
+    let bad_names: &[&str] = &[
+        "",
+        "a/b",
+        "a\\b",
+        "..",
+        ".",
+        " foo",
+        "foo ",
+        "\t",
+        &overlong,
+    ];
+    for bad in bad_names {
+        let out = run_against(
+            &old_sock,
+            &dir,
+            &["rename-session", "--old", "old", "--new", bad],
+        );
+        assert_eq!(
+            out.status.code(),
+            Some(2),
+            "invalid name {bad:?} should exit 2; stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let err = String::from_utf8_lossy(&out.stderr).to_lowercase();
+        // At this commit the verb is unknown, so the error is the
+        // unknown-verb/argument rejection (plus a USAGE dump) rather than a
+        // real name-validation rejection. Require the validation message AND
+        // the absence of the unknown-verb fallback so the assertion only
+        // passes once the feature genuinely rejects bad names client-side.
+        assert!(
+            !err.contains("unknown argument")
+                && !err.contains("unknown verb")
+                && !err.contains("unexpected argument"),
+            "invalid name {bad:?} must not hit the unknown-verb path; got {err:?}"
+        );
+        assert!(
+            err.contains("session name"),
+            "invalid name {bad:?} should explain the session-name rejection; got {err:?}"
+        );
+        // Source must be untouched by every rejected attempt.
+        assert!(old_sock.exists(), "old socket must survive a rejected rename ({bad:?})");
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// AC2/T8: after rename, `identify` reports the new session name and the
+/// protocol version is still 6 (rename is an additive command variant).
+#[test]
+fn identify_reports_new_name_after_rename() {
+    let dir = unique_temp_dir("rename-t8");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_sock = dir.join("old.sock");
+
+    let rename = run_against(
+        &old_sock,
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_success(&rename);
+
+    let id = run_against(&dir.join("bar.sock"), &dir, &["--json", "identify"]);
+    assert_success(&id);
+    let v: serde_json::Value = serde_json::from_slice(&id.stdout).unwrap();
+    assert_eq!(v["session"].as_str(), Some("bar"));
+    assert_eq!(v["protocol"].as_u64(), Some(6));
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// AC1/T9: the pid FILE contents are unchanged across the rename (only the
+/// filename moves) and the daemon process is alive throughout.
+#[test]
+fn pid_file_contents_unchanged_after_rename() {
+    let dir = unique_temp_dir("rename-t9");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_pid = dir.join("old.pid");
+    let pid_before = read_pid_file(&old_pid);
+    assert!(mux_core::server::is_process_alive(pid_before));
+
+    let rename = run_against(
+        &dir.join("old.sock"),
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_success(&rename);
+
+    let pid_after = read_pid_file(&dir.join("bar.pid"));
+    assert_eq!(pid_after, pid_before, "pid file contents must be identical after rename");
+    assert!(mux_core::server::is_process_alive(pid_after), "daemon must stay alive across rename");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// AC7/T10: after rename, the session-list / kill-session / kill-stale verbs
+/// work against the renamed session with no regressions.
+#[test]
+fn rename_no_regressions_on_list_kill_killstale() {
+    let dir = unique_temp_dir("rename-t10");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "old");
+    let old_sock = dir.join("old.sock");
+
+    let rename = run_against(
+        &old_sock,
+        &dir,
+        &["rename-session", "--old", "old", "--new", "bar"],
+    );
+    assert_success(&rename);
+
+    let new_sock = dir.join("bar.sock");
+    // list-sessions sees bar live, old absent.
+    let list = run_against(&new_sock, &dir, &["--json", "list-sessions"]);
+    assert_success(&list);
+    let v: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    let sessions = v["sessions"].as_array().expect("sessions array");
+    assert!(sessions.iter().any(|s| s["session"] == "bar" && s["status"] == "live"));
+    assert!(!sessions.iter().any(|s| s["session"] == "old"));
+
+    // kill-session on the renamed name terminates the daemon & cleans up.
+    let kill = run_against(&new_sock, &dir, &["kill-session", "--session", "bar"]);
+    assert_success(&kill);
+    let _ = child.wait();
+    assert!(!new_sock.exists(), "bar.sock should be removed by kill-session");
+    assert!(!dir.join("bar.pid").exists(), "bar.pid should be removed by kill-session");
+
+    // kill-stale is a clean no-op now.
+    let stale = run_against(&new_sock, &dir, &["kill-stale"]);
+    assert_success(&stale);
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+// T11 (`rename_session_at_renames_via_socket`) lives in `cli.rs`'s own
+// `#[cfg(test)]` module: mux-tui is a bin-only crate, so this integration
+// test file links only against the `mux-core` lib + the `cmux` binary and
+// cannot import the `pub(crate)` helper. The in-process unit test there
+// drives a `mux-core` server directly (no subprocess) and exercises the
+// exact code path the picker's `r` flow uses.

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -2011,11 +2011,12 @@ fn rename_rejects_invalid_names() {
             String::from_utf8_lossy(&out.stderr)
         );
         let err = String::from_utf8_lossy(&out.stderr).to_lowercase();
-        // At this commit the verb is unknown, so the error is the
-        // unknown-verb/argument rejection (plus a USAGE dump) rather than a
-        // real name-validation rejection. Require the validation message AND
-        // the absence of the unknown-verb fallback so the assertion only
-        // passes once the feature genuinely rejects bad names client-side.
+        // Regression guard: bad names must be rejected by validate_session_name
+        // (exit 2, "session name") and never fall through to the generic
+        // unknown-verb/argument path. Require the validation message AND the
+        // absence of the unknown-verb fallback so that a future regression —
+        // where a bad name slips past validation and surfaces as an
+        // unknown-verb rejection — is caught.
         assert!(
             !err.contains("unknown argument")
                 && !err.contains("unknown verb")

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -1919,15 +1919,19 @@ fn rename_preserves_inherited_cmux_socket_in_existing_panes() {
     assert_success(&ws);
     let surface_pre: u64 =
         String::from_utf8(ws.stdout).unwrap().trim().parse().unwrap();
-    let probe = "printf 'E=%s\\n' \"$CMUX_MUX_SOCKET\"\\n";
+    let old_sock_str = old_sock.display().to_string();
+    // Fish is the default surface shell; the trailing real `\n` submits
+    // the line (no --send-cr needed — matches the cli_verbs marker probe).
+    let probe = "printf 'E=%s\\n' \"$CMUX_MUX_SOCKET\"\n";
     let send = run_against(
         &old_sock,
         &dir,
         &["send", "--surface", &surface_pre.to_string(), "--text", probe],
     );
     assert_success(&send);
-    let before = wait_for_screen_at(&old_sock, surface_pre, "E=");
-    let old_sock_str = old_sock.display().to_string();
+    // Poll for the actual path VALUE (only present after the shell expands
+    // the var), not a substring of the typed command.
+    let before = wait_for_screen_at(&old_sock, surface_pre, &old_sock_str);
     assert!(
         before.contains(&old_sock_str),
         "pre-rename pane should carry the old socket path; screen was {before:?}"
@@ -1941,18 +1945,23 @@ fn rename_preserves_inherited_cmux_socket_in_existing_panes() {
     );
     assert_success(&rename);
     let new_sock = dir.join("bar.sock");
+    let new_sock_str = new_sock.display().to_string();
 
     // Existing pane: env is unchanged for its lifetime (AC4 first half).
+    // Re-probe and clear the screen's prior line by checking the LAST `E=`
+    // value: it must still be the old path, never the new one.
     let send2 = run_against(
         &new_sock,
         &dir,
         &["send", "--surface", &surface_pre.to_string(), "--text", probe],
     );
     assert_success(&send2);
-    let after = wait_for_screen_at(&new_sock, surface_pre, "E=");
+    // Existing pane keeps the OLD value (env inherited at spawn, unchanged).
+    let after = wait_for_screen_at(&new_sock, surface_pre, &old_sock_str);
     assert!(
-        after.contains(&old_sock_str) && !after.contains(&new_sock.display().to_string().split('/').last().unwrap()),
-        "existing pane must keep the old CMUX_MUX_SOCKET after rename; screen was {after:?}"
+        after.contains(&old_sock_str) && !after.contains(&new_sock_str),
+        "existing pane must keep the old CMUX_MUX_SOCKET after rename; \
+         screen was {after:?}"
     );
 
     // New pane spawned after the rename inherits the refreshed path.
@@ -1966,9 +1975,10 @@ fn rename_preserves_inherited_cmux_socket_in_existing_panes() {
         &["send", "--surface", &surface_post.to_string(), "--text", probe],
     );
     assert_success(&send3);
-    let post = wait_for_screen_at(&new_sock, surface_post, "E=");
+    // New pane inherits the refreshed (new) path.
+    let post = wait_for_screen_at(&new_sock, surface_post, &new_sock_str);
     assert!(
-        post.contains(&new_sock.display().to_string()),
+        post.contains(&new_sock_str),
         "post-rename pane should carry the new socket path; screen was {post:?}"
     );
 

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -179,15 +179,7 @@ fn send_shell_flag_validates_and_accepts() {
     // any other invalid flag value.
     let bad = cli(
         &server,
-        &[
-            "send",
-            "--surface",
-            &surface.to_string(),
-            "--text",
-            "echo ok",
-            "--shell",
-            "tcsh",
-        ],
+        &["send", "--surface", &surface.to_string(), "--text", "echo ok", "--shell", "tcsh"],
     );
     assert_eq!(bad.status.code(), Some(2));
     assert!(String::from_utf8_lossy(&bad.stderr).contains("--shell"));
@@ -307,11 +299,7 @@ fn agent_session_round_trips_through_list_workspaces_json() {
     let server = HeadlessServer::start("agent-session-rpc");
     let workspace = cli(&server, &["new-workspace", "--name", "agent-rpc"]);
     assert_success(&workspace);
-    let surface = String::from_utf8(workspace.stdout)
-        .unwrap()
-        .trim()
-        .parse::<u64>()
-        .unwrap();
+    let surface = String::from_utf8(workspace.stdout).unwrap().trim().parse::<u64>().unwrap();
 
     let report = cli(
         &server,
@@ -1378,11 +1366,8 @@ fn attach_overlay_layers_over_server_config() {
     let server_cfg_root = dir.join("server-config");
     let server_cmux_dir = server_cfg_root.join("cmux");
     fs::create_dir_all(&server_cmux_dir).unwrap();
-    fs::write(
-        server_cmux_dir.join("mux.json"),
-        r##"{"theme": {"sidebar_rail": "#112233"}}"##,
-    )
-    .unwrap();
+    fs::write(server_cmux_dir.join("mux.json"), r##"{"theme": {"sidebar_rail": "#112233"}}"##)
+        .unwrap();
 
     let socket = dir.join("mux.sock");
     let mut server = Command::new(bin())
@@ -1404,10 +1389,7 @@ fn attach_overlay_layers_over_server_config() {
     if !socket.exists() {
         let _ = server.kill();
         let _ = server.wait();
-        panic!(
-            "headless server did not create socket at {}",
-            socket.display()
-        );
+        panic!("headless server did not create socket at {}", socket.display());
     }
     // Give the server a moment to register its resolved chrome (it is set
     // before `serve()` binds, so a live socket implies it is published).
@@ -1418,11 +1400,7 @@ fn attach_overlay_layers_over_server_config() {
     let local_cfg_root = dir.join("local-config");
     let local_cmux_dir = local_cfg_root.join("cmux");
     fs::create_dir_all(&local_cmux_dir).unwrap();
-    fs::write(
-        local_cmux_dir.join("mux.local.toml"),
-        "[keys]\nprefix = \"ctrl+s\"\n",
-    )
-    .unwrap();
+    fs::write(local_cmux_dir.join("mux.local.toml"), "[keys]\nprefix = \"ctrl+s\"\n").unwrap();
 
     let output = Command::new(bin())
         .args(["attach", "--socket"])
@@ -1443,15 +1421,11 @@ fn attach_overlay_layers_over_server_config() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(
-        output.status.success(),
-        "attach --print-resolved-config failed: {combined}"
-    );
+    assert!(output.status.success(), "attach --print-resolved-config failed: {combined}");
 
-    let merged: serde_json::Value =
-        serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
-            panic!("expected merged chrome JSON on stdout, parse failed:{e}\n{combined}")
-        });
+    let merged: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!("expected merged chrome JSON on stdout, parse failed:{e}\n{combined}")
+    });
 
     // Server's theme colour survived: the overlay layered, not replaced.
     assert_eq!(
@@ -1482,11 +1456,8 @@ fn get_resolved_config_cli_verb_returns_server_chrome() {
     let server_cfg_root = dir.join("server-config");
     let server_cmux_dir = server_cfg_root.join("cmux");
     fs::create_dir_all(&server_cmux_dir).unwrap();
-    fs::write(
-        server_cmux_dir.join("mux.json"),
-        r##"{"theme": {"sidebar_rail": "#445566"}}"##,
-    )
-    .unwrap();
+    fs::write(server_cmux_dir.join("mux.json"), r##"{"theme": {"sidebar_rail": "#445566"}}"##)
+        .unwrap();
 
     let socket = dir.join("mux.sock");
     let mut server = Command::new(bin())
@@ -1508,10 +1479,7 @@ fn get_resolved_config_cli_verb_returns_server_chrome() {
     if !socket.exists() {
         let _ = server.kill();
         let _ = server.wait();
-        panic!(
-            "headless server did not create socket at {}",
-            socket.display()
-        );
+        panic!("headless server did not create socket at {}", socket.display());
     }
     // `set_resolved_chrome` runs before `serve()` binds, so a live socket
     // implies the chrome is published; still give it a beat to settle.
@@ -1534,10 +1502,7 @@ fn get_resolved_config_cli_verb_returns_server_chrome() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(
-        output.status.success(),
-        "cmux get-resolved-config failed: {combined}"
-    );
+    assert!(output.status.success(), "cmux get-resolved-config failed: {combined}");
 
     let chrome: serde_json::Value = serde_json::from_slice(&output.stdout)
         .unwrap_or_else(|e| panic!("expected chrome JSON on stdout, parse failed:{e}\n{combined}"));
@@ -1594,14 +1559,8 @@ fn plugin_install_list_uninstall_round_trip() {
         list_out.contains("pifactory-fleet"),
         "list should name the installed plugin: {list_out}"
     );
-    assert!(
-        list_out.contains("enabled"),
-        "list should show the enabled state: {list_out}"
-    );
-    assert!(
-        list_out.contains("deploy,rollback"),
-        "list should show the claimed verbs: {list_out}"
-    );
+    assert!(list_out.contains("enabled"), "list should show the enabled state: {list_out}");
+    assert!(list_out.contains("deploy,rollback"), "list should show the claimed verbs: {list_out}");
 
     let uninstall = run(&["plugin", "uninstall", "pifactory-fleet"]);
     assert_success(&uninstall);
@@ -1634,10 +1593,7 @@ fn plugin_shipped_example_manifest_installs() {
         .join("../../spec/plugins/pifactory-fleet/cmux-plugin.toml")
         .canonicalize()
         .unwrap_or_else(|_| {
-            panic!(
-                "shipped example manifest not found relative to {}",
-                env!("CARGO_MANIFEST_DIR")
-            )
+            panic!("shipped example manifest not found relative to {}", env!("CARGO_MANIFEST_DIR"))
         });
     assert!(
         manifest_path.exists(),
@@ -1673,10 +1629,7 @@ fn plugin_shipped_example_manifest_installs() {
         list_out.contains("bin/fleet.wasm"),
         "installed entry path should be preserved: {list_out}"
     );
-    assert!(
-        list_out.contains("cmux_call"),
-        "verb allowlist should include cmux_call: {list_out}"
-    );
+    assert!(list_out.contains("cmux_call"), "verb allowlist should include cmux_call: {list_out}");
 }
 
 /// Issue #59: `cmux --version` / `-V` print `cmux <CARGO_PKG_VERSION>`
@@ -1687,11 +1640,7 @@ fn version_flag_prints_cargo_version_and_exits_zero() {
     let expected = format!("cmux {}", env!("CARGO_PKG_VERSION"));
 
     let run = |args: &[&str]| {
-        Command::new(bin())
-            .args(args)
-            .env_remove("CMUX_MUX_SOCKET")
-            .output()
-            .unwrap()
+        Command::new(bin()).args(args).env_remove("CMUX_MUX_SOCKET").output().unwrap()
     };
 
     for args in [&["--version"][..], &["-V"][..], &["--headless", "--version"][..]] {
@@ -1772,11 +1721,11 @@ fn wait_for_screen_at(socket: &std::path::Path, surface: u64, needle: &str) -> S
     let deadline = Instant::now() + Duration::from_secs(10);
     let mut last = String::new();
     while Instant::now() < deadline {
-        let out = run_against(socket, std::path::Path::new("/tmp"), &[
-            "read-screen",
-            "--surface",
-            &surface.to_string(),
-        ]);
+        let out = run_against(
+            socket,
+            std::path::Path::new("/tmp"),
+            &["read-screen", "--surface", &surface.to_string()],
+        );
         last = String::from_utf8_lossy(&out.stdout).to_string();
         if last.contains(needle) {
             return last;
@@ -1797,11 +1746,7 @@ fn rename_session_moves_socket_and_pid_and_keeps_serving() {
     let old_pid = dir.join("old.pid");
     let daemon_pid = read_pid_file(&old_pid);
 
-    let rename = run_against(
-        &old_sock,
-        &dir,
-        &["rename-session", "--old", "old", "--new", "bar"],
-    );
+    let rename = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", "bar"]);
     assert_success(&rename);
 
     let new_sock = dir.join("bar.sock");
@@ -1837,11 +1782,7 @@ fn rename_makes_old_socket_unreachable_and_keeps_protocol() {
     let old_sock = dir.join("old.sock");
     let daemon_pid = read_pid_file(&dir.join("old.pid"));
 
-    let rename = run_against(
-        &old_sock,
-        &dir,
-        &["rename-session", "--old", "old", "--new", "bar"],
-    );
+    let rename = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", "bar"]);
     assert_success(&rename);
 
     // New path serves the same daemon; protocol must NOT bump (scout Q2).
@@ -1872,11 +1813,7 @@ fn old_session_name_gone_after_rename() {
     let mut child = spawn_named_headless(&dir, "old");
     let old_sock = dir.join("old.sock");
 
-    let rename = run_against(
-        &old_sock,
-        &dir,
-        &["rename-session", "--old", "old", "--new", "bar"],
-    );
+    let rename = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", "bar"]);
     assert_success(&rename);
 
     let list = run_against(&old_sock, &dir, &["--json", "list-sessions"]);
@@ -1885,8 +1822,10 @@ fn old_session_name_gone_after_rename() {
     // (list-sessions does not need a connectable --socket.)
     let v: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap_or_else(|_| {
         let s = String::from_utf8_lossy(&list.stdout);
-        panic!("list-sessions produced non-JSON output: {s}\nstderr: {}",
-            String::from_utf8_lossy(&list.stderr))
+        panic!(
+            "list-sessions produced non-JSON output: {s}\nstderr: {}",
+            String::from_utf8_lossy(&list.stderr)
+        )
     });
     let sessions = v["sessions"].as_array().expect("sessions array");
     assert!(
@@ -1917,8 +1856,7 @@ fn rename_preserves_inherited_cmux_socket_in_existing_panes() {
     // Existing pane (spawned before the rename).
     let ws = run_against(&old_sock, &dir, &["new-workspace", "--name", "pre"]);
     assert_success(&ws);
-    let surface_pre: u64 =
-        String::from_utf8(ws.stdout).unwrap().trim().parse().unwrap();
+    let surface_pre: u64 = String::from_utf8(ws.stdout).unwrap().trim().parse().unwrap();
     let old_sock_str = old_sock.display().to_string();
     // Fish is the default surface shell; the trailing real `\n` submits
     // the line (no --send-cr needed — matches the cli_verbs marker probe).
@@ -1938,11 +1876,7 @@ fn rename_preserves_inherited_cmux_socket_in_existing_panes() {
     );
 
     // Rename old -> bar.
-    let rename = run_against(
-        &old_sock,
-        &dir,
-        &["rename-session", "--old", "old", "--new", "bar"],
-    );
+    let rename = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", "bar"]);
     assert_success(&rename);
     let new_sock = dir.join("bar.sock");
     let new_sock_str = new_sock.display().to_string();
@@ -1967,8 +1901,7 @@ fn rename_preserves_inherited_cmux_socket_in_existing_panes() {
     // New pane spawned after the rename inherits the refreshed path.
     let ws2 = run_against(&new_sock, &dir, &["new-workspace", "--name", "post"]);
     assert_success(&ws2);
-    let surface_post: u64 =
-        String::from_utf8(ws2.stdout).unwrap().trim().parse().unwrap();
+    let surface_post: u64 = String::from_utf8(ws2.stdout).unwrap().trim().parse().unwrap();
     let send3 = run_against(
         &new_sock,
         &dir,
@@ -1997,11 +1930,7 @@ fn rename_to_existing_live_session_fails_exit_2() {
     let mut child_bar = spawn_named_headless(&dir, "bar");
     let old_sock = dir.join("old.sock");
 
-    let rename = run_against(
-        &old_sock,
-        &dir,
-        &["rename-session", "--old", "old", "--new", "bar"],
-    );
+    let rename = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", "bar"]);
     assert_eq!(
         rename.status.code(),
         Some(2),
@@ -2043,11 +1972,7 @@ fn rename_to_stale_target_clears_and_succeeds() {
     fs::write(&stale_sock, b"").unwrap();
     fs::write(&stale_pid, "999999\n").unwrap();
 
-    let rename = run_against(
-        &old_sock,
-        &dir,
-        &["rename-session", "--old", "old", "--new", "bar"],
-    );
+    let rename = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", "bar"]);
     assert_success(&rename);
 
     // bar.sock is now live under the daemon's pid; old.sock is gone.
@@ -2076,23 +2001,9 @@ fn rename_rejects_invalid_names() {
     let old_sock = dir.join("old.sock");
 
     let overlong = "a".repeat(256);
-    let bad_names: &[&str] = &[
-        "",
-        "a/b",
-        "a\\b",
-        "..",
-        ".",
-        " foo",
-        "foo ",
-        "\t",
-        &overlong,
-    ];
+    let bad_names: &[&str] = &["", "a/b", "a\\b", "..", ".", " foo", "foo ", "\t", &overlong];
     for bad in bad_names {
-        let out = run_against(
-            &old_sock,
-            &dir,
-            &["rename-session", "--old", "old", "--new", bad],
-        );
+        let out = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", bad]);
         assert_eq!(
             out.status.code(),
             Some(2),
@@ -2133,11 +2044,7 @@ fn identify_reports_new_name_after_rename() {
     let mut child = spawn_named_headless(&dir, "old");
     let old_sock = dir.join("old.sock");
 
-    let rename = run_against(
-        &old_sock,
-        &dir,
-        &["rename-session", "--old", "old", "--new", "bar"],
-    );
+    let rename = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", "bar"]);
     assert_success(&rename);
 
     let id = run_against(&dir.join("bar.sock"), &dir, &["--json", "identify"]);
@@ -2187,11 +2094,7 @@ fn rename_no_regressions_on_list_kill_killstale() {
     let mut child = spawn_named_headless(&dir, "old");
     let old_sock = dir.join("old.sock");
 
-    let rename = run_against(
-        &old_sock,
-        &dir,
-        &["rename-session", "--old", "old", "--new", "bar"],
-    );
+    let rename = run_against(&old_sock, &dir, &["rename-session", "--old", "old", "--new", "bar"]);
     assert_success(&rename);
 
     let new_sock = dir.join("bar.sock");


### PR DESCRIPTION
## Summary

Part of issue #63 (L2 of 3). Adds `cmux rename-session --old <name> --new <name>` — rename an ACTIVE session in place.

- New backward-compatible protocol command `rename-session` (no protocol-version bump; additive serde variant)
- Server renames `.sock` + `.pid` (pid first; the socket rename is the commit point, with rollback on failure), flips `Mux.session`, best-effort reparents the snapshot, and keeps serving — the bound AF_UNIX listener never rebinds (`rename(2)` reparents the dirent; pinned by `unix_socket_survives_rename`)
- `Mux.session` → interior-mutable + `socket_path` single source of truth; new panes spawned after a rename inherit the NEW `CMUX_MUX_SOCKET`; existing panes keep the old path for their lifetime (documented guarantee, not a bug)
- Refuse-live / clobber-stale target policy (mirrors `serve()`); renaming onto a live session exits 2
- `validate_session_name` in both CLI and server (path-traversal defence in depth)
- Session picker `r` key wired (L1 stub promise fulfilled) via testable `rename_session_at` helper
- USAGE + server.rs protocol docstring updated; L3 follow-ups documented (watchdog respawn, browser_session_name)

## TDD

RED suite committed first (`f000d78`, 13 tests incl. kernel-pin T0) then implemented to green across refactor → mux-core → mux-tui → picker commits. 286/286 tests pass locally (CI scope `-p mux-tui`: 201/201). Review: APPROVE-WITH-NITS (nits fixed in d5f23fb). Independent verify: PASS incl. live-daemon smoke and cross-family TDD archaeology.

## Test plan

- [x] `cargo test -p mux-tui -p mux-core` — 286 passed, 0 failed
- [x] Live smoke: rename moves socket+pid, same daemon pid keeps serving, old name exit 3, live target exit 2
- [x] No regressions: list-sessions / kill-session / kill-stale / attach --session-list (28 pre-existing tests green)