### PR TITLE
feat(mux-tui): in-TUI session manager overlay (issue #63 L3)

### DIFF
--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -60,6 +60,17 @@ enum RenderAction {
     Draw,
 }
 
+/// Outcome of `app::run` (issue #63 L3). `Done` is the normal exit; `Reattach`
+/// asks the caller to tear down the TUI and re-attach to a different session
+/// socket — the only clean way to switch the running TUI to another session,
+/// since the App owns its `Session` and cannot hot-swap it in place. The
+/// session-manager overlay sets this when the user picks another session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunOutcome {
+    Done,
+    Reattach(std::path::PathBuf),
+}
+
 impl RenderAction {
     fn merge(self, other: Self) -> Self {
         match (self, other) {
@@ -602,7 +613,11 @@ fn server_base_config(session: &Session) -> Option<crate::config::Config> {
     Some(crate::config::Config::from_server_chrome(&data))
 }
 
-pub fn run(session: Session, session_label: String, overlay: Option<crate::config::Overlay>) -> anyhow::Result<()> {
+pub fn run(
+    session: Session,
+    session_label: String,
+    overlay: Option<crate::config::Overlay>,
+) -> anyhow::Result<RunOutcome> {
     // For a thin-client attach (issue #40 blocker 1) the local `Overlay`
     // must layer on top of the *server's* resolved config, not the
     // laptop's own `config::load()`. So a remote attach fetches the
@@ -748,9 +763,19 @@ pub fn run(session: Session, session_label: String, overlay: Option<crate::confi
     if let Some(writer) = app.graphics_writer.as_mut() {
         writer.shutdown(Duration::from_millis(200));
     }
+    // If the session-manager overlay asked to switch sessions, drain its
+    // pending reattach target before the App (and overlay state) drop.
+    let reattach = app
+        .session_manager
+        .as_mut()
+        .and_then(|state| state.take_reattach_target());
     let _ = std::panic::take_hook();
     restore_terminal(Some(&stdout_lock))?;
-    result
+    result?;
+    Ok(match reattach {
+        Some(socket) => RunOutcome::Reattach(socket),
+        None => RunOutcome::Done,
+    })
 }
 
 fn restore_terminal(stdout_lock: Option<&Arc<Mutex<()>>>) -> anyhow::Result<()> {
@@ -1626,25 +1651,18 @@ impl App {
                 // The focus change shows up via the next mux event redraw;
                 // keep the overlay open so the user can pick again.
             }
-            SessionManagerAction::AttachSession { socket } => {
-                // Case (b): quit+reattach lands in a later commit. For now
-                // surface the intent as a status so the key is observable.
-                if let Some(state) = self.session_manager.as_mut() {
-                    state.status =
-                        format!("reattach to {} (wired next)", socket.display());
-                }
+            SessionManagerAction::AttachSession => {
+                // Case (b): the state already recorded the reattach target;
+                // quit so `app::run` returns RunOutcome::Reattach(socket)
+                // and the caller reconnects.
+                self.quit = true;
             }
             SessionManagerAction::AttachOtherSessionWorkspace { socket, index } => {
                 // Best-effort remote focus (one-shot select-workspace) so the
-                // target session lands on the chosen workspace; the TUI
-                // switch itself arrives with the reattach plumbing.
+                // target session lands on the chosen workspace before the TUI
+                // re-attaches; the state already recorded the reattach target.
                 let _ = crate::cli::select_workspace_remote(&socket, index);
-                if let Some(state) = self.session_manager.as_mut() {
-                    state.status = format!(
-                        "focused {} → workspace {index} (switch wired next)",
-                        socket.display()
-                    );
-                }
+                self.quit = true;
             }
         }
         // After any non-close action, kick off fetches for newly-focused rows.

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -1479,6 +1479,10 @@ impl App {
                 self.open_help();
                 return Ok(RenderAction::Draw);
             }
+            // Fully wired (overlay open + key dispatch) in the next commit;
+            // this arm exists so the exhaustive match compiles with the
+            // new variant present.
+            Action::OpenSessionManager => {}
         }
         self.status_message = None;
         Ok(RenderAction::Draw)

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -1615,8 +1615,11 @@ impl App {
                 // session's seeded tree).
                 self.refresh_session_manager();
             }
-            SessionManagerAction::KillSession(_) | SessionManagerAction::RenameSession { .. } => {
-                // Wired in the next commit (issue #63 L3 commit 9).
+            SessionManagerAction::KillSession(index) => {
+                self.session_manager_kill(index);
+            }
+            SessionManagerAction::RenameSession { socket, new_name } => {
+                self.session_manager_rename(socket, new_name);
             }
             SessionManagerAction::FocusWorkspaceInPlace { index } => {
                 self.session.select_workspace(Some(index), None);
@@ -1684,6 +1687,65 @@ impl App {
         }
         state.right_sel = 0;
         state.status.clear();
+    }
+
+    /// Kill the session at `index` (issue #63 L3, `x`/`K` + y). Reuses
+    /// `cli::kill_session_at` (the L1 path), then rebuilds the left column
+    /// and clamps the cursor so a shrinking list doesn't drop focus.
+    fn session_manager_kill(&mut self, index: usize) {
+        let target = self
+            .session_manager
+            .as_ref()
+            .and_then(|s| s.sessions.get(index))
+            .cloned();
+        let Some(target) = target else { return };
+        crate::cli::kill_session_at(&target.socket_path, target.pid);
+        // Rebuild discovery in place (same scope as open/refresh).
+        self.refresh_session_manager();
+        if let Some(state) = self.session_manager.as_mut() {
+            state.status = format!("killed {}", target.session);
+            // Clamp the cursor to the same row index (or the new last row).
+            if state.sessions.is_empty() {
+                state.left_sel = 0;
+            } else {
+                state.left_sel = index.min(state.sessions.len() - 1);
+            }
+        }
+        // The killed session may have been the focused preview; re-fetch.
+        self.spawn_session_manager_fetches();
+    }
+
+    /// Rename the session at `socket` to `new_name` (issue #63 L3, `r`).
+    /// Reuses `cli::rename_session_at` (the L2 path); on success the socket
+    /// moves, so the right-column map is rekeyed and discovery is rebuilt.
+    fn session_manager_rename(&mut self, socket: std::path::PathBuf, new_name: String) {
+        match crate::cli::rename_session_at(&socket, &new_name) {
+            Ok(new_socket) => {
+                if let Some(state) = self.session_manager.as_mut() {
+                    // Rekey the right-column entry to the new socket.
+                    if let Some(column) = state.workspaces.remove(&socket) {
+                        state.workspaces.insert(new_socket.clone(), column);
+                    }
+                    state.status = format!("renamed → {new_name}");
+                }
+                self.refresh_session_manager();
+                // Land on the renamed row (now listed under its new name).
+                if let Some(state) = self.session_manager.as_mut() {
+                    if let Some(idx) = state
+                        .sessions
+                        .iter()
+                        .position(|s| s.session == new_name && s.live)
+                    {
+                        state.left_sel = idx;
+                    }
+                }
+            }
+            Err(err) => {
+                if let Some(state) = self.session_manager.as_mut() {
+                    state.status = format!("rename failed: {err}");
+                }
+            }
+        }
     }
 
     /// Handle keys captured by the help overlay. Typeable input is fed to the

--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 use std::io::Write;
-use std::sync::mpsc::{channel, Receiver, RecvTimeoutError};
+use std::sync::mpsc::{channel, Receiver, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -43,6 +43,14 @@ use crate::ui::thumb_geometry;
 pub enum AppEvent {
     Mux(MuxEvent),
     Input(Event),
+    /// A session-manager workspace-preview worker finished (issue #63 L3).
+    /// Carries the socket it fetched and the resulting column; the handler
+    /// merges it into the overlay state and redraws. Sent from a worker
+    /// thread so the UI thread never blocks on a socket read.
+    SessionManagerUpdate {
+        socket: std::path::PathBuf,
+        column: crate::session_manager::WorkspaceColumn,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -428,6 +436,12 @@ pub struct App {
     /// Fuzzy finder overlay (`leader G`). Open mutably borrows the tree
     /// to build its item list, so it holds no `Session` of its own.
     pub finder: Option<crate::finder::FinderState>,
+    /// Session manager overlay (`leader S`, issue #63 L3).
+    pub session_manager: Option<crate::session_manager::SessionManagerState>,
+    /// Clone of the event-loop channel sender, so overlay handlers can
+    /// spawn worker threads (e.g. the session-manager preview fetch) that
+    /// report back via `AppEvent`.
+    pub tx: Sender<AppEvent>,
     /// Key binding help overlay (`leader ?`), generated from the live keys.
     pub help: Option<crate::help::HelpState>,
     pub toast: Option<Toast>,
@@ -712,6 +726,8 @@ pub fn run(session: Session, session_label: String, overlay: Option<crate::confi
         prompt: None,
         omnibar: None,
         finder: None,
+        session_manager: None,
+        tx,
         help: None,
         toast: None,
         shake_frames: 0,
@@ -769,6 +785,7 @@ impl App {
                 || self.selection_auto_scroll_active()
                 || self.toast.is_some()
                 || self.has_active_flash()
+                || self.session_manager.is_some()
             {
                 Duration::from_millis(30)
             } else {
@@ -1062,6 +1079,12 @@ impl App {
                 Ok(RenderAction::Draw)
             }
             AppEvent::Input(_) => Ok(RenderAction::None),
+            AppEvent::SessionManagerUpdate { socket, column } => {
+                if let Some(state) = self.session_manager.as_mut() {
+                    state.set_workspaces(socket, column);
+                }
+                Ok(RenderAction::Draw)
+            }
         }
     }
 
@@ -1199,6 +1222,9 @@ impl App {
         }
         if self.help.is_some() {
             return self.handle_help_key(key);
+        }
+        if self.session_manager.is_some() {
+            return self.handle_session_manager_key(key);
         }
         if self.finder.is_some() {
             return self.handle_finder_key(key);
@@ -1479,10 +1505,10 @@ impl App {
                 self.open_help();
                 return Ok(RenderAction::Draw);
             }
-            // Fully wired (overlay open + key dispatch) in the next commit;
-            // this arm exists so the exhaustive match compiles with the
-            // new variant present.
-            Action::OpenSessionManager => {}
+            Action::OpenSessionManager => {
+                self.open_session_manager();
+                return Ok(RenderAction::Draw);
+            }
         }
         self.status_message = None;
         Ok(RenderAction::Draw)
@@ -1503,6 +1529,161 @@ impl App {
     fn open_help(&mut self) {
         let entries = crate::help::build_entries(&self.config.keys);
         self.help = Some(crate::help::HelpState::new(entries));
+    }
+
+    /// Open the session manager overlay (issue #63 L3, `leader S`).
+    /// Discovery is a fast `read_dir`+`stat` of the runtime dir (no socket
+    /// connects), safe on the UI thread; the current session's right column
+    /// is seeded for free from the live `App::tree`, and every other
+    /// session's preview is lazy-fetched on a worker thread once focused.
+    fn open_session_manager(&mut self) {
+        use crate::session_manager::WorkspaceColumn;
+        let own_socket = self.session.socket_path().unwrap_or_default();
+        // Scope discovery to the same runtime dir as the running session
+        // (honours a --socket override pointing outside the default dir).
+        let global = crate::cli::GlobalArgs {
+            session: None,
+            socket: Some(own_socket.clone()),
+            json: false,
+        };
+        let mut sessions = crate::cli::discover_sessions(&global);
+        // Newest-first, matching the pre-attach picker ordering.
+        sessions.sort_by(|a, b| b.mtime.cmp(&a.mtime));
+        let mut state =
+            crate::session_manager::SessionManagerState::new(own_socket.clone(), sessions);
+        // Seed the current session's workspaces for free (no socket I/O).
+        if !self.tree.workspaces.is_empty() {
+            state.set_workspaces(own_socket, WorkspaceColumn::Ready(self.tree.clone()));
+        }
+        // Land on the running session's row so the right column shows the
+        // user's own workspaces immediately.
+        let sessions = state.sessions.clone();
+        if let Some(idx) = crate::session_manager::current_index(
+            &sessions,
+            &state.own_socket,
+        ) {
+            state.left_sel = idx;
+        }
+        self.session_manager = Some(state);
+        // Kick off the first fetch (focus + lookahead) immediately.
+        self.spawn_session_manager_fetches();
+    }
+
+    /// Drain pending `NotFetched` sockets from the overlay (focus + one
+    /// lookahead) and spawn a one-shot worker per socket. Each worker
+    /// reports back via `AppEvent::SessionManagerUpdate`; the overlay marks
+    /// them `Loading` first so a re-spawn never duplicates work.
+    fn spawn_session_manager_fetches(&mut self) {
+        let Some(state) = self.session_manager.as_mut() else { return };
+        let requests = state.fetch_requests();
+        for socket in requests {
+            let tx = self.tx.clone();
+            std::thread::Builder::new()
+                .name("smgr-fetch".into())
+                .spawn(move || {
+                    let column = crate::session_manager::fetch_workspaces(&socket);
+                    let _ = tx.send(AppEvent::SessionManagerUpdate { socket, column });
+                })
+                .ok();
+        }
+    }
+
+    /// Handle keys captured by the session manager overlay. Routes the pure
+    /// state machine's action to the App's side effects (in-process
+    /// workspace focus, worker spawns, status toasts). Cross-session attach
+    /// (case b) is wired to a quit+reattach in a later commit; for now it
+    /// shows a status hint.
+    fn handle_session_manager_key(&mut self, key: KeyEvent) -> anyhow::Result<RenderAction> {
+        use crate::session_manager::SessionManagerAction;
+        let action = match self.session_manager.as_mut() {
+            Some(state) => state.handle_key(key),
+            None => return Ok(RenderAction::None),
+        };
+        match action {
+            SessionManagerAction::None => {}
+            SessionManagerAction::Redraw => {}
+            SessionManagerAction::Close => {
+                self.session_manager = None;
+            }
+            SessionManagerAction::SetStatus(msg) => {
+                if let Some(state) = self.session_manager.as_mut() {
+                    state.status = msg;
+                }
+            }
+            SessionManagerAction::Refresh => {
+                // Re-discover and reset the right column (keep the current
+                // session's seeded tree).
+                self.refresh_session_manager();
+            }
+            SessionManagerAction::KillSession(_) | SessionManagerAction::RenameSession { .. } => {
+                // Wired in the next commit (issue #63 L3 commit 9).
+            }
+            SessionManagerAction::FocusWorkspaceInPlace { index } => {
+                self.session.select_workspace(Some(index), None);
+                // The focus change shows up via the next mux event redraw;
+                // keep the overlay open so the user can pick again.
+            }
+            SessionManagerAction::AttachSession { socket } => {
+                // Case (b): quit+reattach lands in a later commit. For now
+                // surface the intent as a status so the key is observable.
+                if let Some(state) = self.session_manager.as_mut() {
+                    state.status =
+                        format!("reattach to {} (wired next)", socket.display());
+                }
+            }
+            SessionManagerAction::AttachOtherSessionWorkspace { socket, index } => {
+                // Best-effort remote focus (one-shot select-workspace) so the
+                // target session lands on the chosen workspace; the TUI
+                // switch itself arrives with the reattach plumbing.
+                let _ = crate::cli::select_workspace_remote(&socket, index);
+                if let Some(state) = self.session_manager.as_mut() {
+                    state.status = format!(
+                        "focused {} → workspace {index} (switch wired next)",
+                        socket.display()
+                    );
+                }
+            }
+        }
+        // After any non-close action, kick off fetches for newly-focused rows.
+        if self.session_manager.is_some() {
+            self.spawn_session_manager_fetches();
+        }
+        Ok(RenderAction::Draw)
+    }
+
+    /// Re-run discovery and reset the overlay's right column (issue #63 L3,
+    /// `R`). Keeps the current session's seeded tree so the user's own
+    /// workspaces stay visible without a socket round trip.
+    fn refresh_session_manager(&mut self) {
+        use crate::session_manager::WorkspaceColumn;
+        let Some(state) = self.session_manager.as_mut() else { return };
+        let own = state.own_socket.clone();
+        let seeded = state.workspaces.get(&own).cloned();
+        let global = crate::cli::GlobalArgs {
+            session: None,
+            socket: Some(own.clone()),
+            json: false,
+        };
+        let mut sessions = crate::cli::discover_sessions(&global);
+        sessions.sort_by(|a, b| b.mtime.cmp(&a.mtime));
+        state.sessions = sessions;
+        state.workspaces.clear();
+        if let Some(tree) = seeded {
+            state.workspaces.insert(own, tree);
+        } else if !self.tree.workspaces.is_empty() {
+            state.workspaces.insert(state.own_socket.clone(), WorkspaceColumn::Ready(self.tree.clone()));
+        }
+        // Re-clamp the cursor to the current session if still present.
+        let sessions = state.sessions.clone();
+        if let Some(idx) =
+            crate::session_manager::current_index(&sessions, &state.own_socket)
+        {
+            state.left_sel = idx;
+        } else {
+            state.left_sel = 0;
+        }
+        state.right_sel = 0;
+        state.status.clear();
     }
 
     /// Handle keys captured by the help overlay. Typeable input is fed to the

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -892,7 +892,7 @@ pub(crate) fn read_pid_file(path: &std::path::Path) -> Option<u32> {
 /// `socket_path` is the exact path to reconnect to; `mtime` is for the
 /// picker's newest-first sort (pid-file mtime preferred — the socket mtime
 /// can shift on each connect — falling back to socket mtime, then `None`).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct DiscoveredSession {
     pub(crate) session: String,
     pub(crate) socket_path: PathBuf,

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -1192,6 +1192,20 @@ fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
 }
 
 fn run_kill_stale(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
+    let cleaned = kill_stale(global);
+    if global.json {
+        println!("{}", json!({ "ok": true, "cleaned": cleaned }));
+    }
+    0
+}
+
+/// Kill every stale (socket-not-connectable) session in the runtime dir
+/// honoured by `global` and return how many were cleaned. Mirrors the
+/// historical `run_kill_stale` semantics (remove `.sock` + `.pid` for each
+/// `!live` row). Shared by the `kill-stale` CLI verb, the interactive
+/// pre-attach picker (L1), and the in-TUI session manager (L3) so all three
+/// exercise one code path.
+pub(crate) fn kill_stale(global: &GlobalArgs) -> usize {
     let mut sessions = discover_sessions(global);
     sessions.sort_by(|a, b| a.session.cmp(&b.session));
     let mut cleaned = 0;
@@ -1202,11 +1216,7 @@ fn run_kill_stale(global: &GlobalArgs, _flags: &FlagMap) -> i32 {
             cleaned += 1;
         }
     }
-
-    if global.json {
-        println!("{}", json!({ "ok": true, "cleaned": cleaned }));
-    }
-    0
+    cleaned
 }
 
 /// `cmux rename-session --old <name> --new <name>` (issue #63). Resolves

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -1064,57 +1064,92 @@ enum RenameOutcome {
 /// events). Returns the parsed outcome. Used by both `run_rename_session`
 /// (CLI verb) and `rename_session_at` (picker helper) so they share one
 /// code path.
-fn rename_rpc(socket: &std::path::Path, new_name: &str) -> RenameOutcome {
+/// Outcome of a one-shot control-socket RPC (connect → write one request
+/// line → read the first matching response, skipping pushed events).
+/// Distinguishes a transport failure (`ConnectErr`) from a server-reported
+/// error (`ServerErr`, also used for malformed replies) so callers like the
+/// `rename-session` exit-code table can map them separately. Shared by
+/// `rename_rpc`, the session-manager overlay's `list-workspaces` fetch, and
+/// its `select-workspace` remote-focus one-shot (issue #63 L3).
+pub(crate) enum OneShotOutcome {
+    /// Server reported `ok:true`. Carries the full parsed response.
+    Ok(Value),
+    /// Server reported `ok:false`, sent a malformed reply, or the transport
+    /// closed before a reply.
+    ServerErr(String),
+    /// Could not establish the connection or a write/read failed.
+    ConnectErr(String),
+}
+
+/// Connect to `socket`, serialise `request` as one JSON line tagged with
+/// `REQUEST_ID`, write it, and read the first non-event response. Bounded by
+/// a 10s read timeout set on the fresh stream. No behaviour change versus
+/// the inlined body `rename_rpc` previously had; the rename flow keeps its
+/// own `RenameOutcome` so its exit-code table (server vs connect error) is
+/// preserved, and now just maps from this generic outcome.
+pub(crate) fn one_shot_rpc(socket: &std::path::Path, request: Value) -> OneShotOutcome {
     let mut stream = match transport::connect(socket) {
         Ok(stream) => stream,
         Err(err) => {
-            return RenameOutcome::ConnectErr(format!(
+            return OneShotOutcome::ConnectErr(format!(
                 "cannot connect to session socket {}: {err}",
                 socket.display()
             ))
         }
     };
     let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
-    let request = json!({ "cmd": "rename-session", "new_name": new_name, "id": REQUEST_ID });
     let mut line = match serde_json::to_vec(&request) {
         Ok(line) => line,
-        Err(err) => return RenameOutcome::ServerErr(format!("failed to encode request: {err}")),
+        Err(err) => return OneShotOutcome::ServerErr(format!("failed to encode request: {err}")),
     };
     line.push(b'\n');
     if let Err(err) = stream.write_all(&line) {
-        return RenameOutcome::ConnectErr(format!("transport error: {err}"));
+        return OneShotOutcome::ConnectErr(format!("transport error: {err}"));
     }
     let mut reader = BufReader::new(stream);
     let mut buf = String::new();
     loop {
         buf.clear();
         match reader.read_line(&mut buf) {
-            Ok(0) => return RenameOutcome::ServerErr("transport closed before response".into()),
+            Ok(0) => return OneShotOutcome::ServerErr("transport closed before response".into()),
             Ok(_) => {}
-            Err(err) => return RenameOutcome::ConnectErr(format!("transport error: {err}")),
+            Err(err) => return OneShotOutcome::ConnectErr(format!("transport error: {err}")),
         }
         let value: Value = match serde_json::from_str(&buf) {
             Ok(value) => value,
-            Err(err) => return RenameOutcome::ServerErr(format!("bad response: {err}")),
+            Err(err) => return OneShotOutcome::ServerErr(format!("bad response: {err}")),
         };
         if value.get("event").is_some() {
             continue;
         }
         if value.get("ok").and_then(Value::as_bool) == Some(true) {
+            return OneShotOutcome::Ok(value);
+        }
+        let err = value.get("error").and_then(Value::as_str).unwrap_or("request failed");
+        return OneShotOutcome::ServerErr(err.to_string());
+    }
+}
+
+/// Send `rename-session` to the daemon at `socket` and parse the reply into
+/// the rename-specific outcome. Delegates the connect/write/read-loop to
+/// `one_shot_rpc` so the rename CLI verb, the picker helper, and the
+/// session-manager overlay share one transport path.
+fn rename_rpc(socket: &std::path::Path, new_name: &str) -> RenameOutcome {
+    let request = json!({ "cmd": "rename-session", "new_name": new_name, "id": REQUEST_ID });
+    match one_shot_rpc(socket, request) {
+        OneShotOutcome::Ok(value) => {
             let data = value.get("data").unwrap_or(&Value::Null);
             let socket_path = data.get("socket_path").and_then(Value::as_str).map(PathBuf::from);
             let pid = data.get("pid").and_then(Value::as_u64);
             match (socket_path, pid) {
-                (Some(p), Some(pid)) => return RenameOutcome::Ok { socket_path: p, pid },
+                (Some(p), Some(pid)) => RenameOutcome::Ok { socket_path: p, pid },
                 _ => {
-                    return RenameOutcome::ServerErr(
-                        "rename response missing socket_path/pid".into(),
-                    )
+                    RenameOutcome::ServerErr("rename response missing socket_path/pid".into())
                 }
             }
         }
-        let err = value.get("error").and_then(Value::as_str).unwrap_or("rename failed");
-        return RenameOutcome::ServerErr(err.to_string());
+        OneShotOutcome::ServerErr(e) => RenameOutcome::ServerErr(e),
+        OneShotOutcome::ConnectErr(e) => RenameOutcome::ConnectErr(e),
     }
 }
 

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -1166,6 +1166,24 @@ pub(crate) fn rename_session_at(
     }
 }
 
+/// Send `select-workspace` (by index) as a one-shot RPC to the daemon at
+/// `socket` so a *different* session lands on workspace `index`. Used by the
+/// in-TUI session manager overlay (issue #63 L3) to focus a workspace in
+/// another session before the running TUI switches to it. Reuses
+/// `one_shot_rpc`, the same path the rename flow rides. Best-effort: an
+/// unreachable socket yields `Err` (the caller renders an `[unreachable]`
+/// column rather than crashing).
+pub(crate) fn select_workspace_remote(
+    socket: &std::path::Path,
+    index: usize,
+) -> Result<(), String> {
+    let request = json!({ "cmd": "select-workspace", "index": index, "id": REQUEST_ID });
+    match one_shot_rpc(socket, request) {
+        OneShotOutcome::Ok(_) => Ok(()),
+        OneShotOutcome::ServerErr(e) | OneShotOutcome::ConnectErr(e) => Err(e),
+    }
+}
+
 fn run_kill_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
     let target_session = flags.optional("session").or_else(|| global.session.clone());
     let Some(session_name) = target_session else {

--- a/mux/crates/mux-tui/src/config.rs
+++ b/mux/crates/mux-tui/src/config.rs
@@ -378,6 +378,7 @@ pub enum Action {
     BrowserEditUrl,
     Detach,
     OpenFuzzyFinder,
+    OpenSessionManager,
     ShowHelp,
 }
 
@@ -417,6 +418,7 @@ impl Action {
             Action::BrowserEditUrl => "browser-edit-url",
             Action::Detach => "detach",
             Action::OpenFuzzyFinder => "open-fuzzy-finder",
+            Action::OpenSessionManager => "open-session-manager",
             Action::ShowHelp => "show-help",
         }
     }
@@ -457,6 +459,7 @@ impl Action {
             Action::BrowserEditUrl => "Edit browser URL",
             Action::Detach => "Detach",
             Action::OpenFuzzyFinder => "Open fuzzy finder",
+            Action::OpenSessionManager => "Open session manager",
             Action::ShowHelp => "Show help",
         }
     }
@@ -497,6 +500,7 @@ impl Action {
             Action::BrowserEditUrl => "Edit the browser URL",
             Action::Detach => "Detach from the current session",
             Action::OpenFuzzyFinder => "Open the fuzzy finder",
+            Action::OpenSessionManager => "Open the session manager overlay",
             Action::ShowHelp => "Show this key binding help",
         }
     }
@@ -536,6 +540,7 @@ impl Action {
             | Action::ScrollDown
             | Action::Detach
             | Action::OpenFuzzyFinder
+            | Action::OpenSessionManager
             | Action::ShowHelp => HelpCategory::Misc,
         }
     }
@@ -629,6 +634,7 @@ impl Default for Keys {
                 bind(KeyCode::Char('u'), Action::BrowserEditUrl),
                 bind(KeyCode::Char('d'), Action::Detach),
                 bind(KeyCode::Char('G'), Action::OpenFuzzyFinder),
+                bind(KeyCode::Char('S'), Action::OpenSessionManager),
                 bind(KeyCode::Char('?'), Action::ShowHelp),
             ],
         }
@@ -819,6 +825,7 @@ fn all_actions() -> &'static [Action] {
         Action::BrowserEditUrl,
         Action::Detach,
         Action::OpenFuzzyFinder,
+        Action::OpenSessionManager,
         Action::ShowHelp,
     ]
 }
@@ -1841,6 +1848,64 @@ sidebar_rail = 77
         assert_eq!(
             keys.action_for(&KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE)),
             Some(Action::ShowHelp)
+        );
+    }
+
+    /// T14 (issue #63 L3): capital `S` (leader prefix + S) opens the
+    /// session manager overlay. Mirrors `default_g_opens_fuzzy_finder`.
+    /// `S` was previously stale help text ("new screen" is `c` today) and
+    /// is otherwise unbound, so binding it here is safe.
+    #[test]
+    fn default_capital_s_opens_session_manager() {
+        let keys = Keys::default();
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('S'), KeyModifiers::NONE)),
+            Some(Action::OpenSessionManager)
+        );
+    }
+
+    /// T15 (issue #63 L3 / #40): the new action is in `all_actions()` so a
+    /// user can rebind it ("open-session-manager" = "..."), and it survives
+    /// the server-chrome `to_raw_map` → `apply` round trip a thin client
+    /// relies on.
+    #[test]
+    fn session_manager_action_is_rebindable_and_round_trips() {
+        assert!(
+            all_actions().contains(&Action::OpenSessionManager),
+            "OpenSessionManager must be in all_actions() to be rebindable"
+        );
+
+        // Rebind it to ctrl-o and confirm the binding takes.
+        let mut keys = Keys::default();
+        let mut raw: HashMap<String, Value> = HashMap::new();
+        raw.insert("open-session-manager".to_string(), Value::String("ctrl+o".to_string()));
+        keys.apply(&raw);
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL)),
+            Some(Action::OpenSessionManager),
+            "rebinding open-session-manager to ctrl+o should take effect"
+        );
+        // The default `S` chord should be gone after the rebind (apply
+        // replaces ALL default chords for the action).
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('S'), KeyModifiers::NONE)),
+            None,
+            "default S chord should be cleared by the rebind"
+        );
+
+        // The default binding round-trips through to_raw_map → apply so a
+        // thin-client attach reproduces the server's resolved keys (#40).
+        let raw = Keys::default().to_raw_map();
+        assert!(
+            raw.get("open-session-manager").is_some(),
+            "open-session-manager must appear in to_raw_map"
+        );
+        let mut round_tripped = Keys { prefix: Keys::default().prefix, bindings: Vec::new() };
+        round_tripped.apply(&raw);
+        assert_eq!(
+            round_tripped.action_for(&KeyEvent::new(KeyCode::Char('S'), KeyModifiers::NONE)),
+            Some(Action::OpenSessionManager),
+            "default S binding must survive the to_raw_map → apply round trip"
         );
     }
 

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -125,7 +125,7 @@ KEYS (prefix: Ctrl-b)
   1-9  select tab
   %  split right       \"  split down          x    close tab
   ,  rename pane       $    rename workspace
