### PR TITLE
fix(mux-tui): solid session-manager overlay bg + ? command-palette Enter (issue #63 follow-up)

### DIFF
--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -1778,6 +1778,17 @@ impl App {
         let rows = crate::help::HelpState::rows_visible(self.screen).max(1);
         let Some(help) = self.help.as_mut() else { return Ok(RenderAction::None) };
         match key.code {
+            KeyCode::Enter if key.modifiers == KeyModifiers::NONE => {
+                // Command-palette behaviour: run the selected binding's
+                // action (issue #63 follow-up). Closing help first so the
+                // action sees a clean overlay state.
+                let action = help.selected_action();
+                self.help = None;
+                if let Some(action) = action {
+                    self.run_action(action)?;
+                }
+                return Ok(RenderAction::Draw);
+            }
             KeyCode::Char('/') if key.modifiers == KeyModifiers::NONE => {
                 help.set_query(String::new());
             }

--- a/mux/crates/mux-tui/src/help.rs
+++ b/mux/crates/mux-tui/src/help.rs
@@ -64,6 +64,17 @@ impl HelpState {
         self.scroll = 0;
     }
 
+    /// The action bound to the currently highlighted (filtered) row, if any.
+    /// Used by the help overlay's Enter key for command-palette dispatch:
+    /// `?` then type + Enter runs the selected binding.
+    pub fn selected_action(&self) -> Option<Action> {
+        let ranked = self.ranked();
+        ranked
+            .get(self.cursor)
+            .and_then(|&(item_index, _)| self.items.get(item_index))
+            .map(|entry| entry.action)
+    }
+
     /// Move the selected result by a clamped number of rows.
     pub fn move_cursor(&mut self, delta: isize, rows_visible: usize) {
         let len = self.ranked().len();
@@ -341,6 +352,25 @@ mod tests {
 
         state.set_query("?");
         assert!(state.ranked().iter().any(|(index, _)| state.items[*index].chord == "?"));
+    }
+
+    #[test]
+    fn selected_action_returns_the_highlighted_rows_binding() {
+        let keys = Keys::default();
+        let mut state = HelpState::new(build_entries(&keys));
+        // Without a query, cursor 0 is the first entry in category order.
+        let action = state.selected_action();
+        assert!(action.is_some(), "a default binding list must have at least one row");
+        // Filtering to a specific action name makes the selection deterministic:
+        // "OpenSessionManager" appears exactly once (it is the only binding
+        // for the leader-S chord).
+        state.set_query("session manager");
+        let focused = state.selected_action();
+        assert_eq!(
+            focused,
+            Some(Action::OpenSessionManager),
+            "filtering to 'session manager' must select the OpenSessionManager action"
+        );
     }
 
     #[test]

--- a/mux/crates/mux-tui/src/session_manager.rs
+++ b/mux/crates/mux-tui/src/session_manager.rs
@@ -527,6 +527,39 @@ pub fn draw(app: &mut crate::app::App, frame: &mut ratatui::Frame) {
 
     let Some(state) = app.session_manager.as_ref() else { return };
 
+    // Solid background so pane content underneath does not bleed through
+    // (mirrors help.rs::draw's fill). Same indexed palette as the help
+    // overlay: base bg 236, border 244, title 255.
+    {
+        let buf = frame.buffer_mut();
+        let base = Style::default().bg(Color::Indexed(236)).fg(Color::Indexed(252));
+        let border = base.fg(Color::Indexed(244));
+        for dy in 0..height {
+            for dx in 0..width {
+                let cell = &mut buf[(rect.x + dx, rect.y + dy)];
+                cell.reset();
+                cell.set_symbol(" ").set_style(base);
+            }
+        }
+        // Draw the outer border cells in the border colour (only if room).
+        if width >= 2 && height >= 2 {
+            let right = rect.x + width - 1;
+            let bottom = rect.y + height - 1;
+            for col in rect.x + 1..right {
+                buf[(col, rect.y)].set_style(border);
+                buf[(col, bottom)].set_style(border);
+            }
+            for row in rect.y + 1..bottom {
+                buf[(rect.x, row)].set_style(border);
+                buf[(right, row)].set_style(border);
+            }
+            buf[(rect.x, rect.y)].set_style(border);
+            buf[(right, rect.y)].set_style(border);
+            buf[(rect.x, bottom)].set_style(border);
+            buf[(right, bottom)].set_style(border);
+        }
+    }
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(4), Constraint::Length(3)])


### PR DESCRIPTION
## What

Two follow-ups from hands-on testing of the v0.17.0 session manager overlay:

1. **Solid overlay background** — `session_manager::draw` now fills the modal
   rect with the same indexed palette as the help overlay (bg 236 / border
   244 / fg 252) before drawing the two columns. Previously the pane text
   underneath bled through the transparent modal.

2. **`?` help becomes a command palette** — new `HelpState::selected_action()`
   resolves the highlighted (filtered) row's `Action`; pressing Enter in the
   help overlay now dispatches it via the existing `run_action` path. So
   `?` → type "session manager" → Enter opens the session manager overlay.
   Works for every bound action, not just that one.

## Tests

- New: `help::tests::selected_action_returns_the_highlighted_rows_binding`
  (pins that filtering to "session manager" selects `Action::OpenSessionManager`)
- Full suite: 176 unit + 42 integration = 218 passed / 0 failed
- `cargo check` clean (7 pre-existing warnings in plugin_host.rs/plugin.rs,
  untouched by this branch)

## TDD

- `b064e58` test first (RED before impl)
- `4753bb1` implementation

Part of issue #63 (L3 follow-up).