### PR TITLE
fix(release): stop fetch-tags from breaking tag-triggered releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,16 @@ jobs:
           # CMUX_VERSION is unset (i.e. workflow_dispatch runs). Tag refs
           # are a few KB — far cheaper than fetch-depth: 0, which would
           # also deepen the ghostty submodule.
-          fetch-tags: true
+          #
+          # Only on non-tag runs, though: checking out a tag ref already
+          # fetches `+<sha>:refs/tags/<tag>`, and fetch-tags adds the
+          # `refs/tags/*` refspec on top, so git aborts the whole checkout
+          # with "Cannot fetch both <sha> and refs/tags/<tag> to
+          # refs/tags/<tag>" (actions/checkout#1467). That combination
+          # broke the v0.17.3 release outright. Tag runs don't need any of
+          # it: the step below resolves the version from GITHUB_REF_NAME
+          # and build.rs never reaches its `git describe` tier.
+          fetch-tags: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Resolve version from the release tag
         # The pushed tag is the single source of truth for a release; no


### PR DESCRIPTION
## Problem

The `v0.17.3` tag push produced **no release**: both matrix legs died in `actions/checkout`.

```
fatal: Cannot fetch both b34f7752ca49985a95e129ac43703a5d14e8b2f2 and refs/tags/v0.17.3 to refs/tags/v0.17.3
```

Checking out a tag ref already fetches `+<sha>:refs/tags/<tag>`. `fetch-tags: true` adds the `refs/tags/*` refspec on top, and git aborts when two refspecs target the same destination ref (actions/checkout#1467).

## Fix

`fetch-tags: ${{ !startsWith(github.ref, 'refs/tags/') }}`.

`fetch-tags` landed in #72 for the `workflow_dispatch` path, where `CMUX_VERSION` is empty and `mux-core/build.rs` falls back to `git describe` — that path still gets tags. Tag runs resolve the version from `GITHUB_REF_NAME` and never reach the `git describe` tier, so they need nothing extra.

## Verification

`v0.17.3` will be re-tagged onto this commit once merged; the workflow's own "Verify the baked-in version" gate confirms the tag → `CMUX_VERSION` → `cmux -V` chain end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)