### PR TITLE
fix: login-shell PTY spawn and Grok hook schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ cmux aider install-hooks --uninstall
 
 #### 6. Grok CLI
 ```bash
-cmux grok install-hooks            # installs workspace-level hooks in .grok/hooks.json
-cmux grok install-hooks --global   # installs global hooks in ~/.grok/hooks.json
+cmux grok install-hooks            # workspace hooks in .grok/hooks/cmux-agent-state.json
+cmux grok install-hooks --global   # global hooks in ~/.grok/hooks/cmux-agent-state.json
 cmux grok install-hooks --uninstall
 ```
 

--- a/mux/crates/mux-core/src/surface.rs
+++ b/mux/crates/mux-core/src/surface.rs
@@ -26,7 +26,11 @@ pub use crate::browser::{
 /// How to spawn surface children.
 #[derive(Debug, Clone)]
 pub struct SurfaceOptions {
-    /// Command argv; defaults to the platform shell.
+    /// Command argv. When unset, the platform shell is spawned as a
+    /// login shell (argv0 `-<basename>`, e.g. `-bash`) — the same
+    /// convention as gnome-terminal / wezterm / tmux. A bare `/bin/bash`
+    /// on a freshly opened PTY is CrowdStrike Falcon's GenReverseShell
+    /// signature.
     pub command: Option<Vec<String>>,
     pub cwd: Option<String>,
     /// TERM value for children. xterm-256color is the compatible default;
@@ -288,20 +292,39 @@ impl Surface {
                 .context("opening local pty (check /dev/ptmx and devpts mount)")?,
         };
 
-        let argv = opts
-            .command
-            .clone()
-            .filter(|argv| !argv.is_empty())
-            .unwrap_or_else(|| vec![platform::default_shell()]);
-        let mut cmd = CommandBuilder::new(&argv[0]);
-        cmd.args(&argv[1..]);
+        // Default surfaces are a login shell (argv0 "-bash"), matching
+        // gnome-terminal / wezterm / tmux. A bare `/bin/bash` attached to
+        // a PTY opened by an unsigned parent is CrowdStrike Falcon IOA
+        // GenReverseShell's textbook signature and gets the child SIGKILLed
+        // on protected hosts (the pane then looks "Killed" mid-test).
+        // Explicit `command` argv is left untouched so tests can still
+        // spawn `/bin/cat`, `/bin/sh -c …`, etc.
+        let (mut cmd, spawn_label) = match opts.command.as_ref().filter(|argv| !argv.is_empty()) {
+            Some(argv) => {
+                let mut cmd = CommandBuilder::new(&argv[0]);
+                cmd.args(&argv[1..]);
+                (cmd, argv.join(" "))
+            }
+            None => {
+                let mut cmd = CommandBuilder::new_default_prog();
+                cmd.env("SHELL", platform::default_shell());
+                (cmd, format!("login-shell({})", platform::default_shell()))
+            }
+        };
         cmd.env("TERM", &opts.term);
         // Lets a hook script (e.g. a Claude Code hook) invoked from inside
         // this pty call back into `cmux report-agent --surface
         // $CMUX_MUX_SURFACE ...` without needing to know its own surface id.
         cmd.env("CMUX_MUX_SURFACE", id.to_string());
+        // Grok Build's multiplexer detector (and macOS cmux) look for these
+        // names. Dual-write so an unpatched grok still classifies the pane
+        // as MultiplexerKind::Cmux.
+        cmd.env("CMUX_PANEL_ID", id.to_string());
         for (k, v) in &opts.extra_env {
             cmd.env(k, v);
+            if k == "CMUX_MUX_SOCKET" {
+                cmd.env("CMUX_SOCKET_PATH", v);
+            }
         }
         // The local-home-dir fallback only makes sense for a local child;
         // for a remote surface, an unset cwd should mean "let the remote
@@ -317,7 +340,7 @@ impl Surface {
         let mut child = pty
             .slave
             .spawn_command(cmd)
-            .with_context(|| format!("spawning pty child: {}", argv.join(" ")))?;
+            .with_context(|| format!("spawning pty child: {spawn_label}"))?;
         drop(pty.slave);
         let child_pid = child.process_id();
         let killer = child.clone_killer();

--- a/mux/crates/mux-core/tests/pty.rs
+++ b/mux/crates/mux-core/tests/pty.rs
@@ -54,6 +54,49 @@ fn read_json_line(reader: &mut impl BufRead) -> Option<serde_json::Value> {
     }
 }
 
+/// Default surfaces must be a login shell (argv0 starts with `-`).
+/// CrowdStrike Falcon IOA GenReverseShell kills a bare `/bin/bash`
+/// attached to a PTY from an unsigned parent; login-shell argv0 is how
+/// real terminals spawn and is what we have to match.
+#[test]
+#[cfg(target_os = "linux")]
+fn default_shell_is_spawned_as_login_shell() {
+    // Dash, not the user's bash: this test only checks argv0, and a
+    // bare interactive bash is exactly what Falcon GenReverseShell kills.
+    let _guard = PERSIST_ENV_LOCK.lock().unwrap();
+    let previous_shell = std::env::var("SHELL").ok();
+    std::env::set_var("SHELL", "/bin/sh");
+    let mux = Mux::new(unique_session("test-login-shell"), SurfaceOptions::default());
+    let surface = mux.new_workspace(None, None).unwrap();
+    let pid = surface.child_pid().expect("pty child pid");
+    // portable-pty fork+exec: /proc/pid/cmdline still shows the test
+    // binary until execve lands. Wait for the login-shell argv0.
+    let argv0 = wait_for(
+        || {
+            let bytes = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+            let argv0 = bytes.split(|&b| b == 0).next().unwrap_or_default();
+            let argv0 = String::from_utf8_lossy(argv0);
+            argv0.starts_with('-').then(|| argv0.into_owned())
+        },
+        Duration::from_secs(3),
+    );
+    let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).unwrap_or_default();
+    let exe = std::fs::read_link(format!("/proc/{pid}/exe"))
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|e| format!("<exe unreadable: {e}>"));
+    let alive = mux_core::process::is_alive(pid);
+    assert!(
+        argv0.is_some(),
+        "default shell must be a login shell (argv0 starts with '-'), \
+         pid={pid} alive={alive} comm={comm:?} exe={exe}"
+    );
+    mux.close_surface(surface.id);
+    match previous_shell {
+        Some(shell) => std::env::set_var("SHELL", shell),
+        None => std::env::remove_var("SHELL"),
+    }
+}
+
 #[test]
 fn surface_runs_command_and_screen_updates() {
     let mux = Mux::new("test-pty", shell_opts("printf 'marker-42\\n'; sleep 30"));

--- a/mux/crates/mux-tui/src/agents.rs
+++ b/mux/crates/mux-tui/src/agents.rs
@@ -179,11 +179,7 @@ fn pi_path(global: bool) -> Option<PathBuf> {
     }
 }
 fn grok_path(global: bool) -> Option<PathBuf> {
-    if global {
-        home_join(&[".grok", "hooks.json"])
-    } else {
-        Some(PathBuf::from(".grok").join("hooks.json"))
-    }
+    crate::grok_hook::config_path(global)
 }
 fn opencode_path(global: bool) -> Option<PathBuf> {
     if global {

--- a/mux/crates/mux-tui/src/grok_hook.rs
+++ b/mux/crates/mux-tui/src/grok_hook.rs
@@ -1,22 +1,41 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 
 use crate::hook_merge;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct GrokHook {
-    pub event: String,
-    pub command: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-pub struct GrokHooksConfig {
+/// Legacy flat-array schema previously written to `.grok/hooks.json`.
+/// Kept so install/uninstall can clean leftovers that Grok Build never loaded.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+struct LegacyGrokHooksConfig {
     #[serde(default)]
-    pub hooks: Vec<GrokHook>,
+    hooks: Vec<LegacyGrokHook>,
 }
 
-fn config_path(global: bool) -> Option<PathBuf> {
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct LegacyGrokHook {
+    event: String,
+    command: String,
+}
+
+const HOOK_FILENAME: &str = "cmux-agent-state.json";
+
+/// Grok Build loads `$GROK_HOME/hooks/*.json` (and `<repo>/.grok/hooks/*.json`)
+/// in the Claude-compatible object schema. The old installer wrote
+/// `.grok/hooks.json` (wrong path) in a flat array (wrong shape) with
+/// `--source grok` (rejected by `report-agent`, which only accepts
+/// `socket` or `hook`).
+pub(crate) fn config_path(global: bool) -> Option<PathBuf> {
+    if global {
+        mux_core::platform::home_dir().map(|h| h.join(".grok").join("hooks").join(HOOK_FILENAME))
+    } else {
+        Some(PathBuf::from(".grok").join("hooks").join(HOOK_FILENAME))
+    }
+}
+
+fn legacy_config_path(global: bool) -> Option<PathBuf> {
     if global {
         mux_core::platform::home_dir().map(|h| h.join(".grok").join("hooks.json"))
     } else {
@@ -24,10 +43,80 @@ fn config_path(global: bool) -> Option<PathBuf> {
     }
 }
 
+fn report_command(state: &str) -> String {
+    format!(
+        "test -n \"$CMUX_MUX_SURFACE\" && cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state {state} --source hook || true"
+    )
+}
+
+fn grok_native_hooks() -> Value {
+    let command = |state: &str| {
+        json!({
+            "type": "command",
+            "command": report_command(state),
+            "timeout": 5
+        })
+    };
+    let group = |state: &str| json!([{ "hooks": [command(state)] }]);
+    json!({
+        "hooks": {
+            "SessionStart": group("working"),
+            "PreToolUse": group("working"),
+            "PostToolUse": group("idle"),
+            "Notification": [{
+                "matcher": "idle_prompt|permission_prompt",
+                "hooks": [command("blocked")]
+            }],
+            "Stop": group("done"),
+            "SubagentStart": group("working"),
+            "SubagentStop": group("idle")
+        }
+    })
+}
+
+fn refuse_symlink(path: &Path) -> Option<i32> {
+    if let Ok(meta) = fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            eprintln!(
+                "error: refusing to overwrite symlink at {}. Remove it manually if you want to install the hooks.",
+                path.display()
+            );
+            return Some(1);
+        }
+    }
+    None
+}
+
+/// Strip leftover cmux entries from the pre-fix `.grok/hooks.json`. Deletes
+/// the file when nothing else remains. Leaves an unreadable or non-legacy
+/// file alone so we never clobber a user config we don't understand.
+fn clean_legacy(global: bool) -> bool {
+    let Some(path) = legacy_config_path(global) else {
+        return false;
+    };
+    match hook_merge::load_json::<LegacyGrokHooksConfig>(&path) {
+        Ok(mut config) => {
+            let before = config.hooks.len();
+            config.hooks.retain(|h| !h.command.contains("cmux report-agent"));
+            if config.hooks.is_empty() {
+                let _ = fs::remove_file(&path);
+                before > 0
+            } else if config.hooks.len() != before {
+                let _ = hook_merge::save_pretty(&path, &config);
+                true
+            } else {
+                false
+            }
+        }
+        Err(hook_merge::LoadError::NotFound) => false,
+        Err(_) => false,
+    }
+}
+
 pub fn run(args: &[String]) -> i32 {
     let mut uninstall = false;
     let mut global = false;
-    
+
     for arg in args.iter().skip(1) {
         if arg == "--uninstall" {
             uninstall = true;
@@ -53,97 +142,54 @@ fn run_install(uninstall: bool, global: bool) -> i32 {
     };
 
     if uninstall {
-        let mut config: GrokHooksConfig = match hook_merge::load_json(&path) {
-            Ok(c) => c,
-            Err(hook_merge::LoadError::NotFound) => {
-                println!("No Grok hooks file found at {}", path.display());
-                return 0;
-            }
-            Err(hook_merge::LoadError::Parse(e)) => {
-                eprintln!(
-                    "error: malformed Grok config at {}: {e}",
-                    path.display()
-                );
+        let mut removed = false;
+        if path.exists() {
+            if let Err(e) = fs::remove_file(&path) {
+                eprintln!("error removing {}: {e}", path.display());
                 return 1;
             }
-            Err(hook_merge::LoadError::Io(e)) => {
-                eprintln!("error reading {}: {e}", path.display());
-                return 1;
-            }
-        };
-        config.hooks.retain(|h| !h.command.contains("cmux report-agent"));
-
-        if let Err(e) = hook_merge::save_pretty(&path, &config) {
-            match e {
-                hook_merge::SaveError::Serialize(e) => {
-                    eprintln!("error: failed to serialize config: {e}");
-                    return 1;
-                }
-                hook_merge::SaveError::Io(e) => {
-                    eprintln!("error writing {}: {e}", path.display());
-                    return 1;
-                }
-            }
+            removed = true;
         }
-        println!("Successfully removed cmux hooks from {}", path.display());
-        0
-    } else {
-        if let Some(parent) = path.parent() {
-            let _ = fs::create_dir_all(parent);
+        let cleaned_legacy = clean_legacy(global);
+        if removed || cleaned_legacy {
+            println!("Successfully removed cmux hooks from {}", path.display());
+        } else {
+            println!("No Grok hooks file found at {}", path.display());
         }
-        let mut config = match hook_merge::load_or_default::<GrokHooksConfig>(&path) {
-            Ok(c) => c,
-            Err(hook_merge::LoadError::Parse(e)) => {
-                eprintln!(
-                    "error: malformed Grok config at {}: {e}",
-                    path.display()
-                );
-                return 1;
-            }
-            Err(hook_merge::LoadError::Io(e)) => {
-                eprintln!("error reading {}: {e}", path.display());
-                return 1;
-            }
-            Err(hook_merge::LoadError::NotFound) => GrokHooksConfig::default(),
-        };
-
-        // Remove any existing cmux hooks to avoid duplicates
-        config.hooks.retain(|h| !h.command.contains("cmux report-agent"));
-
-        // Add fresh ones
-        config.hooks.push(GrokHook {
-            event: "PreToolUse".to_string(),
-            command: "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state working --source grok".to_string(),
-        });
-        config.hooks.push(GrokHook {
-            event: "PostToolUse".to_string(),
-            command: "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state idle --source grok".to_string(),
-        });
-        config.hooks.push(GrokHook {
-            event: "Stop".to_string(),
-            command: "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state done --source grok".to_string(),
-        });
-
-        if let Err(e) = hook_merge::save_pretty(&path, &config) {
-            match e {
-                hook_merge::SaveError::Serialize(e) => {
-                    eprintln!("error: failed to serialize config: {e}");
-                    return 1;
-                }
-                hook_merge::SaveError::Io(e) => {
-                    eprintln!("error writing {}: {e}", path.display());
-                    return 1;
-                }
-            }
-        }
-        println!("Successfully installed cmux hooks into {}", path.display());
-        0
+        return 0;
     }
+
+    if let Some(code) = refuse_symlink(&path) {
+        return code;
+    }
+    if let Some(parent) = path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            eprintln!("error creating {}: {e}", parent.display());
+            return 1;
+        }
+    }
+
+    if let Err(e) = hook_merge::save_pretty(&path, &grok_native_hooks()) {
+        match e {
+            hook_merge::SaveError::Serialize(e) => {
+                eprintln!("error: failed to serialize config: {e}");
+                return 1;
+            }
+            hook_merge::SaveError::Io(e) => {
+                eprintln!("error writing {}: {e}", path.display());
+                return 1;
+            }
+        }
+    }
+    clean_legacy(global);
+    println!("Successfully installed cmux hooks into {}", path.display());
+    0
 }
 
 fn skill_path(global: bool) -> Option<PathBuf> {
     if global {
-        mux_core::platform::home_dir().map(|h| h.join(".grok").join("skills").join("cmux-orchestration").join("SKILL.md"))
+        mux_core::platform::home_dir()
+            .map(|h| h.join(".grok").join("skills").join("cmux-orchestration").join("SKILL.md"))
     } else {
         Some(PathBuf::from(".agents").join("skills").join("cmux-orchestration").join("SKILL.md"))
     }
@@ -204,15 +250,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_grok_hooks_config_serialization() {
-        let mut config = GrokHooksConfig::default();
-        config.hooks.push(GrokHook {
-            event: "PreToolUse".to_string(),
-            command: "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state working --source grok".to_string(),
-        });
-        let json = serde_json::to_string(&config).unwrap();
-        let parsed: GrokHooksConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(config, parsed);
+    fn native_hooks_use_grok_object_schema_and_hook_source() {
+        let hooks = grok_native_hooks();
+        let pre = &hooks["hooks"]["PreToolUse"][0]["hooks"][0];
+        assert_eq!(pre["type"], "command");
+        let command = pre["command"].as_str().expect("command is a string");
+        assert!(command.contains("--source hook"), "{command}");
+        assert!(!command.contains("--source grok"), "{command}");
+        assert!(command.contains("test -n \"$CMUX_MUX_SURFACE\""), "{command}");
+        assert_eq!(hooks["hooks"]["Notification"][0]["matcher"], "idle_prompt|permission_prompt");
+    }
+
+    #[test]
+    fn config_path_is_the_grok_hooks_directory() {
+        let project = config_path(false).expect("project path");
+        assert_eq!(
+            project,
+            PathBuf::from(".grok").join("hooks").join("cmux-agent-state.json")
+        );
     }
 
     #[test]

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -222,8 +222,9 @@ AIDER INTEGRATION
 
 GROK CLI INTEGRATION
   cmux grok install-hooks [--uninstall] [--global]
-      Installs hooks into .grok/hooks.json (or ~/.grok/hooks.json if --global)
-      to automatically report state changes to cmux.
+      Installs hooks into .grok/hooks/cmux-agent-state.json (or
+      ~/.grok/hooks/cmux-agent-state.json if --global) in the schema Grok
+      Build actually loads, so panes report working/idle/blocked/done.
   cmux grok install-skill [--uninstall] [--global]
       Installs the orchestration skill to .agents/skills/cmux-orchestration/SKILL.md
       (or ~/.grok/skills/cmux-orchestration/SKILL.md if --global).

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -58,6 +58,9 @@ impl HeadlessServer {
             .args(["--headless", "--socket"])
             .arg(&socket)
             .env("XDG_STATE_HOME", &dir)
+            // Dash, not bash: Falcon GenReverseShell targets a bare
+            // `/bin/bash` on a PTY. CLI tests only need printf/echo.
+            .env("SHELL", "/bin/sh")
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
@@ -78,6 +81,7 @@ impl HeadlessServer {
             .arg(&socket)
             .env("CMUX_MUX_CONFIG", &config)
             .env("XDG_STATE_HOME", &dir)
+            .env("SHELL", "/bin/sh")
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
@@ -541,6 +545,115 @@ fn install_skill_refuses_symlinks() {
 
     // guard goes out of scope here: Drop removes the symlink, the target
     // file, and the temp project dir — even if any assertion above panicked.
+}
+
+#[test]
+fn grok_install_hooks_writes_native_schema() {
+    let project = unique_temp_dir("grok-install-hooks-project");
+    fs::create_dir_all(&project).unwrap();
+
+    let install = Command::new(bin())
+        .args(["grok", "install-hooks"])
+        .current_dir(&project)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&install);
+
+    let path = project.join(".grok").join("hooks").join("cmux-agent-state.json");
+    assert!(path.is_file(), "expected hooks at {}", path.display());
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    let command = value["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("command string");
+    assert_eq!(value["hooks"]["PreToolUse"][0]["hooks"][0]["type"], "command");
+    assert!(command.contains("--source hook"), "{command}");
+    assert!(!command.contains("--source grok"), "{command}");
+    assert!(
+        !project.join(".grok").join("hooks.json").exists(),
+        "must not write the legacy ~/.grok/hooks.json path"
+    );
+
+    let listed = Command::new(bin())
+        .args(["agents", "list"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert_success(&listed);
+    let output = String::from_utf8(listed.stdout).unwrap();
+    let grok = output.lines().find(|row| row.starts_with("grok\t")).unwrap();
+    assert!(grok.contains("\tinstalled\t"), "unexpected row: {grok}");
+
+    fs::remove_dir_all(project).unwrap();
+}
+
+#[test]
+fn grok_install_hooks_cleans_legacy_file() {
+    let project = unique_temp_dir("grok-install-hooks-legacy");
+    fs::create_dir_all(project.join(".grok")).unwrap();
+    fs::write(
+        project.join(".grok").join("hooks.json"),
+        r#"{
+  "hooks": [
+    {
+      "event": "PreToolUse",
+      "command": "cmux report-agent --surface \"$CMUX_MUX_SURFACE\" --state working --source grok"
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let install = Command::new(bin())
+        .args(["grok", "install-hooks"])
+        .current_dir(&project)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert_success(&install);
+    assert!(
+        !project.join(".grok").join("hooks.json").exists(),
+        "legacy file that only held cmux hooks should be removed"
+    );
+
+    fs::remove_dir_all(project).unwrap();
+}
+
+#[test]
+fn grok_install_hooks_refuses_symlinks() {
+    let project = unique_temp_dir("grok-install-hooks-symlink");
+    let hook_path = project.join(".grok").join("hooks").join("cmux-agent-state.json");
+    fs::create_dir_all(hook_path.parent().unwrap()).unwrap();
+    let target = project.join("target.json");
+    fs::write(&target, "{\"keep\":true}\n").unwrap();
+    symlink(&target, &hook_path).unwrap();
+
+    let output = Command::new(bin())
+        .args(["grok", "install-hooks"])
+        .current_dir(&project)
+        .env_remove("CMUX_MUX_SOCKET")
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "grok install-hooks must refuse a symlink target, got status {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        combined.to_lowercase().contains("symlink"),
+        "error output must mention \"symlink\", got: {combined:?}"
+    );
+    assert_eq!(fs::read_to_string(&target).unwrap(), "{\"keep\":true}\n");
+
+    fs::remove_dir_all(project).unwrap();
 }
 
 // Regression test for the symlink_metadata guard added to


### PR DESCRIPTION
## Summary

Two fixes that came out of live cmux smoke testing on a CrowdStrike-protected host.

1. **Default PTY spawn is a login shell.** Falcon IOA `GenReverseShell` was SIGKILL-ing a bare `/bin/bash` that `cmux` opened on a PTY. Real terminals spawn argv0 `-bash`. Default surfaces now use portable-pty `new_default_prog()`. Explicit `command` argv is unchanged. Also dual-write `CMUX_PANEL_ID` / `CMUX_SOCKET_PATH` so Grok Build's multiplexer detector classifies the pane.

2. **`cmux grok install-hooks` writes what Grok Build actually loads.** The old installer wrote `.grok/hooks.json` (wrong path) as a flat array (wrong shape) with `--source grok` (rejected by `report-agent`). Hooks now go to `.grok/hooks/cmux-agent-state.json` in the Claude-compatible object schema, report `--source hook`, refuse symlink overwrite, and clean the legacy file.

Live CLI smoke against the rebuilt binary: **71/71**, including four new panes still alive as `-bash` and a live `example.com` browser tab.

## Test plan

- [x] `cargo test -p mux-core --test pty default_shell_is_spawned_as_login_shell`
- [x] `cargo test -p mux-tui --test cli grok_install_hooks`
- [x] `cargo test -p mux-tui --bin cmux native_hooks` / `config_path_is_the_grok`
- [x] Live smoke: splits, tabs, second screen, browser tab, no dead panes, argv0 `-bash`
- [ ] After merge: `cmux grok install-hooks --global` on a machine that already has the legacy `.grok/hooks.json` and confirm it is cleaned
- [ ] Optional Falcon backup: IOA exclusion for `GenReverseShell` / parent `cmux` if a host still kills `-bash`