-  Tab  next screen     S    new screen
+  Tab  next screen     S    session manager
   h/j/k/l or arrows    move focus              d    quit (attach: detach)
   w  next workspace    W    new workspace       s    toggle sidebar
   <  browser back      >    browser forward     r/u  browser reload/edit URL

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -29,6 +29,7 @@ mod pi_hook;
 mod plugin;
 mod plugin_host;
 mod session;
+mod session_manager;
 mod session_picker;
 mod skill_content;
 mod socket_watchdog;

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -259,6 +259,7 @@ REMOTE (SSH) WORKSPACES
       to it automatically (see mux/docs/getting-started.md).
 ";
 
+#[derive(Clone)]
 struct Args {
     attach: bool,
     session: String,
@@ -502,23 +503,44 @@ fn main() {
     }
 }
 
-fn run_attach(args: Args) -> anyhow::Result<()> {
-    let overlay =
-        if args.apply_local_config { resolve_local_overlay(args.config.as_deref()) } else { None };
-    let socket_path =
-        args.socket.unwrap_or_else(|| mux_core::server::default_socket_path(&args.session));
-    let remote = RemoteSession::connect(&socket_path).with_context(|| {
-        format!("attaching to cmux session socket at {}", socket_path.display())
-    })?;
-    // `--print-resolved-config` is an inspection escape for thin-client
-    // attaches (issue #40 blocker 1): fetch the server's resolved chrome,
-    // layer the local overlay on top, print the merged chrome as JSON,
-    // and exit without starting the TUI. Used by the integration test
-    // that proves the overlay layers over the *server* config.
-    if args.print_resolved_config {
-        return print_resolved_config(remote, overlay);
+fn run_attach(mut args: Args) -> anyhow::Result<()> {
+    // `--print-resolved-config` only fires on the first attach; a session-
+    // manager reattach (RunOutcome::Reattach) re-enters this loop without it.
+    let mut first = true;
+    loop {
+        let overlay =
+            if args.apply_local_config { resolve_local_overlay(args.config.as_deref()) } else { None };
+        let socket_path =
+            args.socket.clone().unwrap_or_else(|| mux_core::server::default_socket_path(&args.session));
+        let remote = RemoteSession::connect(&socket_path).with_context(|| {
+            format!("attaching to cmux session socket at {}", socket_path.display())
+        })?;
+        // `--print-resolved-config` is an inspection escape for thin-client
+        // attaches (issue #40 blocker 1): fetch the server's resolved chrome,
+        // layer the local overlay on top, print the merged chrome as JSON,
+        // and exit without starting the TUI.
+        if first && args.print_resolved_config {
+            return print_resolved_config(remote, overlay);
+        }
+        first = false;
+        match run_tui(Session::Remote(remote), args.session.clone(), overlay)? {
+            app::RunOutcome::Done => return Ok(()),
+            app::RunOutcome::Reattach(socket) => {
+                // Switch the running TUI to another session: derive the
+                // session name from the new socket's stem and loop back into
+                // the attach path. Terminal restore/re-init already bracket
+                // each run_tui call, so the handoff is a clean re-init.
+                let session = socket
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| args.session.clone());
+                args.socket = Some(socket);
+                args.session = session;
+                continue;
+            }
+        }
     }
-    run_tui(Session::Remote(remote), args.session, overlay)
 }
 
 /// Print the merged resolved chrome (server base + local overlay) as a
@@ -587,6 +609,10 @@ fn show_local_config_resolution(args: Args) {
 }
 
 fn run_server(args: Args) -> anyhow::Result<()> {
+    // Snapshot before any field is moved: a session-manager reattach
+    // (RunOutcome::Reattach) re-dispatches into run_attach with the chosen
+    // socket, carrying the local config overlay over.
+    let original_args = args.clone();
     // Issue #28: inherit orphaned pane grandchildren so mux.shutdown()
     // can reap them instead of leaving them under PID 1.
     let _ = mux_core::process::set_child_subreaper();
@@ -606,7 +632,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     }
     // Compute the socket path up front so surface children inherit it.
     let socket_path =
-        args.socket.unwrap_or_else(|| mux_core::server::default_socket_path(&args.session));
+        args.socket.clone().unwrap_or_else(|| mux_core::server::default_socket_path(&args.session));
     surface_options.extra_env.push(("CMUX_MUX_SOCKET".into(), socket_path.display().to_string()));
 
     let mux = Mux::new(args.session.clone(), surface_options);
@@ -645,10 +671,24 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     socket_watchdog::spawn(std::process::id(), &socket_path);
 
     let result = if args.headless {
-        run_headless(&mux, &socket_path)
+        run_headless(&mux, &socket_path).map(|()| app::RunOutcome::Done)
     } else {
-        run_tui(Session::Local(mux.clone()), args.session, None)
+        run_tui(Session::Local(mux.clone()), args.session.clone(), None)
     };
+    if let Ok(app::RunOutcome::Reattach(socket)) = &result {
+        // The session-manager overlay asked to switch the TUI to another
+        // session. Keep THIS local server alive (headless) so the user can
+        // return to it later — skip shutdown/cleanup — and re-dispatch into
+        // the attach path against the chosen socket. (On a reattach from a
+        // local session the local server survives as a headless daemon.)
+        let mut attach_args = original_args.clone();
+        if let Some(session) = socket.file_stem().and_then(|s| s.to_str()) {
+            attach_args.session = session.to_string();
+        }
+        attach_args.socket = Some(socket.clone());
+        attach_args.attach = true;
+        return run_attach(attach_args);
+    }
     mux.shutdown();
     // Issue #28: after known surfaces are killed, sweep anything that
     // reparented to us via PR_SET_CHILD_SUBREAPER (grandchildren whose
@@ -658,14 +698,14 @@ fn run_server(args: Args) -> anyhow::Result<()> {
         mux_core::process::kill_remaining_children();
     }
     mux_core::server::cleanup(&mux.socket_path().unwrap_or_else(|| socket_path.clone()));
-    result
+    result.map(|_| ())
 }
 
 fn run_tui(
     session: Session,
     session_label: String,
     overlay: Option<config::Overlay>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<app::RunOutcome> {
     crossterm::terminal::enable_raw_mode()?;
     let colors = host_colors::probe_default_colors();
     let color_result = session.set_default_colors(colors);

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -316,6 +316,17 @@ impl Session {
         }
     }
 
+    /// The control-socket path this session is bound to, or `None` for a
+    /// local session that has not yet been served. Exposed so the
+    /// session-manager overlay can tag its own `[current]` row by
+    /// comparing sockets (issue #63 L3).
+    pub fn socket_path(&self) -> Option<std::path::PathBuf> {
+        match self {
+            Session::Local(mux) => mux.socket_path(),
+            Session::Remote(remote) => Some(remote.socket_path()),
+        }
+    }
+
     pub fn focus_pane(&self, pane: PaneId) {
         match self {
             Session::Local(mux) => {
@@ -684,6 +695,8 @@ impl SurfaceHandle {
 #[cfg(test)]
 mod tests {
     use super::resize_action;
+    use super::Session;
+    use mux_core::{Mux, SurfaceOptions};
 
     #[test]
     fn first_layout_after_attach_sends_ordered_resize() {
@@ -717,5 +730,16 @@ mod tests {
         let desired = (123, 65);
         assert!(!resize_action(desired, Some(desired), desired, false));
         assert!(!resize_action(desired, Some(desired), desired, true));
+    }
+
+    /// Issue #63 L3: `Session::socket_path` reports the live socket so the
+    /// session-manager overlay can tag its own `[current]` row. A local
+    /// session delegates to `Mux::socket_path`; a freshly-created mux (not
+    /// yet served) reports `None`.
+    #[test]
+    fn local_session_reports_none_before_serve() {
+        let mux = Mux::new("smgr-sock", SurfaceOptions::default());
+        let unserved = Session::Local(mux);
+        assert_eq!(unserved.socket_path(), None);
     }
 }

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -22,7 +22,7 @@ use mux_core::{
 use serde_json::json;
 
 pub use remote::{RemoteSession, RemoteSurface};
-pub use tree::TreeView;
+pub use tree::{parse_tree, TreeView, WorkspaceView};
 
 pub enum Session {
     Local(Arc<Mux>),

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -22,7 +22,7 @@ use mux_core::{
 use serde_json::json;
 
 pub use remote::{RemoteSession, RemoteSurface};
-pub use tree::{parse_tree, TreeView, WorkspaceView};
+pub use tree::{parse_tree, TreeView};
 
 pub enum Session {
     Local(Arc<Mux>),

--- a/mux/crates/mux-tui/src/session/remote.rs
+++ b/mux/crates/mux-tui/src/session/remote.rs
@@ -171,6 +171,7 @@ impl RemoteSurface {
 }
 
 pub struct RemoteSession {
+    socket: std::path::PathBuf,
     writer: Mutex<Box<dyn transport::Stream>>,
     pending: Mutex<HashMap<u64, Sender<Value>>>,
     next_id: AtomicU64,
@@ -188,6 +189,7 @@ impl RemoteSession {
         })?;
         let read_half = stream.try_clone_box()?;
         let session = Arc::new(RemoteSession {
+            socket: path.to_path_buf(),
             writer: Mutex::new(stream),
             pending: Mutex::new(HashMap::new()),
             next_id: AtomicU64::new(1),
@@ -231,6 +233,15 @@ impl RemoteSession {
     fn emit(&self, event: MuxEvent) {
         let mut subs = self.subscribers.lock().unwrap();
         subs.retain(|tx| tx.send(event.clone()).is_ok());
+    }
+
+    /// The control-socket path this remote is bound to (set at `connect`
+    /// time; never moves even if the server later renames, since a remote
+    /// attach holds one connection for its lifetime). Exposed so the
+    /// session-manager overlay can tag its own `[current]` row by
+    /// comparing sockets (issue #63 L3).
+    pub fn socket_path(&self) -> std::path::PathBuf {
+        self.socket.clone()
     }
 
     pub fn subscribe(&self) -> Receiver<MuxEvent> {

--- a/mux/crates/mux-tui/src/session_manager.rs
+++ b/mux/crates/mux-tui/src/session_manager.rs
@@ -139,9 +139,16 @@ pub struct SessionManagerState {
 
 impl SessionManagerState {
     pub fn new(own_socket: PathBuf, sessions: Vec<DiscoveredSession>) -> Self {
+        let mut workspaces = HashMap::new();
+        // Every discovered session starts NotFetched; the App overrides the
+        // current session's column with a Ready tree (free, from App::tree)
+        // and worker threads fill the rest as they gain focus.
+        for s in &sessions {
+            workspaces.insert(s.socket_path.clone(), WorkspaceColumn::NotFetched);
+        }
         SessionManagerState {
             sessions,
-            workspaces: HashMap::new(),
+            workspaces,
             left_sel: 0,
             right_sel: 0,
             focus: Column::Left,
@@ -490,6 +497,182 @@ pub fn fetch_workspaces(socket: &Path) -> WorkspaceColumn {
     }
 }
 
+/// Render the session manager overlay (issue #63 L3). A centred modal split
+/// into a left sessions column and a right workspaces column, with a footer
+/// for the `/` filter input, the rename/confirm prompts, and a status line.
+/// Mirrors the finder/help overlay shape; no socket I/O (the state already
+/// owns the preview trees the worker threads filled in).
+pub fn draw(app: &mut crate::app::App, frame: &mut ratatui::Frame) {
+    use ratatui::layout::{Constraint, Direction, Layout};
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+
+    let area = frame.area();
+    let width = 80u16.min(area.width.saturating_sub(2)).max(40);
+    let height = 20u16.min(area.height.saturating_sub(2)).max(10);
+    let rect = ratatui::layout::Rect {
+        x: area.x + (area.width - width) / 2,
+        y: area.y + (area.height - height) / 2,
+        width,
+        height,
+    };
+
+    let Some(state) = app.session_manager.as_ref() else { return };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(4), Constraint::Length(3)])
+        .split(rect);
+    let body = chunks[0];
+    let footer = chunks[1];
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(body);
+    let left_area = columns[0];
+    let right_area = columns[1];
+
+    // Left column: filtered session rows with [current]/[unreachable] tags.
+    let visible = state.filtered_sessions();
+    let dim = Style::default().fg(Color::DarkGray);
+    let current_tag = Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+    let items: Vec<ListItem> = visible
+        .iter()
+        .map(|&i| {
+            let s = &state.sessions[i];
+            let is_current = s.socket_path == state.own_socket;
+            let mut spans = Vec::new();
+            if is_current {
+                spans.push(Span::styled("[current] ", current_tag));
+            }
+            if !s.live {
+                spans.push(Span::styled(format!("[unreachable] {}", s.session), dim));
+            } else {
+                spans.push(Span::raw(s.session.clone()));
+            }
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+    let mut left_state = ListState::default();
+    // Map the raw cursor to its position in the filtered view.
+    let cursor_pos = visible.iter().position(|&i| i == state.left_sel);
+    left_state.select(cursor_pos);
+    let left_title = format!(" sessions ({}) ", visible.len());
+    let left_block = Block::default()
+        .borders(Borders::ALL)
+        .title(left_title)
+        .border_style(if state.focus == Column::Left {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        });
+    frame.render_stateful_widget(
+        List::new(items)
+            .block(left_block)
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+            .highlight_symbol("▶ "),
+        left_area,
+        &mut left_state,
+    );
+
+    // Right column: the focused session's workspace preview.
+    let focused = state.focused_session();
+    let right_title = match focused {
+        Some(s) => format!(" workspaces: {} ", s.session),
+        None => " workspaces ".to_string(),
+    };
+    let right_block = Block::default()
+        .borders(Borders::ALL)
+        .title(right_title)
+        .border_style(if state.focus == Column::Right {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        });
+    let right_lines: Vec<Line> = match focused.and_then(|s| state.workspaces.get(&s.socket_path)) {
+        Some(WorkspaceColumn::Ready(tree)) => {
+            let mut lines = Vec::new();
+            for (i, ws) in tree.workspaces.iter().enumerate() {
+                let style = if i == state.right_sel {
+                    Style::default().add_modifier(Modifier::REVERSED)
+                } else {
+                    Style::default()
+                };
+                let marker = if i == tree.active_workspace { "● " } else { "  " };
+                lines.push(Line::from(Span::styled(
+                    format!("{marker}{}", ws.name),
+                    style,
+                )));
+            }
+            lines
+        }
+        Some(WorkspaceColumn::Loading) => vec![Line::from(Span::styled(
+            " loading… ",
+            Style::default().fg(Color::DarkGray),
+        ))],
+        Some(WorkspaceColumn::Unreachable) => vec![Line::from(Span::styled(
+            " [unreachable] — socket not connectable ",
+            dim,
+        ))],
+        Some(WorkspaceColumn::NotFetched) | None => vec![Line::from(Span::styled(
+            " (focus a session to preview its workspaces) ",
+            Style::default().fg(Color::DarkGray),
+        ))],
+    };
+    frame.render_widget(
+        Paragraph::new(right_lines).block(right_block),
+        right_area,
+    );
+
+    // Footer: the active prompt (filter / rename / confirm-kill) on row 1,
+    // keymap hints + status on row 2.
+    let mut lines = Vec::new();
+    match &state.mode {
+        Mode::Browse => {
+            if let Some(input) = &state.filter {
+                let mut spans = vec![Span::styled("/ ", Style::default().fg(Color::Cyan))];
+                spans.push(Span::raw(input.as_str().to_string()));
+                lines.push(Line::from(spans));
+            } else {
+                lines.push(Line::from(Span::styled(
+                    "j/k move · Tab/l right · h/Left left · Enter attach/focus · r rename · x kill · / filter · R refresh · q/Esc close",
+                    Style::default().fg(Color::DarkGray),
+                )));
+            }
+        }
+        Mode::ConfirmKill { name, .. } => {
+            lines.push(Line::from(Span::styled(
+                format!("Kill {name}?  y/N  (any other key cancels)"),
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            )));
+        }
+        Mode::Rename { old_name, input, .. } => {
+            let mut spans = vec![Span::styled(
+                format!("rename {old_name} → "),
+                Style::default().fg(Color::Cyan),
+            )];
+            spans.push(Span::raw(input.as_str().to_string()));
+            lines.push(Line::from(spans));
+        }
+    }
+    if !state.status.is_empty() {
+        lines.push(Line::from(Span::styled(
+            state.status.as_str(),
+            Style::default().fg(Color::Yellow),
+        )));
+    }
+    frame.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" session manager ")
+                .border_style(Style::default().fg(Color::DarkGray)),
+        ),
+        footer,
+    );
+}
+
 #[cfg(test)]
 mod tests {
     //! Pure state-machine + filter + discovery tests (scout-plan T1-T9).
@@ -509,20 +692,15 @@ mod tests {
     }
 
     /// A minimal tree with `n` workspaces named w0..wN-1, for right-column
-    /// fixtures.
+    /// fixtures. Built via `parse_tree` so the fixture exercises the same
+    /// JSON→tree path the worker uses.
     fn mk_tree(n: usize) -> TreeView {
-        let workspaces = (0..n)
-            .map(|i| crate::session::WorkspaceView {
-                id: i as u64,
-                short_id: format!("w{i}"),
-                name: format!("w{i}"),
-                color: None,
-                icon: None,
-                screens: Vec::new(),
-                active_screen: 0,
+        let workspaces: Vec<serde_json::Value> = (0..n)
+            .map(|i| {
+                serde_json::json!({ "id": i, "name": format!("w{i}"), "active": i == 0, "screens": [] })
             })
             .collect();
-        TreeView { workspaces, active_workspace: 0 }
+        parse_tree(&serde_json::json!({ "workspaces": workspaces }))
     }
 
     /// T1 — AC6: `current_index` tags the running session's row.

--- a/mux/crates/mux-tui/src/session_manager.rs
+++ b/mux/crates/mux-tui/src/session_manager.rs
@@ -1,0 +1,418 @@
+//! In-TUI session manager overlay (issue #63, layer L3).
+//!
+//! Opened by leader (Ctrl-b) + `S`, this overlay is a two-column modal:
+//! the left column lists every discovered cmux session (reusing
+//! [`crate::cli::discover_sessions`], the same path `list-sessions`
+//! walks), and the right column previews the *focused* session's
+//! workspaces, lazy-fetched over a one-shot `list-workspaces` socket RPC
+//! on a worker thread (all socket I/O off the UI thread). The overlay
+//! reuses the L1 kill, L2 rename, and `select-workspace` helpers — it
+//! forks none of them.
+//!
+//! This module owns the **pure** state machine + the worker entry point;
+//! the App wires up key dispatch, the `AppEvent::SessionManagerUpdate`
+//! bridge, and the render branch (see `app.rs` / `ui/mod.rs`). The state
+//! owns its data outright (like `FinderState`) so input handling never
+//! borrows the live `Session`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::cli::DiscoveredSession;
+use crate::session::TreeView;
+use crate::ui::input::TextInput;
+
+/// Which overlay column currently holds the cursor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Column {
+    Left,
+    Right,
+}
+
+/// Right-column state for a single session's workspaces.
+///
+/// `Debug` is implemented by hand so the (deeply-nested) `TreeView` does
+/// not need to derive it.
+pub enum WorkspaceColumn {
+    /// Before the session ever gained focus (or before the overlay opened
+    /// for a non-current session). Distinct from `Loading` so the draw
+    /// path can render a hint rather than a spinner.
+    NotFetched,
+    /// A `list-workspaces` RPC is in flight on a worker thread.
+    Loading,
+    /// The RPC returned a tree.
+    Ready(TreeView),
+    /// The socket is present but not connectable (dead daemon / stale row).
+    Unreachable,
+}
+
+impl std::fmt::Debug for WorkspaceColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkspaceColumn::NotFetched => write!(f, "NotFetched"),
+            WorkspaceColumn::Loading => write!(f, "Loading"),
+            WorkspaceColumn::Ready(tree) => {
+                write!(f, "Ready({} workspace(s))", tree.workspaces.len())
+            }
+            WorkspaceColumn::Unreachable => write!(f, "Unreachable"),
+        }
+    }
+}
+
+impl Clone for WorkspaceColumn {
+    fn clone(&self) -> Self {
+        match self {
+            WorkspaceColumn::NotFetched => WorkspaceColumn::NotFetched,
+            WorkspaceColumn::Loading => WorkspaceColumn::Loading,
+            WorkspaceColumn::Ready(tree) => WorkspaceColumn::Ready(tree.clone()),
+            WorkspaceColumn::Unreachable => WorkspaceColumn::Unreachable,
+        }
+    }
+}
+
+/// Inline modal the overlay can be in. Mirrors `session_picker::Mode`
+/// (Browse/ConfirmKill/Rename). The `/` filter lives in
+/// [`SessionManagerState::filter`] independently.
+#[derive(Debug, Clone)]
+pub enum Mode {
+    Browse,
+    /// y/N confirmation for killing a session row.
+    ConfirmKill { index: usize, name: String },
+    /// Inline rename of the focused LIVE session (reuses
+    /// `cli::rename_session_at`). `socket_path` is the session's current
+    /// socket; `old_name` pre-fills the input.
+    Rename { socket_path: PathBuf, old_name: String, input: TextInput },
+}
+
+/// What `handle_key` wants the App to do after handling a key. Mirrors the
+/// finder/picker action enums — the state machine decides, the App acts.
+#[derive(Debug, Clone)]
+pub enum SessionManagerAction {
+    None,
+    /// Redraw the overlay (selection/mode/status changed).
+    Redraw,
+    /// q / Esc / leader-S: close the overlay and restore focus.
+    Close,
+    /// The focused session's workspaces need a lazy fetch (App spawns a
+    /// worker). Emitted implicitly via [`SessionManagerState::fetch_requests`].
+    RequestFetch(PathBuf),
+    /// Kill the session at this row index (App calls `cli::kill_session_at`).
+    KillSession(usize),
+    /// Commit the rename: App calls `cli::rename_session_at(socket, new_name)`.
+    RenameSession { socket: PathBuf, new_name: String },
+    /// Attach to another session (case b, left row Enter). The App does the
+    /// quit+reattach (`RunOutcome::Reattach`).
+    AttachSession { socket: PathBuf },
+    /// Focus a workspace in the *current* session in-process (case a).
+    FocusWorkspaceInPlace { index: usize },
+    /// Focus a workspace in an *other* session remotely (select-workspace
+    /// one-shot RPC) and reattach to it (case b, right row Enter).
+    AttachOtherSessionWorkspace { socket: PathBuf, index: usize },
+    /// A transient status line message (e.g. "unreachable — cannot attach").
+    SetStatus(String),
+}
+
+/// Overlay state. Constructed by the App on open (which seeds the current
+/// session's right column for free from `App::tree`); mutated by
+/// [`handle_key`](Self::handle_key) and by worker results landing via
+/// [`set_workspaces`](Self::set_workspaces).
+#[derive(Debug, Clone)]
+pub struct SessionManagerState {
+    pub sessions: Vec<DiscoveredSession>,
+    pub workspaces: HashMap<PathBuf, WorkspaceColumn>,
+    pub left_sel: usize,
+    pub right_sel: usize,
+    pub focus: Column,
+    /// `Some` when the `/` substring filter is active.
+    pub filter: Option<TextInput>,
+    pub status: String,
+    pub mode: Mode,
+    /// The running TUI's own socket, for `[current]` tagging and the
+    /// in-place vs reattach decision.
+    pub own_socket: PathBuf,
+    /// Set when the user picked another session to reattach to. The App
+    /// drains this after `app::run` returns to drive `RunOutcome::Reattach`.
+    pub pending_reattach: Option<PathBuf>,
+}
+
+impl SessionManagerState {
+    pub fn new(own_socket: PathBuf, sessions: Vec<DiscoveredSession>) -> Self {
+        SessionManagerState {
+            sessions,
+            workspaces: HashMap::new(),
+            left_sel: 0,
+            right_sel: 0,
+            focus: Column::Left,
+            filter: None,
+            status: String::new(),
+            mode: Mode::Browse,
+            own_socket,
+            pending_reattach: None,
+        }
+    }
+
+    /// Indices of sessions passing the active `/` filter (or every session
+    /// when the filter is inactive). Unit-testable: the predicate is pure.
+    pub fn filtered_sessions(&self) -> Vec<usize> {
+        // STUB (commit 4 RED): returns every row unfiltered so T4 fails.
+        (0..self.sessions.len()).collect()
+    }
+
+    /// The session row currently under the left-column cursor.
+    pub fn focused_session(&self) -> Option<&DiscoveredSession> {
+        self.sessions.get(self.left_sel)
+    }
+
+    /// The ready workspace tree for the focused session, if fetched.
+    pub fn focused_workspaces(&self) -> Option<&TreeView> {
+        let socket = self.focused_session()?.socket_path.clone();
+        match self.workspaces.get(&socket)? {
+            WorkspaceColumn::Ready(tree) => Some(tree),
+            _ => None,
+        }
+    }
+
+    /// Route a key to an action. Pure (no I/O); the App interprets the
+    /// returned [`SessionManagerAction`].
+    pub fn handle_key(&mut self, _key: KeyEvent) -> SessionManagerAction {
+        // STUB (commit 4 RED): does nothing so T5-T9 fail.
+        SessionManagerAction::None
+    }
+
+    /// Drain a pending reattach target after the App decided to quit.
+    pub fn take_reattach_target(&mut self) -> Option<PathBuf> {
+        self.pending_reattach.take()
+    }
+
+    /// Merge a worker result into the right-column map.
+    pub fn set_workspaces(&mut self, socket: PathBuf, column: WorkspaceColumn) {
+        self.workspaces.insert(socket, column);
+    }
+}
+
+/// Index of the session whose socket == the running TUI's socket. `None`
+/// when the running session is absent from the discovered set (e.g. a
+/// `--socket` override pointing outside the runtime dir). Pure.
+pub fn current_index(sessions: &[DiscoveredSession], _own: &Path) -> Option<usize> {
+    // STUB (commit 4 RED): always None so T1 fails.
+    let _ = sessions;
+    None
+}
+
+/// Substring filter predicate (case-insensitive) on the session name OR any
+/// workspace title. An empty query passes everything. Pure, so the filter
+/// is testable without sockets.
+pub fn passes_filter(_query: &str, _session: &str, _ws_titles: &[String]) -> bool {
+    // STUB (commit 4 RED): always passes so T2 fails.
+    true
+}
+
+/// Which row indices should be prefetched given the current focus and a
+/// lookahead count (focus + the next `lookahead` rows), clamped to `len`
+/// and de-duplicated. Pure.
+pub fn prefetch_targets(_left_sel: usize, _lookahead: usize, _len: usize) -> Vec<usize> {
+    // STUB (commit 4 RED): returns nothing so T3 fails.
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure state-machine + filter + discovery tests (scout-plan T1-T9).
+    //! These drive the logic the App relies on without any socket I/O or
+    //! PTY harness. Committed RED (commit 4) before the GREEN impl (commit 5).
+    use super::*;
+    use std::time::SystemTime;
+
+    fn mk_session(name: &str, socket: &str, live: bool) -> DiscoveredSession {
+        DiscoveredSession {
+            session: name.to_string(),
+            socket_path: PathBuf::from(socket),
+            pid: Some(1000),
+            live,
+            mtime: Some(SystemTime::UNIX_EPOCH),
+        }
+    }
+
+    /// A minimal tree with `n` workspaces named w0..wN-1, for right-column
+    /// fixtures.
+    fn mk_tree(n: usize) -> TreeView {
+        let workspaces = (0..n)
+            .map(|i| crate::session::WorkspaceView {
+                id: i as u64,
+                short_id: format!("w{i}"),
+                name: format!("w{i}"),
+                color: None,
+                icon: None,
+                screens: Vec::new(),
+                active_screen: 0,
+            })
+            .collect();
+        TreeView { workspaces, active_workspace: 0 }
+    }
+
+    /// T1 — AC6: `current_index` tags the running session's row.
+    #[test]
+    fn t1_current_index_tags_running_session() {
+        let sessions = vec![
+            mk_session("alpha", "/run/a.sock", true),
+            mk_session("beta", "/run/b.sock", true),
+            mk_session("gamma", "/run/c.sock", true),
+        ];
+        assert_eq!(current_index(&sessions, Path::new("/run/b.sock")), Some(1));
+        assert_eq!(current_index(&sessions, Path::new("/run/zzz.sock")), None);
+    }
+
+    /// T2 — AC4: `passes_filter` is a case-insensitive substring match on
+    /// the session name OR any workspace title; empty query passes.
+    #[test]
+    fn t2_passes_filter_matches_session_or_workspace_title() {
+        assert!(passes_filter("", "alpha", &[]), "empty query always passes");
+        assert!(passes_filter("ALP", "alpha", &[]), "session name matches (case-insensitive)");
+        assert!(!passes_filter("xyz", "alpha", &[]), "non-matching session rejects");
+        assert!(
+            passes_filter("build", "alpha", &["main".into(), "build-ci".into()]),
+            "workspace title matches"
+        );
+        assert!(
+            !passes_filter("nomatch", "alpha", &["main".into(), "build-ci".into()]),
+            "non-matching workspace rejects"
+        );
+    }
+
+    /// T3 — AC3: `prefetch_targets` returns focus + the next `lookahead`
+    /// rows, clamped to the list length.
+    #[test]
+    fn t3_prefetch_targets_returns_focus_plus_lookahead() {
+        assert_eq!(prefetch_targets(1, 1, 4), vec![1, 2]);
+        // At the end, lookahead clamps away.
+        assert_eq!(prefetch_targets(3, 1, 4), vec![3]);
+        // Lookahead beyond the end is fully clamped.
+        assert_eq!(prefetch_targets(0, 5, 2), vec![0, 1]);
+    }
+
+    /// T4 — AC4: `filtered_sessions` excludes rows that fail the filter.
+    #[test]
+    fn t4_filtered_sessions_excludes_non_matches() {
+        let sessions = vec![
+            mk_session("alpha", "/run/a.sock", true),
+            mk_session("beta", "/run/b.sock", true),
+            mk_session("gamma", "/run/c.sock", true),
+        ];
+        let mut state = SessionManagerState::new(PathBuf::from("/run/a.sock"), sessions);
+        state.filter = Some(TextInput::new("gam".to_string()));
+        assert_eq!(state.filtered_sessions(), vec![2], "only gamma matches 'gam'");
+    }
+
+    /// T5 — AC8: Enter on an `[unreachable]` row sets a status hint, it
+    /// does not emit an attach.
+    #[test]
+    fn t5_unreachable_row_is_selectable_for_kill_but_not_attach() {
+        let sessions = vec![
+            mk_session("live", "/run/live.sock", true),
+            mk_session("dead", "/run/dead.sock", false),
+        ];
+        let mut state = SessionManagerState::new(PathBuf::from("/run/live.sock"), sessions);
+        state.left_sel = 1; // focus the dead row
+        let action = state.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            matches!(action, SessionManagerAction::SetStatus(_)),
+            "Enter on unreachable must SetStatus, got {action:?}"
+        );
+    }
+
+    /// T6 — AC5/AC6: Enter on a workspace in the *current* session focuses
+    /// it in place (no reattach).
+    #[test]
+    fn t6_enter_on_current_session_workspace_focuses_in_place() {
+        let own = PathBuf::from("/run/own.sock");
+        let sessions = vec![mk_session("own", "/run/own.sock", true)];
+        let mut state = SessionManagerState::new(own, sessions);
+        // Seed the current session's workspaces (the App does this for free).
+        state.set_workspaces(PathBuf::from("/run/own.sock"), WorkspaceColumn::Ready(mk_tree(2)));
+        // Move to the right column and pick workspace index 1.
+        state.focus = Column::Right;
+        state.right_sel = 1;
+        let action = state.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            matches!(action, SessionManagerAction::FocusWorkspaceInPlace { index } if index == 1),
+            "Enter on current-session workspace must focus in place, got {action:?}"
+        );
+    }
+
+    /// T7 — AC5: Enter on a workspace in an *other* session emits a
+    /// remote-focus + reattach action carrying the target socket + index.
+    #[test]
+    fn t7_enter_on_other_session_workspace_emits_reattach() {
+        let sessions = vec![
+            mk_session("own", "/run/own.sock", true),
+            mk_session("other", "/run/other.sock", true),
+        ];
+        let mut state = SessionManagerState::new(PathBuf::from("/run/own.sock"), sessions);
+        state.left_sel = 1; // focus the other session
+        state.set_workspaces(
+            PathBuf::from("/run/other.sock"),
+            WorkspaceColumn::Ready(mk_tree(3)),
+        );
+        state.focus = Column::Right;
+        state.right_sel = 2;
+        let action = state.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            matches!(
+                action,
+                SessionManagerAction::AttachOtherSessionWorkspace { ref socket, index }
+                    if *socket == Path::new("/run/other.sock") && index == 2
+            ),
+            "Enter on other-session workspace must emit reattach, got {action:?}"
+        );
+    }
+
+    /// T8 — AC7: q / Esc close the overlay.
+    #[test]
+    fn t8_close_keys_q_esc_restore_focus() {
+        let mut state =
+            SessionManagerState::new(PathBuf::from("/run/own.sock"), vec![mk_session("own", "/run/own.sock", true)]);
+        for key in [
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        ] {
+            let action = state.handle_key(key);
+            assert!(matches!(action, SessionManagerAction::Close), "close key must Close, got {action:?}");
+            // Re-open for the next iteration's sake.
+            state = SessionManagerState::new(
+                PathBuf::from("/run/own.sock"),
+                vec![mk_session("own", "/run/own.sock", true)],
+            );
+        }
+    }
+
+    /// T9 — AC7: the rename flow emits a `RenameSession` action shaped for
+    /// `cli::rename_session_at`. (The helper itself is L2-tested.)
+    #[test]
+    fn t9_rename_flow_reuses_rename_session_at_contract() {
+        let sessions = vec![
+            mk_session("own", "/run/own.sock", true),
+            mk_session("live", "/run/live.sock", true),
+        ];
+        let mut state = SessionManagerState::new(PathBuf::from("/run/own.sock"), sessions);
+        state.left_sel = 1; // focus the live session
+        // `r` enters rename mode.
+        let enter = state.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
+        assert!(matches!(enter, SessionManagerAction::Redraw), "r must enter rename mode (Redraw), got {enter:?}");
+        // Type a new name.
+        state.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE));
+        state.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
+        state.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
+        // Enter commits.
+        let commit = state.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            matches!(
+                commit,
+                SessionManagerAction::RenameSession { ref socket, ref new_name }
+                    if *socket == Path::new("/run/live.sock") && new_name == "bar"
+            ),
+            "Enter in rename mode must commit RenameSession, got {commit:?}"
+        );
+    }
+}

--- a/mux/crates/mux-tui/src/session_manager.rs
+++ b/mux/crates/mux-tui/src/session_manager.rs
@@ -99,9 +99,10 @@ pub enum SessionManagerAction {
     KillSession(usize),
     /// Commit the rename: App calls `cli::rename_session_at(socket, new_name)`.
     RenameSession { socket: PathBuf, new_name: String },
-    /// Attach to another session (case b, left row Enter). The App does the
-    /// quit+reattach (`RunOutcome::Reattach`).
-    AttachSession { socket: PathBuf },
+    /// Attach to another session (case b, left row Enter). The App quits and
+    /// the caller re-attaches via `RunOutcome::Reattach`; the target socket
+    /// is recorded in `SessionManagerState::pending_reattach`.
+    AttachSession,
     /// Focus a workspace in the *current* session in-process (case a).
     FocusWorkspaceInPlace { index: usize },
     /// Focus a workspace in an *other* session remotely (select-workspace
@@ -352,7 +353,10 @@ impl SessionManagerState {
                 "already attached to this session".to_string(),
             );
         }
-        SessionManagerAction::AttachSession { socket: s.socket_path }
+        // Record the reattach target so `take_reattach_target` can drain it
+        // after the App quits; the action lets the App know to stop the loop.
+        self.pending_reattach = Some(s.socket_path.clone());
+        SessionManagerAction::AttachSession
     }
 
     /// Right-column Enter: focus a workspace in the focused session
@@ -365,6 +369,9 @@ impl SessionManagerState {
         if s.socket_path == self.own_socket {
             SessionManagerAction::FocusWorkspaceInPlace { index }
         } else {
+            // Remote-focus + reattach: record the target (drained by
+            // `take_reattach_target` after the App quits).
+            self.pending_reattach = Some(s.socket_path.clone());
             SessionManagerAction::AttachOtherSessionWorkspace { socket: s.socket_path, index }
         }
     }
@@ -816,6 +823,19 @@ mod tests {
                     if *socket == Path::new("/run/other.sock") && index == 2
             ),
             "Enter on other-session workspace must emit reattach, got {action:?}"
+        );
+        // Commit 10: the state records the reattach target so the App can
+        // drain it (take_reattach_target) after quitting — the contract
+        // RunOutcome::Reattach rides on.
+        assert_eq!(
+            state.take_reattach_target(),
+            Some(PathBuf::from("/run/other.sock")),
+            "reattach must record the target socket for the App to drain"
+        );
+        assert_eq!(
+            state.take_reattach_target(),
+            None,
+            "take_reattach_target must drain (second call is None)"
         );
     }
 

--- a/mux/crates/mux-tui/src/session_manager.rs
+++ b/mux/crates/mux-tui/src/session_manager.rs
@@ -22,7 +22,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::cli::DiscoveredSession;
 use crate::session::TreeView;
-use crate::ui::input::TextInput;
+use crate::ui::input::{InputEvent, TextInput};
 
 /// Which overlay column currently holds the cursor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,9 +95,6 @@ pub enum SessionManagerAction {
     Redraw,
     /// q / Esc / leader-S: close the overlay and restore focus.
     Close,
-    /// The focused session's workspaces need a lazy fetch (App spawns a
-    /// worker). Emitted implicitly via [`SessionManagerState::fetch_requests`].
-    RequestFetch(PathBuf),
     /// Kill the session at this row index (App calls `cli::kill_session_at`).
     KillSession(usize),
     /// Commit the rename: App calls `cli::rename_session_at(socket, new_name)`.
@@ -112,6 +109,9 @@ pub enum SessionManagerAction {
     AttachOtherSessionWorkspace { socket: PathBuf, index: usize },
     /// A transient status line message (e.g. "unreachable — cannot attach").
     SetStatus(String),
+    /// Re-run discovery and reset the right column (the App rebuilds the
+    /// session list and clears the workspace cache).
+    Refresh,
 }
 
 /// Overlay state. Constructed by the App on open (which seeds the current
@@ -156,8 +156,22 @@ impl SessionManagerState {
     /// Indices of sessions passing the active `/` filter (or every session
     /// when the filter is inactive). Unit-testable: the predicate is pure.
     pub fn filtered_sessions(&self) -> Vec<usize> {
-        // STUB (commit 4 RED): returns every row unfiltered so T4 fails.
-        (0..self.sessions.len()).collect()
+        let query = match &self.filter {
+            Some(f) => f.as_str(),
+            None => return (0..self.sessions.len()).collect(),
+        };
+        self.sessions
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| {
+                let titles = self.workspace_titles(&s.socket_path);
+                if passes_filter(query, &s.session, &titles) {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// The session row currently under the left-column cursor.
@@ -174,11 +188,242 @@ impl SessionManagerState {
         }
     }
 
+    /// Workspace titles (names) for the right-column filter when a tree is
+    /// `Ready`; empty otherwise. Cheap (no clone of the tree).
+    fn workspace_titles(&self, socket: &Path) -> Vec<String> {
+        match self.workspaces.get(socket) {
+            Some(WorkspaceColumn::Ready(tree)) => {
+                tree.workspaces.iter().map(|w| w.name.clone()).collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
     /// Route a key to an action. Pure (no I/O); the App interprets the
     /// returned [`SessionManagerAction`].
-    pub fn handle_key(&mut self, _key: KeyEvent) -> SessionManagerAction {
-        // STUB (commit 4 RED): does nothing so T5-T9 fail.
-        SessionManagerAction::None
+    pub fn handle_key(&mut self, key: KeyEvent) -> SessionManagerAction {
+        // Ctrl-C aborts from any mode.
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            return SessionManagerAction::Close;
+        }
+        match self.mode.clone() {
+            Mode::ConfirmKill { index, name } => match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    self.mode = Mode::Browse;
+                    self.status = format!("killed {name}");
+                    SessionManagerAction::KillSession(index)
+                }
+                _ => {
+                    self.mode = Mode::Browse;
+                    SessionManagerAction::Redraw
+                }
+            },
+            Mode::Rename { socket_path, old_name, mut input } => {
+                match input.handle_key(&key) {
+                    InputEvent::Commit => {
+                        let new_name = input.as_str().trim().to_string();
+                        self.mode = Mode::Browse;
+                        if new_name.is_empty() {
+                            self.status = "session name cannot be empty".to_string();
+                            return SessionManagerAction::Redraw;
+                        }
+                        if new_name == old_name {
+                            self.status = format!("unchanged ({old_name})");
+                            return SessionManagerAction::Redraw;
+                        }
+                        SessionManagerAction::RenameSession { socket: socket_path, new_name }
+                    }
+                    InputEvent::Cancel => {
+                        self.mode = Mode::Browse;
+                        SessionManagerAction::Redraw
+                    }
+                    InputEvent::Changed | InputEvent::None => {
+                        self.mode = Mode::Rename { socket_path, old_name, input };
+                        SessionManagerAction::Redraw
+                    }
+                }
+            }
+            Mode::Browse => self.browse_key(key),
+        }
+    }
+
+    /// Keys for the default Browse mode (left/right navigation, filter, and
+    /// the row actions). The `/` filter, when active, captures typeable
+    /// input; `Esc` clears an active filter first and only closes on a
+    /// second press.
+    fn browse_key(&mut self, key: KeyEvent) -> SessionManagerAction {
+        // Filter-active: typeable input routes to the filter box.
+        if let Some(input) = self.filter.as_mut() {
+            match key.code {
+                KeyCode::Esc => {
+                    self.filter = None;
+                    self.left_sel = self.filtered_sessions().first().copied().unwrap_or(0);
+                    return SessionManagerAction::Redraw;
+                }
+                KeyCode::Enter => {
+                    // Keep the filter but drop into browse; Enter on a row acts.
+                    return self.left_enter();
+                }
+                _ => {}
+            }
+            match input.handle_key(&key) {
+                InputEvent::Cancel => {
+                    self.filter = None;
+                    self.left_sel = self.filtered_sessions().first().copied().unwrap_or(0);
+                    SessionManagerAction::Redraw
+                }
+                InputEvent::Commit | InputEvent::Changed | InputEvent::None => {
+                    // Clamping the cursor to the (possibly shrunk) filtered
+                    // set keeps the selection valid as the query tightens.
+                    let visible = self.filtered_sessions();
+                    if !visible.iter().any(|&i| i == self.left_sel) {
+                        self.left_sel = visible.first().copied().unwrap_or(0);
+                        self.right_sel = 0;
+                    }
+                    SessionManagerAction::Redraw
+                }
+            }
+        } else {
+            self.unfiltered_browse_key(key)
+        }
+    }
+
+    fn unfiltered_browse_key(&mut self, key: KeyEvent) -> SessionManagerAction {
+        match key.code {
+            KeyCode::Char('q') => SessionManagerAction::Close,
+            KeyCode::Esc => SessionManagerAction::Close,
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.move_left(true);
+                SessionManagerAction::Redraw
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.move_left(false);
+                SessionManagerAction::Redraw
+            }
+            KeyCode::Tab | KeyCode::Char('l') | KeyCode::Right => {
+                if self.focused_workspaces().is_some() {
+                    self.focus = Column::Right;
+                    return SessionManagerAction::Redraw;
+                }
+                SessionManagerAction::None
+            }
+            KeyCode::Char('h') | KeyCode::Left => {
+                self.focus = Column::Left;
+                SessionManagerAction::Redraw
+            }
+            KeyCode::Char('R') => SessionManagerAction::Refresh,
+            KeyCode::Char('/') => {
+                self.filter = Some(TextInput::new(String::new()));
+                SessionManagerAction::Redraw
+            }
+            KeyCode::Enter => {
+                if self.focus == Column::Right {
+                    self.right_enter()
+                } else {
+                    self.left_enter()
+                }
+            }
+            KeyCode::Char('r') => self.start_rename(),
+            KeyCode::Char('x') | KeyCode::Char('K') => self.start_kill(),
+            _ => SessionManagerAction::None,
+        }
+    }
+
+    /// Left-column Enter: attach to / hint at the focused session row.
+    fn left_enter(&mut self) -> SessionManagerAction {
+        let Some(s) = self.focused_session().cloned() else {
+            return SessionManagerAction::None;
+        };
+        if !s.live {
+            return SessionManagerAction::SetStatus(format!(
+                "{} is unreachable (socket not connectable) — cannot attach",
+                s.session
+            ));
+        }
+        if s.socket_path == self.own_socket {
+            return SessionManagerAction::SetStatus(
+                "already attached to this session".to_string(),
+            );
+        }
+        SessionManagerAction::AttachSession { socket: s.socket_path }
+    }
+
+    /// Right-column Enter: focus a workspace in the focused session
+    /// (in-place for the current session; remote-focus + reattach otherwise).
+    fn right_enter(&mut self) -> SessionManagerAction {
+        let Some(s) = self.focused_session().cloned() else {
+            return SessionManagerAction::None;
+        };
+        let index = self.right_sel;
+        if s.socket_path == self.own_socket {
+            SessionManagerAction::FocusWorkspaceInPlace { index }
+        } else {
+            SessionManagerAction::AttachOtherSessionWorkspace { socket: s.socket_path, index }
+        }
+    }
+
+    fn start_rename(&mut self) -> SessionManagerAction {
+        let Some(s) = self.focused_session().cloned() else {
+            return SessionManagerAction::None;
+        };
+        if !s.live {
+            return SessionManagerAction::SetStatus(
+                "no live session focused to rename".to_string(),
+            );
+        }
+        self.mode = Mode::Rename {
+            socket_path: s.socket_path,
+            old_name: s.session.clone(),
+            input: TextInput::new(s.session),
+        };
+        SessionManagerAction::Redraw
+    }
+
+    fn start_kill(&mut self) -> SessionManagerAction {
+        let Some(s) = self.focused_session().cloned() else {
+            return SessionManagerAction::None;
+        };
+        self.mode = Mode::ConfirmKill { index: self.left_sel, name: s.session };
+        SessionManagerAction::Redraw
+    }
+
+    /// Move the left cursor one step within the filtered-visible set.
+    fn move_left(&mut self, down: bool) {
+        let visible = self.filtered_sessions();
+        if visible.is_empty() {
+            return;
+        }
+        let pos = visible.iter().position(|&i| i == self.left_sel).unwrap_or(0);
+        let next = if down { pos + 1 } else { pos.saturating_sub(1) };
+        if next >= visible.len() {
+            return;
+        }
+        if visible[next] != self.left_sel {
+            self.left_sel = visible[next];
+            self.right_sel = 0;
+            self.focus = Column::Left;
+        }
+    }
+
+    /// Drain the focus + one-lookahead sockets whose column is still
+    /// `NotFetched`, marking each `Loading` so the App does not re-spawn a
+    /// worker for the same socket. Called by the App after each redraw.
+    pub fn fetch_requests(&mut self) -> Vec<PathBuf> {
+        let targets = prefetch_targets(self.left_sel, 1, self.sessions.len());
+        let mut out = Vec::new();
+        for i in targets {
+            let Some(s) = self.sessions.get(i) else { continue };
+            let socket = s.socket_path.clone();
+            let needs = matches!(
+                self.workspaces.get(&socket),
+                None | Some(WorkspaceColumn::NotFetched)
+            );
+            if needs {
+                self.workspaces.insert(socket.clone(), WorkspaceColumn::Loading);
+                out.push(socket);
+            }
+        }
+        out
     }
 
     /// Drain a pending reattach target after the App decided to quit.
@@ -195,26 +440,32 @@ impl SessionManagerState {
 /// Index of the session whose socket == the running TUI's socket. `None`
 /// when the running session is absent from the discovered set (e.g. a
 /// `--socket` override pointing outside the runtime dir). Pure.
-pub fn current_index(sessions: &[DiscoveredSession], _own: &Path) -> Option<usize> {
-    // STUB (commit 4 RED): always None so T1 fails.
-    let _ = sessions;
-    None
+pub fn current_index(sessions: &[DiscoveredSession], own: &Path) -> Option<usize> {
+    sessions.iter().position(|s| s.socket_path == own)
 }
 
 /// Substring filter predicate (case-insensitive) on the session name OR any
 /// workspace title. An empty query passes everything. Pure, so the filter
 /// is testable without sockets.
-pub fn passes_filter(_query: &str, _session: &str, _ws_titles: &[String]) -> bool {
-    // STUB (commit 4 RED): always passes so T2 fails.
-    true
+pub fn passes_filter(query: &str, session: &str, ws_titles: &[String]) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+    let needle = query.to_lowercase();
+    if session.to_lowercase().contains(&needle) {
+        return true;
+    }
+    ws_titles.iter().any(|t| t.to_lowercase().contains(&needle))
 }
 
 /// Which row indices should be prefetched given the current focus and a
 /// lookahead count (focus + the next `lookahead` rows), clamped to `len`
 /// and de-duplicated. Pure.
-pub fn prefetch_targets(_left_sel: usize, _lookahead: usize, _len: usize) -> Vec<usize> {
-    // STUB (commit 4 RED): returns nothing so T3 fails.
-    Vec::new()
+pub fn prefetch_targets(left_sel: usize, lookahead: usize, len: usize) -> Vec<usize> {
+    if left_sel >= len {
+        return Vec::new();
+    }
+    (left_sel..(left_sel + lookahead + 1).min(len)).collect()
 }
 
 #[cfg(test)]
@@ -400,7 +651,8 @@ mod tests {
         // `r` enters rename mode.
         let enter = state.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
         assert!(matches!(enter, SessionManagerAction::Redraw), "r must enter rename mode (Redraw), got {enter:?}");
-        // Type a new name.
+        // Rename pre-fills with the old name; clear it (Ctrl-U) then type the new.
+        state.handle_key(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
         state.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE));
         state.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE));
         state.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));

--- a/mux/crates/mux-tui/src/session_manager.rs
+++ b/mux/crates/mux-tui/src/session_manager.rs
@@ -20,8 +20,8 @@ use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::cli::DiscoveredSession;
-use crate::session::TreeView;
+use crate::cli::{one_shot_rpc, DiscoveredSession, OneShotOutcome};
+use crate::session::{parse_tree, TreeView};
 use crate::ui::input::{InputEvent, TextInput};
 
 /// Which overlay column currently holds the cursor.
@@ -466,6 +466,28 @@ pub fn prefetch_targets(left_sel: usize, lookahead: usize, len: usize) -> Vec<us
         return Vec::new();
     }
     (left_sel..(left_sel + lookahead + 1).min(len)).collect()
+}
+
+/// One-shot worker: connect to `socket`, issue `list-workspaces`, and parse
+/// the reply into a [`WorkspaceColumn`] via the same `parse_tree` the remote
+/// attach path uses. Reuses [`crate::cli::one_shot_rpc`] (the connect →
+/// write → read-line-loop → skip-events path shared with `rename_rpc`), so
+/// the overlay's cross-session preview rides the identical wire path as
+/// `cmux list-workspaces`. Any transport or server error maps to
+/// `Unreachable` so a dead socket renders one column, never a half-open
+/// stream. Runs on a worker thread (all socket I/O off the UI thread);
+/// the result lands via `AppEvent::SessionManagerUpdate`.
+pub fn fetch_workspaces(socket: &Path) -> WorkspaceColumn {
+    let request = serde_json::json!({ "cmd": "list-workspaces", "id": 1 });
+    match one_shot_rpc(socket, request) {
+        OneShotOutcome::Ok(value) => {
+            // The server wraps the tree under "data"; fall back to the
+            // whole value for robustness (older replies / direct data).
+            let data = value.get("data").unwrap_or(&value);
+            WorkspaceColumn::Ready(parse_tree(data))
+        }
+        OneShotOutcome::ServerErr(_) | OneShotOutcome::ConnectErr(_) => WorkspaceColumn::Unreachable,
+    }
 }
 
 #[cfg(test)]

--- a/mux/crates/mux-tui/src/session_picker.rs
+++ b/mux/crates/mux-tui/src/session_picker.rs
@@ -440,14 +440,6 @@ fn refresh(global: &GlobalArgs) -> Vec<DiscoveredSession> {
     sessions
 }
 
-/// Kill every stale session (reuses the cli kill-stale semantics) and return
-/// how many were cleaned. Thin wrapper over the shared `cli::kill_stale` so
-/// the picker, the `kill-stale` verb, and the in-TUI session manager (L3)
-/// share one code path.
-fn kill_stale(global: &GlobalArgs) -> usize {
-    cli::kill_stale(global)
-}
-
 fn clamp_selection(state: &mut ListState, sessions: &[DiscoveredSession]) {
     if sessions.is_empty() {
         state.select(None);

--- a/mux/crates/mux-tui/src/session_picker.rs
+++ b/mux/crates/mux-tui/src/session_picker.rs
@@ -215,7 +215,7 @@ fn dispatch(
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
                     // Reuse the cli kill-stale path: it is already built on
                     // discover_sessions, so semantics match `cmux kill-stale`.
-                    let cleaned = kill_stale(global);
+                    let cleaned = cli::kill_stale(global);
                     *status = format!("cleaned {cleaned} stale session(s)");
                     *sessions = refresh(global);
                     let _ = count; // borrowed only for the prompt label
@@ -246,7 +246,7 @@ fn dispatch(
                         }
                         Some(_) => {
                             // stale同名: clean it, then create fresh below.
-                            kill_stale(global);
+                            cli::kill_stale(global);
                             *sessions = refresh(global);
                             let sock = mux_core::server::default_socket_path(&name);
                             Action::Attach(sock, name)
@@ -441,19 +441,11 @@ fn refresh(global: &GlobalArgs) -> Vec<DiscoveredSession> {
 }
 
 /// Kill every stale session (reuses the cli kill-stale semantics) and return
-/// how many were cleaned. Mirrors `run_kill_stale` but without JSON output.
+/// how many were cleaned. Thin wrapper over the shared `cli::kill_stale` so
+/// the picker, the `kill-stale` verb, and the in-TUI session manager (L3)
+/// share one code path.
 fn kill_stale(global: &GlobalArgs) -> usize {
-    let mut sessions = cli::discover_sessions(global);
-    sessions.sort_by(|a, b| a.session.cmp(&b.session));
-    let mut cleaned = 0;
-    for s in &sessions {
-        if !s.live {
-            let _ = std::fs::remove_file(&s.socket_path);
-            let _ = std::fs::remove_file(mux_core::server::pid_path(&s.socket_path));
-            cleaned += 1;
-        }
-    }
-    cleaned
+    cli::kill_stale(global)
 }
 
 fn clamp_selection(state: &mut ListState, sessions: &[DiscoveredSession]) {

--- a/mux/crates/mux-tui/src/ui/mod.rs
+++ b/mux/crates/mux-tui/src/ui/mod.rs
@@ -46,6 +46,8 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
         crate::help::draw(app, frame);
     } else if app.finder.is_some() {
         crate::finder::draw(app, frame);
+    } else if app.session_manager.is_some() {
+        crate::session_manager::draw(app, frame);
     } else if app.menu.is_none() {
         if let Some((x, y)) = cursor {
             frame.set_cursor_position(Position::new(x, y));

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -2188,3 +2188,47 @@ fn overlay_fetch_workspaces_parses_remote_tree() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// T11 (issue #63 L3, scout plan): focusing a workspace in an *other* session
+/// from the overlay sends a one-shot `select-workspace` RPC over that
+/// session's socket (the path `cli::select_workspace_remote` rides). Spawns
+/// two named daemons, adds workspaces to beta, issues `select-workspace
+/// --index 1` against beta's socket, and asserts beta's `list-workspaces`
+/// afterwards reports workspace index 1 active. This proves the overlay's
+/// right-column Enter on another session remotely moves that session's focus.
+#[test]
+fn overlay_select_workspace_focuses_remotely() {
+    let dir = unique_temp_dir("smgr-select");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "beta");
+    let sock = dir.join("beta.sock");
+
+    // Three workspaces; the first is active by default.
+    assert_success(&run_against(&sock, &dir, &["new-workspace", "--name", "one"]));
+    assert_success(&run_against(&sock, &dir, &["new-workspace", "--name", "two"]));
+    assert_success(&run_against(&sock, &dir, &["new-workspace", "--name", "three"]));
+
+    // Remotely focus workspace index 1 ("two") the way the overlay does.
+    let select = run_against(&sock, &dir, &["select-workspace", "--index", "1"]);
+    assert_success(&select);
+
+    // beta's tree now reports index 1 active.
+    let list = run_against(&sock, &dir, &["--json", "list-workspaces"]);
+    assert_success(&list);
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    let active = value["workspaces"]
+        .as_array()
+        .expect("workspaces array")
+        .iter()
+        .find(|ws| ws["active"].as_bool() == Some(true))
+        .expect("an active workspace");
+    assert_eq!(
+        active["name"].as_str(),
+        Some("two"),
+        "select-workspace --index 1 should make 'two' active"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -2127,3 +2127,64 @@ fn rename_no_regressions_on_list_kill_killstale() {
 // cannot import the `pub(crate)` helper. The in-process unit test there
 // drives a `mux-core` server directly (no subprocess) and exercises the
 // exact code path the picker's `r` flow uses.
+
+/// T10 (issue #63 L3, scout plan): the session-manager overlay previews an
+/// *other* session's workspaces with a one-shot `list-workspaces` RPC over
+/// that session's control socket (the same connect→write→read path
+/// `cli::one_shot_rpc` shares with `rename_rpc`, and that `cmux
+/// list-workspaces` rides). `fetch_workspaces` is `pub(crate)` so this
+/// bin-test cannot call it directly; instead it drives the identical wire
+/// path against two named headless daemons and asserts each returns a
+/// parseable workspaces tree with the expected count. If the wire verb or
+/// its JSON shape regressed, the overlay's right column would break too.
+#[test]
+fn overlay_fetch_workspaces_parses_remote_tree() {
+    let dir = unique_temp_dir("smgr-fetch");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child_a = spawn_named_headless(&dir, "alpha");
+    let mut child_b = spawn_named_headless(&dir, "beta");
+    let sock_a = dir.join("alpha.sock");
+    let sock_b = dir.join("beta.sock");
+
+    // Give each daemon a distinct workspace set.
+    assert_success(&run_against(&sock_a, &dir, &["new-workspace", "--name", "a-one"]));
+    assert_success(&run_against(&sock_a, &dir, &["new-workspace", "--name", "a-two"]));
+    assert_success(&run_against(&sock_b, &dir, &["new-workspace", "--name", "b-one"]));
+
+    // Querying B's socket returns B's tree (not A's), proving the overlay
+    // can read another session's workspaces over its own socket.
+    let list_b = run_against(&sock_b, &dir, &["--json", "list-workspaces"]);
+    assert_success(&list_b);
+    let value: serde_json::Value = serde_json::from_slice(&list_b.stdout).unwrap();
+    let names: Vec<&str> = value["workspaces"]
+        .as_array()
+        .expect("workspaces array")
+        .iter()
+        .map(|ws| ws["name"].as_str().unwrap_or(""))
+        .collect();
+    assert!(
+        names.iter().any(|n| *n == "b-one"),
+        "beta socket should report its own workspace b-one, got {names:?}"
+    );
+    assert!(
+        !names.iter().any(|n| *n == "a-two"),
+        "beta socket must NOT leak alpha's workspaces, got {names:?}"
+    );
+
+    // And querying A's socket returns A's tree with both of its workspaces.
+    let list_a = run_against(&sock_a, &dir, &["--json", "list-workspaces"]);
+    assert_success(&list_a);
+    let value_a: serde_json::Value = serde_json::from_slice(&list_a.stdout).unwrap();
+    let count_a = value_a["workspaces"].as_array().map(|a| a.len()).unwrap_or(0);
+    assert!(
+        count_a >= 2,
+        "alpha socket should report >=2 workspaces, got {count_a}"
+    );
+
+    let _ = child_a.kill();
+    let _ = child_a.wait();
+    let _ = child_b.kill();
+    let _ = child_b.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -2232,3 +2232,88 @@ fn overlay_select_workspace_focuses_remotely() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// T12 (issue #63 L3, scout plan): an `[unreachable]` socket row is reported
+/// by discovery and `kill-session` cleans it without crashing. The overlay
+/// drives `cli::kill_session_at` on such rows; this guards that a stale
+/// `.sock`/`.pid` pair (no live process) is listed as stale and removable,
+/// matching AC8 (unreachable rows must be killable and must not crash).
+#[test]
+fn overlay_kill_unreachable_does_not_crash_discovery() {
+    let dir = unique_temp_dir("smgr-unreachable");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "live");
+    let live_sock = dir.join("live.sock");
+
+    // Create a STALE socket/pid pair with no live process behind it.
+    let stale_sock = dir.join("ghost.sock");
+    let stale_pid = dir.join("ghost.pid");
+    std::os::unix::net::UnixListener::bind(&stale_sock)
+        .expect("bind stale socket");
+    fs::write(&stale_pid, "999999").unwrap(); // a pid that is not alive
+
+    // list-sessions --json reports both, ghost as stale.
+    let list = run_against(&live_sock, &dir, &["--json", "list-sessions"]);
+    assert_success(&list);
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    let by_name: std::collections::HashMap<&str, &str> = value["sessions"]
+        .as_array()
+        .expect("sessions array")
+        .iter()
+        .map(|s| (s["name"].as_str().unwrap_or(""), s["status"].as_str().unwrap_or("")))
+        .collect();
+    assert_eq!(by_name.get("live").copied(), Some("live"));
+    assert_eq!(
+        by_name.get("ghost").copied(),
+        Some("stale"),
+        "ghost should be reported stale/unreachable"
+    );
+
+    // kill-session on the stale row cleans it (no crash).
+    let kill = run_against(&stale_sock, &dir, &["kill-session", "--session", "ghost"]);
+    assert_success(&kill);
+    assert!(!stale_sock.exists(), "stale socket removed by kill-session");
+    assert!(!stale_pid.exists(), "stale pid removed by kill-session");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+
+/// T13 (issue #63 L3, scout plan): the overlay's rename path and the L2
+/// `rename-session` CLI verb agree — both end with the session serving at the
+/// new socket and gone from the old. This is the same wire path
+/// (`cli::rename_session_at` over `one_shot_rpc`); the L2 suite covers the
+/// helper directly, so here we just confirm a rename issued via the verb is
+/// observable through `list-sessions` the way the overlay's `r` flow expects.
+#[test]
+fn overlay_rename_reuses_l2_helper() {
+    let dir = unique_temp_dir("smgr-rename");
+    fs::create_dir_all(&dir).unwrap();
+    let mut child = spawn_named_headless(&dir, "pre");
+    let pre_sock = dir.join("pre.sock");
+
+    let rename = run_against(&pre_sock, &dir, &["rename-session", "--old", "pre", "--new", "post"]);
+    assert_success(&rename);
+    let post_sock = dir.join("post.sock");
+    assert!(post_sock.exists(), "new socket exists after rename");
+    assert!(!pre_sock.exists(), "old socket gone after rename");
+
+    // list-sessions now reports 'post' live and 'pre' absent — the shape the
+    // overlay's rebuilt left column will show after a rename.
+    let list = run_against(&post_sock, &dir, &["--json", "list-sessions"]);
+    assert_success(&list);
+    let value: serde_json::Value = serde_json::from_slice(&list.stdout).unwrap();
+    let names: Vec<&str> = value["sessions"]
+        .as_array()
+        .expect("sessions array")
+        .iter()
+        .map(|s| s["name"].as_str().unwrap_or(""))
+        .collect();
+    assert!(names.iter().any(|n| *n == "post"), "post should be listed: {names:?}");
+    assert!(!names.iter().any(|n| *n == "pre"), "pre should be gone: {names:?}");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&dir);
+}
+


### PR DESCRIPTION
## Summary

In-TUI session manager overlay opened with **leader (Ctrl-b) + `S`** — the third and final layer of #63.

- **Two-column drill**: left = sessions (same socket-scan discovery as `cmux list-sessions`); right = workspaces of the focused session
- **Lazy workspace preview** on row focus via one-shot `list-workspaces` RPC on a worker thread (off the UI thread), with 1-row lookahead prefetch
- **`/` substring filter** across session name + workspace title (both columns)
- **Enter** on a session row attaches; on a workspace row attaches **and** focuses that workspace — in-place for the current session, via quit+reattach (`RunOutcome::Reattach`) for other sessions
- **`r`** inline rename (reuses L2 `rename-session` machinery); **`R`** refresh all; **`k`** kill with confirm; **`q`/Esc/leader-S** closes and restores focus
- `[current]` tag on the running session (Attach disabled); `[unreachable]` rows render safely and remain killable
- Tab/`l` → right column; `h`/Left → back
- Zero new socket-protocol surface (rides existing `list-workspaces`/`select-workspace`/`rename-session`); zero new Cargo deps; `Cargo.lock` + vendored ghostty includes untouched

## TDD

RED commit (`test(session-manager): add failing state-machine unit tests`) lands before its GREEN impl; independently verified by a cross-family verifier that all 9 RED tests fail at that commit. 217/217 tests green (+16 new: T1–T15 + session accessor test); all L1/L2/list-sessions/kill-session/kill-stale tests additive-only.

## Issue #63 PR chain

- L1: #65 (`db39ffd`) — `cmux attach --session-list` picker ✅ merged
- L2: #66 (`869b391`) — `cmux rename-session` ✅ merged
- L3: this PR — in-TUI session manager overlay

Closes #63