### PR TITLE
fix(mux-tui): recover from dead-target session swap instead of exiting (issue #69)

### DIFF
--- a/mux/crates/mux-tui/src/app.rs
+++ b/mux/crates/mux-tui/src/app.rs
@@ -617,6 +617,7 @@ pub fn run(
     session: Session,
     session_label: String,
     overlay: Option<crate::config::Overlay>,
+    initial_status: Option<String>,
 ) -> anyhow::Result<RunOutcome> {
     // For a thin-client attach (issue #40 blocker 1) the local `Overlay`
     // must layer on top of the *server's* resolved config, not the
@@ -748,7 +749,7 @@ pub fn run(
         shake_frames: 0,
         flashing: HashMap::new(),
         selection: None,
-        status_message: None,
+        status_message: initial_status,
         cell_pixels,
         pointer_shape: false,
         last_browser_hover: None,

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -496,25 +496,77 @@ fn main() {
             }
         }
     }
-    let result = if args.attach { run_attach(args) } else { run_server(args) };
+    let result = if args.attach { run_attach(args, None) } else { run_server(args) };
     if let Err(e) = result {
         eprintln!("cmux: {e}");
         std::process::exit(1);
     }
 }
 
-fn run_attach(mut args: Args) -> anyhow::Result<()> {
+fn run_attach(mut args: Args, fallback: Option<PathBuf>) -> anyhow::Result<()> {
     // `--print-resolved-config` only fires on the first attach; a session-
     // manager reattach (RunOutcome::Reattach) re-enters this loop without it.
     let mut first = true;
+    // last_good: the most recent socket we successfully connected to, so a
+    // dead swap target can recover back to it in-process (issue #69) instead
+    // of exiting to the shell. Seeded by run_server with the still-listening
+    // origin socket; `main()` passes None (a genuine first attach has no
+    // origin to recover to, so a dead target still exits 1).
+    let mut last_good: Option<PathBuf> = fallback;
+    // pending_status: a status-message string carried to the NEXT run_tui
+    // call (the recovery iteration), so the user sees why a handoff failed.
+    let mut pending_status: Option<String> = None;
     loop {
         let overlay =
             if args.apply_local_config { resolve_local_overlay(args.config.as_deref()) } else { None };
         let socket_path =
             args.socket.clone().unwrap_or_else(|| mux_core::server::default_socket_path(&args.session));
-        let remote = RemoteSession::connect(&socket_path).with_context(|| {
-            format!("attaching to cmux session socket at {}", socket_path.display())
-        })?;
+        // Issue #69: retry once on a transiently-unconnectable socket, then
+        // recover in-process to last_good when this is a swap (last_good is
+        // Some) instead of propagating the error to exit 1. A genuine first
+        // attach (last_good is None) still propagates -- exit 1, unchanged.
+        let remote = match session::connect_with_retry(
+            &socket_path,
+            1,
+            std::time::Duration::from_millis(250),
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                let failed_name =
+                    socket_path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+                match session::plan_swap_recovery(
+                    last_good.as_deref(),
+                    &socket_path,
+                    failed_name,
+                ) {
+                    session::SwapRecovery::Propagate => {
+                        return Err(e).with_context(|| {
+                            format!(
+                                "attaching to cmux session socket at {}",
+                                socket_path.display()
+                            )
+                        });
+                    }
+                    session::SwapRecovery::Recover { socket, status } => {
+                        pending_status = Some(status);
+                        let session = socket
+                            .file_stem()
+                            .and_then(|s| s.to_str())
+                            .map(str::to_string)
+                            .unwrap_or_else(|| args.session.clone());
+                        args.socket = Some(socket);
+                        args.session = session;
+                        // Recovery is not a first attach: never fire
+                        // --print-resolved-config on the recovery iteration.
+                        first = false;
+                        continue;
+                    }
+                }
+            }
+        };
+        // Remember the socket we just successfully used so the next swap
+        // failure can recover back to it.
+        last_good = Some(socket_path.clone());
         // `--print-resolved-config` is an inspection escape for thin-client
         // attaches (issue #40 blocker 1): fetch the server's resolved chrome,
         // layer the local overlay on top, print the merged chrome as JSON,
@@ -523,7 +575,8 @@ fn run_attach(mut args: Args) -> anyhow::Result<()> {
             return print_resolved_config(remote, overlay);
         }
         first = false;
-        match run_tui(Session::Remote(remote), args.session.clone(), overlay)? {
+        let initial_status = pending_status.take();
+        match run_tui(Session::Remote(remote), args.session.clone(), overlay, initial_status)? {
             app::RunOutcome::Done => return Ok(()),
             app::RunOutcome::Reattach(socket) => {
                 // Switch the running TUI to another session: derive the
@@ -673,7 +726,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     let result = if args.headless {
         run_headless(&mux, &socket_path).map(|()| app::RunOutcome::Done)
     } else {
-        run_tui(Session::Local(mux.clone()), args.session.clone(), None)
+        run_tui(Session::Local(mux.clone()), args.session.clone(), None, None)
     };
     if let Ok(app::RunOutcome::Reattach(socket)) = &result {
         // The session-manager overlay asked to switch the TUI to another
@@ -687,7 +740,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
         }
         attach_args.socket = Some(socket.clone());
         attach_args.attach = true;
-        return run_attach(attach_args);
+        return run_attach(attach_args, Some(socket_path.clone()));
     }
     mux.shutdown();
     // Issue #28: after known surfaces are killed, sweep anything that
@@ -705,6 +758,7 @@ fn run_tui(
     session: Session,
     session_label: String,
     overlay: Option<config::Overlay>,
+    initial_status: Option<String>,
 ) -> anyhow::Result<app::RunOutcome> {
     crossterm::terminal::enable_raw_mode()?;
     let colors = host_colors::probe_default_colors();
@@ -714,7 +768,7 @@ fn run_tui(
         eprintln!("cmux: failed to set default colors: {err}");
     }
     raw_result?;
-    app::run(session, session_label, overlay)
+    app::run(session, session_label, overlay, initial_status)
 }
 
 fn run_headless(mux: &Arc<Mux>, socket_path: &std::path::Path) -> anyhow::Result<()> {

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -11,6 +11,8 @@ mod reattach;
 mod remote;
 mod tree;
 
+pub(crate) use reattach::{connect_with_retry, plan_swap_recovery, SwapRecovery};
+
 use std::sync::atomic::Ordering;
 use std::sync::mpsc::Receiver;
 use std::sync::Arc;

--- a/mux/crates/mux-tui/src/session/mod.rs
+++ b/mux/crates/mux-tui/src/session/mod.rs
@@ -7,6 +7,7 @@
 //! both into its own ghostty terminal. Rendering, key encoding, and mode
 //! queries then work identically in both cases.
 
+mod reattach;
 mod remote;
 mod tree;
 

--- a/mux/crates/mux-tui/src/session/reattach.rs
+++ b/mux/crates/mux-tui/src/session/reattach.rs
@@ -44,7 +44,6 @@ where
 /// `backoff` before each retry. Wraps `RemoteSession::connect` (which does
 /// the full identify/subscribe handshake) so a transiently-unconnectable
 /// socket gets a second chance before the caller gives up.
-#[allow(dead_code)] // wired into run_attach in the follow-up commit (issue #69)
 pub(crate) fn connect_with_retry(
     path: &Path,
     retries: u32,
@@ -55,7 +54,6 @@ pub(crate) fn connect_with_retry(
 
 /// What `run_attach` should do when a connect failed even after retry.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)] // wired into run_attach in the follow-up commit (issue #69)
 pub(crate) enum SwapRecovery {
     /// No known-good socket to fall back to (a genuine first attach to a
     /// dead socket). The caller propagates the connect error -- exit 1,
@@ -71,7 +69,6 @@ pub(crate) enum SwapRecovery {
 /// failed, decide `Propagate` vs `Recover`. Returns `Propagate` when there
 /// is no fallback, OR when the fallback IS the failed socket (prevents an
 /// infinite recovery loop if the origin itself died).
-#[allow(dead_code)] // wired into run_attach in the follow-up commit (issue #69)
 pub(crate) fn plan_swap_recovery(
     last_good: Option<&Path>,
     failed: &Path,

--- a/mux/crates/mux-tui/src/session/reattach.rs
+++ b/mux/crates/mux-tui/src/session/reattach.rs
@@ -1,0 +1,284 @@
+//! Swap/reattach recovery for the attach path (issue #69).
+//!
+//! When the session-manager overlay hands off to another session
+//! (`leader S` -> pick row -> `Enter`), `run_attach` re-enters its loop and
+//! calls `RemoteSession::connect` against the chosen socket. If that socket
+//! is stale (the target daemon died between discovery and attach), the bare
+//! `?` used to propagate the error all the way out to `main()`, exiting the
+//! process to the shell instead of recovering in-process.
+//!
+//! This module holds the pure retry + decision logic, extracted so it is
+//! unit-testable without a live TUI or a full socket handshake. `run_attach`
+//! (in `main.rs`) wires these helpers into the swap loop.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::RemoteSession;
+
+/// Retry a fallible op up to `retries` extra times, sleeping `backoff`
+/// BEFORE each retry (never after the final failure). Always makes at least
+/// one attempt. Generic over the op so the retry/timing logic is
+/// unit-testable without sockets.
+pub(crate) fn retry<F, T, E>(retries: u32, backoff: Duration, mut op: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    let mut remaining = retries;
+    loop {
+        match op() {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if remaining == 0 {
+                    return Err(e);
+                }
+                remaining -= 1;
+                std::thread::sleep(backoff);
+            }
+        }
+    }
+}
+
+/// Connect to a session socket with up to `retries` retries, sleeping
+/// `backoff` before each retry. Wraps `RemoteSession::connect` (which does
+/// the full identify/subscribe handshake) so a transiently-unconnectable
+/// socket gets a second chance before the caller gives up.
+#[allow(dead_code)] // wired into run_attach in the follow-up commit (issue #69)
+pub(crate) fn connect_with_retry(
+    path: &Path,
+    retries: u32,
+    backoff: Duration,
+) -> anyhow::Result<Arc<RemoteSession>> {
+    retry(retries, backoff, || RemoteSession::connect(path))
+}
+
+/// What `run_attach` should do when a connect failed even after retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // wired into run_attach in the follow-up commit (issue #69)
+pub(crate) enum SwapRecovery {
+    /// No known-good socket to fall back to (a genuine first attach to a
+    /// dead socket). The caller propagates the connect error -- exit 1,
+    /// unchanged behavior.
+    Propagate,
+    /// A swap target died. Re-attach to `socket` (the last-known-good /
+    /// origin socket) and surface `status` on the next TUI open so the
+    /// user learns why the handoff failed.
+    Recover { socket: PathBuf, status: String },
+}
+
+/// Pure decision: given the last-known-good socket and the socket that just
+/// failed, decide `Propagate` vs `Recover`. Returns `Propagate` when there
+/// is no fallback, OR when the fallback IS the failed socket (prevents an
+/// infinite recovery loop if the origin itself died).
+#[allow(dead_code)] // wired into run_attach in the follow-up commit (issue #69)
+pub(crate) fn plan_swap_recovery(
+    last_good: Option<&Path>,
+    failed: &Path,
+    failed_name: &str,
+) -> SwapRecovery {
+    match last_good {
+        Some(good) if good != failed => SwapRecovery::Recover {
+            socket: good.to_path_buf(),
+            status: format!("could not attach to {} - socket unreachable", failed_name),
+        },
+        _ => SwapRecovery::Propagate,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Instant;
+
+    // --- `retry`: generic timing/counting -------------------------------
+
+    /// T1: a first-try success makes exactly one call and skips the backoff.
+    #[test]
+    fn retry_succeeds_first_try_calls_once() {
+        let count = AtomicU32::new(0);
+        let start = Instant::now();
+        let out: Result<u32, ()> = retry(1, Duration::from_millis(2), || {
+            count.fetch_add(1, Ordering::SeqCst);
+            Ok(7)
+        });
+        let elapsed = start.elapsed();
+        assert_eq!(out, Ok(7));
+        assert_eq!(count.load(Ordering::SeqCst), 1, "first-try Ok must call op once");
+        assert!(
+            elapsed < Duration::from_millis(2),
+            "no sleep before the first/only attempt, took {:?}",
+            elapsed
+        );
+    }
+
+    /// T2: an always-Err op with one retry fires the backoff exactly once
+    /// (between the two attempts), so elapsed >= backoff.
+    #[test]
+    fn retry_retries_once_then_errors() {
+        let count = AtomicU32::new(0);
+        let backoff = Duration::from_millis(2);
+        let start = Instant::now();
+        let out: Result<u32, ()> = retry(1, backoff, || {
+            count.fetch_add(1, Ordering::SeqCst);
+            Err(())
+        });
+        let elapsed = start.elapsed();
+        assert!(out.is_err(), "always-Err must return Err");
+        assert_eq!(count.load(Ordering::SeqCst), 2, "retries=1 => 2 total attempts");
+        assert!(
+            elapsed >= backoff,
+            "sleep must fire once between attempts, took {:?}",
+            elapsed
+        );
+    }
+
+    /// T3: an op that fails then succeeds on the second call returns Ok
+    /// after exactly two attempts.
+    #[test]
+    fn retry_succeeds_on_second_attempt() {
+        let count = AtomicU32::new(0);
+        let start = Instant::now();
+        let out: Result<u32, ()> = retry(1, Duration::from_millis(2), || {
+            let n = count.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                Err(())
+            } else {
+                Ok(9)
+            }
+        });
+        let elapsed = start.elapsed();
+        assert_eq!(out, Ok(9));
+        assert_eq!(count.load(Ordering::SeqCst), 2, "two attempts before Ok");
+        assert!(
+            elapsed >= Duration::from_millis(2),
+            "one backoff sleep before the retry, took {:?}",
+            elapsed
+        );
+    }
+
+    /// T4: retries=0 means exactly one attempt and no sleep, even with a
+    /// large backoff.
+    #[test]
+    fn retry_zero_retries_calls_once_no_sleep() {
+        let count = AtomicU32::new(0);
+        let start = Instant::now();
+        let out: Result<u32, ()> = retry(0, Duration::from_millis(50), || {
+            count.fetch_add(1, Ordering::SeqCst);
+            Err(())
+        });
+        let elapsed = start.elapsed();
+        assert!(out.is_err());
+        assert_eq!(count.load(Ordering::SeqCst), 1, "no retries => one call");
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "no sleep when retries=0, took {:?}",
+            elapsed
+        );
+    }
+
+    // --- `plan_swap_recovery`: pure decision -----------------------------
+
+    /// T5: no last-known-good socket (a genuine first attach) must still
+    /// propagate the error -- exit 1, unchanged behavior.
+    #[test]
+    fn plan_propagates_when_no_last_good() {
+        assert_eq!(
+            plan_swap_recovery(None, Path::new("/x/dead.sock"), "dead"),
+            SwapRecovery::Propagate,
+        );
+    }
+
+    /// T6: a swap target died; recover to the last-known-good socket and
+    /// surface the status string. (Plain hyphen, per issue #69 acceptance.)
+    #[test]
+    fn plan_recovers_to_last_good_with_status() {
+        assert_eq!(
+            plan_swap_recovery(
+                Some(Path::new("/run/origin.sock")),
+                Path::new("/run/dead.sock"),
+                "dead",
+            ),
+            SwapRecovery::Recover {
+                socket: Path::new("/run/origin.sock").into(),
+                status: "could not attach to dead - socket unreachable".to_string(),
+            },
+        );
+    }
+
+    /// T7: if the last-known-good IS the failed socket (origin itself
+    /// died), propagate to avoid an infinite recovery loop.
+    #[test]
+    fn plan_propagates_when_last_good_equals_failed() {
+        assert_eq!(
+            plan_swap_recovery(
+                Some(Path::new("/run/origin.sock")),
+                Path::new("/run/origin.sock"),
+                "origin",
+            ),
+            SwapRecovery::Propagate,
+        );
+    }
+
+    // --- `connect_with_retry`: real transport ---------------------------
+
+    /// T8: a stale file (not a listening socket) is retried once with the
+    /// production 250 ms backoff before the final error. Lower-bound only
+    /// (CI variance); the timing proves the retry fired.
+    #[test]
+    fn connect_with_retry_dead_socket_retried_once_and_errors() {
+        let dir = unique_temp_dir("reattach-dead");
+        fs::create_dir_all(&dir).unwrap();
+        let socket = dir.join("dead.sock");
+        // Non-socket file: UnixStream::connect returns ENOTSOCK/ECONNREFUSED,
+        // same stale-file technique as cli.rs::serve_recovers_from_stale_socket.
+        fs::write(&socket, b"").unwrap();
+
+        let start = Instant::now();
+        let result = connect_with_retry(&socket, 1, Duration::from_millis(250));
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "connecting to a stale file must error");
+        assert!(
+            elapsed >= Duration::from_millis(240),
+            "one ~250ms retry must have fired, took {:?}",
+            elapsed
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// T9: a path that was never created errors fast with no retries and
+    /// no sleep.
+    #[test]
+    fn connect_with_retry_missing_path_errors_fast() {
+        let dir = unique_temp_dir("reattach-missing");
+        fs::create_dir_all(&dir).unwrap();
+        let missing = dir.join("nope.sock");
+
+        let start = Instant::now();
+        let result = connect_with_retry(&missing, 0, Duration::from_millis(250));
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "missing path must error");
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "retries=0 => no sleep, took {:?}",
+            elapsed
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Minimal temp dir helper (mirrors tests/cli.rs::unique_temp_dir).
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        PathBuf::from("/tmp").join(format!("cmux-reattach-{name}-{}-{stamp}", std::process::id()))
+    }
+}

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -2317,3 +2317,42 @@ fn overlay_rename_reuses_l2_helper() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// T10 (issue #69, scout plan §3c): REGRESSION -- a genuine first attach to a
+/// dead socket must STILL exit non-zero (exit 1), both before and after the
+/// swap-recovery fix. The recovery path only fires when there is a
+/// last-known-good socket to fall back to (a swap); a fresh `cmux attach`
+/// has no origin, so the connect error propagates to `main()` exactly as
+/// today. This test pins that behavior so the fix cannot accidentally make a
+/// real first-attach silently loop instead of failing.
+#[test]
+fn first_attach_to_dead_socket_still_exits_nonzero() {
+    let dir = unique_temp_dir("attach-dead-first");
+    fs::create_dir_all(&dir).unwrap();
+    let socket = dir.join("dead-first.sock");
+    // Stale file: not a listening socket, so RemoteSession::connect fails
+    // (same technique as serve_recovers_from_stale_socket / attach_session_list_json_marks_stale).
+    fs::write(&socket, b"").unwrap();
+
+    let out = Command::new(bin())
+        .args(["attach", "--socket"])
+        .arg(&socket)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .expect("failed to spawn cmux attach");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "first-attach to a dead socket must still exit 1, got {:?}\nstderr:\n{}",
+        out.status.code(),
+        stderr,
+    );
+    assert!(
+        stderr.contains("attaching to cmux session socket"),
+        "stderr should carry the connect-failure context, got: {stderr:?}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+


### PR DESCRIPTION
## Summary

Swapping sessions from the session-manager overlay (leader+S) sometimes **exited the process to the shell** when the target socket was dead/unconnectable at that instant, because `run_attach` called `RemoteSession::connect(&socket_path)?` with no retry and no recovery.

This PR makes the attach path recover in-process:

- **Retry once with 250ms backoff** (`session::connect_with_retry`) before giving up on a swap target.
- **On final failure, never exit on a swap**: `session::plan_swap_recovery` decides — when a last-known-good socket exists (seeded by `run_server` with the still-listening origin, or set by the previous successful connect), `run_attach` loops back and re-attaches to it in-process instead of propagating.
- **Visible status**: the recovered TUI shows `could not attach to <name> - socket unreachable` (red/bold status bar) via a new `initial_status` param threaded through `run_tui` → `app::run` → `App.status_message`.
- **Unchanged**: a genuine first `cmux attach` to a dead socket still exits 1 with the identical error message (pinned by a new black-box regression test).
- **No infinite loop**: if the origin itself is also dead, `plan_swap_recovery(last_good == failed)` → propagate → exit 1 (bounded: at most 2 iterations / ~500ms).

## TDD (Rule 5)

- Commit 1 (`536121b`): helpers (`retry`, `connect_with_retry`, `SwapRecovery`, `plan_swap_recovery`) + 9 unit tests + 1 black-box regression — **unwired**, `run_attach` byte-identical to main (bug latent).
- Commit 2 (`f723726`): all wiring into `run_attach`/`run_server`/`main`/`run_tui`/`app::run`.

## Test plan

- Suite: **228 passed, 0 failed** (218 existing + 10 new); `cargo check -p mux-tui` clean (7 pre-existing plugin warnings, 0 new).
- New tests: retry timing/counting (T1-T4), recovery decision matrix (T5-T7), real-transport dead-socket retry ≥240ms (T8), missing-path fast-fail (T9), first-attach-to-dead still exits 1 (T10).
- Cross-family verify (Kimi K3) re-ran the suite independently, mutation-checked the new tests are non-vacuous, and audited the TDD commit split.
- Manual swap script (TUI path is not headlessly drivable): `cmux --session a`; `cmux --session b --headless`; leader+S → pick b (in-process handoff); `kill -9` b's daemon; leader+S → pick b's stale row → process stays up, status bar shows `could not attach to b - socket unreachable`, user is back on session a.

Closes #69