### PR TITLE
feat(mux): layout export/apply — JSON fleet snapshot + replay (issue #76)

### DIFF
--- a/mux/crates/mux-core/src/layout_doc.rs
+++ b/mux/crates/mux-core/src/layout_doc.rs
@@ -2,6 +2,368 @@
 //! snapshot of one workspace's tab + pane + agent-argv topology, and its
 //! replay. The schema is versioned (`schema_version: 1`); see
 //! `spec/layout-schema.md`.
+//!
+//! This is the *user-visible* counterpart of `persist.rs`'s internal
+//! session snapshot: same BSP-by-pane-index shape, but it additionally
+//! records each pty tab's spawn argv and env (the "boot this fleet
+//! tomorrow" primitive), browser tab URLs, and remote specs. Capture
+//! reads the provenance recorded at spawn time (`PtySurface::spawn_*`,
+//! set from `SurfaceOptions` in `Surface::spawn`) — agents typed into a
+//! shell by hand have no recoverable argv, so their tabs export with
+//! `command: null` and apply restores a shell in the recorded cwd.
+
+use std::collections::BTreeMap;
+
+use anyhow::bail;
+use serde::{Deserialize, Serialize};
+
+use crate::model::{Node, Screen, State};
+use crate::{SurfaceId, SurfaceKind, WorkspaceId};
+
+/// The only schema version this build reads or writes. `validate`
+/// hard-fails anything else so a future file fails loudly instead of
+/// being misparsed (issue #76 AC4/AC7).
+pub const LAYOUT_SCHEMA_VERSION: u32 = 1;
+
+/// Env keys cmux auto-injects (or dual-writes) into every spawn. They
+/// are re-derived from the *applying* daemon's live socket path, so they
+/// must never round-trip through an exported file (a stale
+/// `CMUX_MUX_SOCKET` would detach the restored fleet).
+const AUTO_ENV_KEYS: &[&str] = &["CMUX_MUX_SOCKET", "CMUX_SOCKET_PATH"];
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutDocument {
+    pub schema_version: u32,
+    /// The cmux build that produced the file (`mux_core::VERSION`, never
+    /// `CARGO_PKG_VERSION` — see issue #71). Informational; not gated.
+    pub cmux_version: String,
+    pub workspace: LayoutWorkspace,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutWorkspace {
+    pub name: String,
+    /// `#rrggbb` or a named preset, as accepted by
+    /// [`crate::server::parse_workspace_color`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    #[serde(default)]
+    pub active_screen: usize,
+    pub screens: Vec<LayoutScreen>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutScreen {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Index into [`LayoutScreen::panes`].
+    #[serde(default)]
+    pub active_pane: usize,
+    /// BSP tree with pane-*index* leaves (the `persist.rs` pattern), in
+    /// the same `node_json` shape the socket already speaks.
+    pub layout: LayoutNode,
+    pub panes: Vec<LayoutPane>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum LayoutNode {
+    Leaf {
+        pane: usize,
+    },
+    Split {
+        dir: LayoutDir,
+        ratio: f32,
+        a: Box<LayoutNode>,
+        b: Box<LayoutNode>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LayoutDir {
+    Right,
+    Down,
+}
+
+impl From<crate::SplitDir> for LayoutDir {
+    fn from(dir: crate::SplitDir) -> Self {
+        match dir {
+            crate::SplitDir::Right => LayoutDir::Right,
+            crate::SplitDir::Down => LayoutDir::Down,
+        }
+    }
+}
+
+impl From<LayoutDir> for crate::SplitDir {
+    fn from(dir: LayoutDir) -> Self {
+        match dir {
+            LayoutDir::Right => crate::SplitDir::Right,
+            LayoutDir::Down => crate::SplitDir::Down,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutPane {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub active_tab: usize,
+    pub tabs: Vec<LayoutTab>,
+}
+
+/// One recorded tab. `pty` is the agent-bearing kind: `command` is the
+/// exact argv the tab was spawned with (recorded at spawn time; `None`
+/// for a default login shell), `env` the injected variables minus cmux's
+/// auto-injected socket keys.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum LayoutTab {
+    Pty {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        command: Option<Vec<String>>,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        env: BTreeMap<String, String>,
+    },
+    Browser {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        url: String,
+    },
+    Remote {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        host: String,
+        slot: String,
+        session_id: String,
+        local_binary_path: String,
+    },
+}
+
+impl LayoutDocument {
+    /// Strict JSON entry point: deserialize (propagating parse errors —
+    /// never silently defaulting) then [`Self::validate`].
+    pub fn from_json_str(json: &str) -> anyhow::Result<Self> {
+        let doc: LayoutDocument = serde_json::from_str(json)
+            .map_err(|e| anyhow::anyhow!("parsing layout document: {e}"))?;
+        doc.validate()?;
+        Ok(doc)
+    }
+
+    /// Structural + semantic gate applied before any replay. Hard-fails
+    /// (issue #76 AC7): unknown `schema_version`, layout leaves outside
+    /// the pane table (or duplicated / unreferenced pane entries), split
+    /// ratios outside (0,1), out-of-range selections, empty tab lists,
+    /// and unparseable workspace color/icon values.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.schema_version != LAYOUT_SCHEMA_VERSION {
+            bail!(
+                "unsupported layout schema_version {} (this cmux writes {})",
+                self.schema_version,
+                LAYOUT_SCHEMA_VERSION
+            );
+        }
+        let ws = &self.workspace;
+        if ws.screens.is_empty() {
+            bail!("layout document has no screens");
+        }
+        if ws.active_screen >= ws.screens.len() {
+            bail!("active_screen {} out of range ({} screens)", ws.active_screen, ws.screens.len());
+        }
+        if let Some(color) = &ws.color {
+            crate::server::parse_workspace_color(color)
+                .map_err(|e| anyhow::anyhow!("workspace color: {e}"))?;
+        }
+        if let Some(icon) = &ws.icon {
+            crate::server::parse_workspace_icon(icon)
+                .map_err(|e| anyhow::anyhow!("workspace icon: {e}"))?;
+        }
+        for (si, screen) in ws.screens.iter().enumerate() {
+            let count = screen.panes.len();
+            if count == 0 {
+                bail!("screen {si} has no panes");
+            }
+            if screen.active_pane >= count {
+                bail!(
+                    "screen {si}: active_pane {} out of range ({count} panes)",
+                    screen.active_pane
+                );
+            }
+            let mut seen = vec![false; count];
+            Self::validate_node(&screen.layout, si, count, &mut seen)?;
+            for (pi, unreferenced) in seen.iter().enumerate() {
+                if !unreferenced {
+                    bail!("screen {si}: pane {pi} is not referenced by the layout tree");
+                }
+            }
+            for (pi, pane) in screen.panes.iter().enumerate() {
+                if pane.tabs.is_empty() {
+                    bail!("screen {si} pane {pi} has no tabs");
+                }
+                if pane.active_tab >= pane.tabs.len() {
+                    bail!(
+                        "screen {si} pane {pi}: active_tab {} out of range ({} tabs)",
+                        pane.active_tab,
+                        pane.tabs.len()
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_node(
+        node: &LayoutNode,
+        screen: usize,
+        pane_count: usize,
+        seen: &mut Vec<bool>,
+    ) -> anyhow::Result<()> {
+        match node {
+            LayoutNode::Leaf { pane } => {
+                if *pane >= pane_count {
+                    bail!(
+                        "screen {screen}: layout leaf pane index {pane} out of range ({pane_count} panes)"
+                    );
+                }
+                if seen[*pane] {
+                    bail!("screen {screen}: pane index {pane} appears more than once in the layout tree");
+                }
+                seen[*pane] = true;
+            }
+            LayoutNode::Split { ratio, a, b, .. } => {
+                if !(*ratio > 0.0 && *ratio < 1.0) {
+                    bail!("screen {screen}: split ratio {ratio} out of range (0,1)");
+                }
+                Self::validate_node(a, screen, pane_count, seen)?;
+                Self::validate_node(b, screen, pane_count, seen)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Result of a successful replay: identity + size of what was created,
+/// for the `layout-apply` response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ApplySummary {
+    pub workspace_id: WorkspaceId,
+    pub panes: usize,
+    pub surfaces: usize,
+}
+
+/// Capture `state.workspaces[ws_idx]` as a standalone document.
+pub fn capture_workspace(state: &State, ws_idx: usize) -> anyhow::Result<LayoutDocument> {
+    let ws = state
+        .workspaces
+        .get(ws_idx)
+        .ok_or_else(|| anyhow::anyhow!("no workspace at index {ws_idx}"))?;
+    Ok(LayoutDocument {
+        schema_version: LAYOUT_SCHEMA_VERSION,
+        cmux_version: crate::VERSION.to_string(),
+        workspace: LayoutWorkspace {
+            name: ws.name.clone(),
+            color: ws.color.map(|c| format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b)),
+            icon: ws.icon.as_ref().map(|icon| icon.as_str().to_string()),
+            active_screen: ws.active_screen,
+            screens: ws.screens.iter().map(|screen| capture_screen(state, screen)).collect(),
+        },
+    })
+}
+
+fn capture_screen(state: &State, screen: &Screen) -> LayoutScreen {
+    let mut pane_ids = Vec::new();
+    screen.root.pane_ids(&mut pane_ids);
+    let index_of =
+        |id: crate::PaneId| pane_ids.iter().position(|&p| p == id).unwrap_or(usize::MAX);
+
+    LayoutScreen {
+        name: screen.name.clone(),
+        active_pane: index_of(screen.active_pane),
+        layout: capture_node(&screen.root, &index_of),
+        panes: pane_ids
+            .iter()
+            .map(|pid| {
+                let pane = &state.panes[pid];
+                LayoutPane {
+                    name: pane.name.clone(),
+                    active_tab: pane.active_tab,
+                    tabs: pane.tabs.iter().map(|sid| capture_tab(state, *sid)).collect(),
+                }
+            })
+            .collect(),
+    }
+}
+
+fn capture_node(node: &Node, index_of: &impl Fn(crate::PaneId) -> usize) -> LayoutNode {
+    match node {
+        Node::Leaf(id) => LayoutNode::Leaf { pane: index_of(*id) },
+        Node::Split { dir, ratio, a, b } => LayoutNode::Split {
+            dir: (*dir).into(),
+            ratio: *ratio,
+            a: Box::new(capture_node(a, index_of)),
+            b: Box::new(capture_node(b, index_of)),
+        },
+    }
+}
+
+fn capture_tab(state: &State, sid: SurfaceId) -> LayoutTab {
+    let surface = state.surfaces.get(&sid);
+    let name = surface.and_then(|s| s.name());
+    match surface.map(|s| s.kind()) {
+        Some(SurfaceKind::Browser) => LayoutTab::Browser {
+            name,
+            url: surface.and_then(|s| s.browser_url()).unwrap_or_default(),
+        },
+        _ => {
+            if let Some(spec) = surface.and_then(|s| s.remote_spec()) {
+                LayoutTab::Remote {
+                    name,
+                    host: spec.host,
+                    slot: spec.slot,
+                    session_id: spec.session_id,
+                    local_binary_path: spec.local_binary_path.display().to_string(),
+                }
+            } else {
+                LayoutTab::Pty {
+                    name,
+                    cwd: surface.and_then(|s| s.cwd()),
+                    command: surface.and_then(|s| s.spawn_command()),
+                    env: surface
+                        .map(|s| {
+                            s.spawn_env()
+                                .into_iter()
+                                .filter(|(k, _)| !AUTO_ENV_KEYS.contains(&k.as_str()))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                }
+            }
+        }
+    }
+}
+
+/// A workspace name turned into a safe single path component for
+/// `layout-export-all` (names are user-chosen and never validated as
+/// filenames at creation time).
+pub fn sanitize_filename(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') { c } else { '_' })
+        .collect();
+    let trimmed = cleaned.trim_matches('.');
+    if trimmed.is_empty() {
+        "workspace".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -9,7 +371,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::{Mux, PaneId, SurfaceId, SurfaceOptions};
+    use crate::{Mux, PaneId, SpawnOverrides, SurfaceId, SurfaceOptions};
 
     /// A mux whose default spawn is a quiet, long-lived child (mirrors
     /// `mux::tests::test_mux`), with cmux's auto-injected socket env keys
@@ -126,8 +488,9 @@ mod tests {
         mux.rename_surface(s1.id, "api".into());
         mux.split(p1, crate::SplitDir::Right, None).unwrap();
         mux.set_ratio(p1, crate::SplitDir::Right, 0.7);
-        mux.new_screen(None, None).unwrap();
         mux.focus_pane(p1);
+        // A second screen, left active: capture must record the selection.
+        mux.new_screen(None, None).unwrap();
 
         let doc = mux.with_state(|s| capture_workspace(s, 0)).unwrap();
         let ws = &doc.workspace;
@@ -162,7 +525,7 @@ mod tests {
                 Some(pane),
                 None,
                 None,
-                Some(SpawnOverrides {
+                Some(&SpawnOverrides {
                     command: Some(vec![
                         "/bin/sh".to_string(),
                         "-c".to_string(),

--- a/mux/crates/mux-core/src/layout_doc.rs
+++ b/mux/crates/mux-core/src/layout_doc.rs
@@ -1,0 +1,248 @@
+//! Layout export/apply document (issue #76): the user-addressable JSON
+//! snapshot of one workspace's tab + pane + agent-argv topology, and its
+//! replay. The schema is versioned (`schema_version: 1`); see
+//! `spec/layout-schema.md`.
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{Mux, PaneId, SurfaceId, SurfaceOptions};
+
+    /// A mux whose default spawn is a quiet, long-lived child (mirrors
+    /// `mux::tests::test_mux`), with cmux's auto-injected socket env keys
+    /// present so capture's exclusion list is exercised.
+    fn test_mux() -> Arc<Mux> {
+        let opts = SurfaceOptions {
+            command: Some(vec!["/bin/cat".to_string()]),
+            extra_env: vec![
+                ("CMUX_MUX_SOCKET".into(), "/tmp/cmux-layout-test.sock".into()),
+                ("CMUX_SOCKET_PATH".into(), "/tmp/cmux-layout-test.sock".into()),
+                ("FLEET_TIER".into(), "A".into()),
+            ],
+            ..Default::default()
+        };
+        Mux::new("layout-doc-test", opts)
+    }
+
+    fn pane_of(mux: &Mux, surface: SurfaceId) -> PaneId {
+        mux.with_state(|s| s.pane_of(surface).unwrap())
+    }
+
+    // 1. `layout_doc_round_trips_through_json`
+    #[test]
+    fn layout_doc_round_trips_through_json() {
+        let mux = test_mux();
+        let s1 = mux.new_workspace(Some("fleet".into()), None).unwrap();
+        let p1 = pane_of(&mux, s1.id);
+        mux.split(p1, crate::SplitDir::Right, None).unwrap();
+        mux.rename_pane(p1, "build".into());
+
+        let doc = mux.with_state(|s| capture_workspace(s, 0)).unwrap();
+        assert_eq!(doc.schema_version, LAYOUT_SCHEMA_VERSION);
+        assert_eq!(doc.cmux_version, crate::VERSION);
+
+        let json = serde_json::to_string_pretty(&doc).unwrap();
+        assert!(json.contains("\"schema_version\": 1"), "json was: {json}");
+        let restored = LayoutDocument::from_json_str(&json).unwrap();
+        assert_eq!(restored, doc);
+    }
+
+    // 2. `layout_doc_rejects_unknown_schema_version`
+    #[test]
+    fn layout_doc_rejects_unknown_schema_version() {
+        let mux = test_mux();
+        mux.new_workspace(Some("fleet".into()), None).unwrap();
+        let mut doc = mux.with_state(|s| capture_workspace(s, 0)).unwrap();
+        doc.schema_version = 2;
+
+        let err = doc.validate().unwrap_err().to_string();
+        assert!(err.contains("schema_version"), "error was: {err}");
+        assert!(err.contains('2'), "error should name the bad version: {err}");
+
+        // The strict JSON entry point applies the same gate.
+        doc.schema_version = LAYOUT_SCHEMA_VERSION;
+        let json = serde_json::to_string(&doc).unwrap().replace("\"schema_version\":1", "\"schema_version\":7");
+        let err = LayoutDocument::from_json_str(&json).unwrap_err().to_string();
+        assert!(err.contains("schema_version"), "error was: {err}");
+    }
+
+    // 3. `layout_doc_rejects_leaf_index_out_of_range`
+    #[test]
+    fn layout_doc_rejects_leaf_index_out_of_range() {
+        let doc = LayoutDocument {
+            schema_version: LAYOUT_SCHEMA_VERSION,
+            cmux_version: crate::VERSION.to_string(),
+            workspace: LayoutWorkspace {
+                name: "bad".into(),
+                color: None,
+                icon: None,
+                active_screen: 0,
+                screens: vec![LayoutScreen {
+                    name: None,
+                    active_pane: 0,
+                    layout: LayoutNode::Leaf { pane: 3 },
+                    panes: vec![
+                        LayoutPane { name: None, active_tab: 0, tabs: vec![sample_tab()] },
+                        LayoutPane { name: None, active_tab: 0, tabs: vec![sample_tab()] },
+                    ],
+                }],
+            },
+        };
+        let err = doc.validate().unwrap_err().to_string();
+        assert!(err.contains('3'), "error should name the bad index: {err}");
+        assert!(err.contains("out of range"), "error was: {err}");
+    }
+
+    // 4. `layout_doc_rejects_unknown_tab_kind`
+    #[test]
+    fn layout_doc_rejects_unknown_tab_kind() {
+        let json = r#"{
+            "schema_version": 1,
+            "cmux_version": "test",
+            "workspace": {
+                "name": "w",
+                "active_screen": 0,
+                "screens": [{
+                    "active_pane": 0,
+                    "layout": {"type": "leaf", "pane": 0},
+                    "panes": [{"tabs": [{"kind": "matrix"}]}]
+                }]
+            }
+        }"#;
+        let err = LayoutDocument::from_json_str(json).unwrap_err().to_string();
+        assert!(err.contains("matrix"), "error should name the unknown kind: {err}");
+    }
+
+    // 5. `layout_doc_capture_includes_split_geometry_names_and_selections`
+    #[test]
+    fn layout_doc_capture_includes_split_geometry_names_and_selections() {
+        let mux = test_mux();
+        let s1 = mux.new_workspace(Some("fleet".into()), None).unwrap();
+        let p1 = pane_of(&mux, s1.id);
+        mux.rename_pane(p1, "build".into());
+        mux.rename_surface(s1.id, "api".into());
+        mux.split(p1, crate::SplitDir::Right, None).unwrap();
+        mux.set_ratio(p1, crate::SplitDir::Right, 0.7);
+        mux.new_screen(None, None).unwrap();
+        mux.focus_pane(p1);
+
+        let doc = mux.with_state(|s| capture_workspace(s, 0)).unwrap();
+        let ws = &doc.workspace;
+        assert_eq!(ws.name, "fleet");
+        assert_eq!(ws.screens.len(), 2);
+        assert_eq!(ws.active_screen, 1, "capture should record the active screen");
+
+        let sc = &ws.screens[0];
+        let LayoutNode::Split { dir, ratio, a, b } = &sc.layout else {
+            panic!("expected a split root, got {:?}", sc.layout);
+        };
+        assert_eq!(*dir, LayoutDir::Right);
+        assert!((*ratio - 0.7).abs() < 1e-6, "ratio was {ratio}");
+        assert_eq!(**a, LayoutNode::Leaf { pane: 0 });
+        assert_eq!(**b, LayoutNode::Leaf { pane: 1 });
+        assert_eq!(sc.panes[0].name.as_deref(), Some("build"));
+        assert_eq!(sc.active_pane, 0, "focused pane is pane 0");
+        match &sc.panes[0].tabs[0] {
+            LayoutTab::Pty { name, .. } => assert_eq!(name.as_deref(), Some("api")),
+            other => panic!("expected a pty tab, got {other:?}"),
+        }
+    }
+
+    // 6. `layout_doc_capture_records_command_and_env_dropping_cmux_auto_vars`
+    #[test]
+    fn layout_doc_capture_records_command_and_env_dropping_cmux_auto_vars() {
+        let mux = test_mux();
+        let s1 = mux.new_workspace(Some("fleet".into()), None).unwrap();
+        let pane = pane_of(&mux, s1.id);
+        let s2 = mux
+            .new_tab_with_overrides(
+                Some(pane),
+                None,
+                None,
+                Some(SpawnOverrides {
+                    command: Some(vec![
+                        "/bin/sh".to_string(),
+                        "-c".to_string(),
+                        "sleep 30".to_string(),
+                    ]),
+                    extra_env: vec![("FLEET_WORKER".into(), "9".into())],
+                    cwd: Some("/tmp".into()),
+                }),
+            )
+            .unwrap();
+        assert!(s2.id > 0);
+
+        let doc = mux.with_state(|s| capture_workspace(s, 0)).unwrap();
+        let tabs = &doc.workspace.screens[0].panes[0].tabs;
+        assert_eq!(tabs.len(), 2, "pane should have the workspace tab + the override tab");
+        match &tabs[1] {
+            LayoutTab::Pty { command, env, cwd, .. } => {
+                assert_eq!(
+                    command.as_deref(),
+                    Some(["/bin/sh".to_string(), "-c".to_string(), "sleep 30".to_string()].as_slice()),
+                    "recorded argv should round-trip"
+                );
+                assert_eq!(env.get("FLEET_TIER").map(String::as_str), Some("A"));
+                assert_eq!(env.get("FLEET_WORKER").map(String::as_str), Some("9"));
+                assert!(!env.contains_key("CMUX_MUX_SOCKET"), "auto socket env must not be exported");
+                assert!(!env.contains_key("CMUX_SOCKET_PATH"), "auto socket env must not be exported");
+                assert_eq!(cwd.as_deref(), Some("/tmp"));
+            }
+            other => panic!("expected a pty tab, got {other:?}"),
+        }
+    }
+
+    // 7. `layout_doc_rejects_bad_ratio`
+    #[test]
+    fn layout_doc_rejects_bad_ratio() {
+        for bad in [1.5f32, 0.0, -0.25, 1.0] {
+            let mut doc = sample_doc();
+            doc.workspace.screens[0].layout = LayoutNode::Split {
+                dir: LayoutDir::Right,
+                ratio: bad,
+                a: Box::new(LayoutNode::Leaf { pane: 0 }),
+                b: Box::new(LayoutNode::Leaf { pane: 1 }),
+            };
+            doc.workspace.screens[0].panes.push(LayoutPane {
+                name: None,
+                active_tab: 0,
+                tabs: vec![sample_tab()],
+            });
+            let err = doc.validate().unwrap_err().to_string();
+            assert!(err.contains("ratio"), "ratio {bad} should be rejected, got: {err}");
+        }
+    }
+
+    // -- fixtures ---------------------------------------------------------
+
+    fn sample_tab() -> LayoutTab {
+        LayoutTab::Pty {
+            name: None,
+            cwd: None,
+            command: None,
+            env: BTreeMap::new(),
+        }
+    }
+
+    fn sample_doc() -> LayoutDocument {
+        LayoutDocument {
+            schema_version: LAYOUT_SCHEMA_VERSION,
+            cmux_version: crate::VERSION.to_string(),
+            workspace: LayoutWorkspace {
+                name: "sample".into(),
+                color: None,
+                icon: None,
+                active_screen: 0,
+                screens: vec![LayoutScreen {
+                    name: None,
+                    active_pane: 0,
+                    layout: LayoutNode::Leaf { pane: 0 },
+                    panes: vec![LayoutPane { name: None, active_tab: 0, tabs: vec![sample_tab()] }],
+                }],
+            },
+        }
+    }
+}

--- a/mux/crates/mux-core/src/lib.rs
+++ b/mux/crates/mux-core/src/lib.rs
@@ -39,14 +39,18 @@ pub use layout::{
     directional_neighbor, layout_screen, split_for_pane_edge, split_sides, LayoutResult, Rect,
     SplitEdge, SplitResize,
 };
+pub use layout_doc::{
+    capture_workspace, sanitize_filename, ApplySummary, LayoutDir, LayoutDocument, LayoutNode,
+    LayoutPane, LayoutScreen, LayoutTab, LayoutWorkspace, LAYOUT_SCHEMA_VERSION,
+};
 pub use model::{IconName, Node, Pane, Screen, State, Workspace};
 pub use mux::{Mux, MuxEvent};
 pub use remote_pty::RemoteSpec;
 pub use short_id::assign_short_ids;
 pub use surface::{
     AgentReport, AgentState, AgentStateSource, AttachFrame, AttachStream, BrowserAttachState,
-    BrowserFrame, BrowserFrameStream, BrowserSource, BrowserStatus, DefaultColors, Surface,
-    SurfaceKind, SurfaceOptions,
+    BrowserFrame, BrowserFrameStream, BrowserSource, BrowserStatus, DefaultColors, SpawnOverrides,
+    Surface, SurfaceKind, SurfaceOptions,
 };
 
 pub use ghostty_vt::Rgb;

--- a/mux/crates/mux-core/src/lib.rs
+++ b/mux/crates/mux-core/src/lib.rs
@@ -9,6 +9,7 @@
 //! themselves, which is what makes the backend attachable.
 
 mod browser;
+mod layout_doc;
 mod model;
 mod mux;
 mod notify;

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -521,6 +521,241 @@ impl Mux {
         }
     }
 
+    /// Replay a validated layout document into this session under
+    /// workspace name `name`, creating the workspace if it doesn't exist
+    /// (issue #76 AC2). `name` — not the document's embedded name — is
+    /// the workspace identity, so one fleet file can be booted under many
+    /// names.
+    ///
+    /// Fails loudly (AC7): a pane whose tabs can't be recreated aborts
+    /// the apply with `pane <index> (pane-id <id>): <error>`; a pane that
+    /// couldn't even be created names its index. Already-created panes
+    /// are left in place — fail-loud, not transactional (a `--replace`
+    /// rollback is follow-up scope).
+    pub fn apply_layout(
+        self: &Arc<Self>,
+        name: &str,
+        doc: &crate::layout_doc::LayoutDocument,
+    ) -> anyhow::Result<crate::layout_doc::ApplySummary> {
+        doc.validate()?;
+        if let Some(existing) =
+            self.with_state(|s| s.workspaces.iter().find(|ws| ws.name == name).map(|ws| ws.id))
+        {
+            anyhow::bail!(
+                "workspace {name:?} already exists (id {existing}); \
+close it first or apply under a new name"
+            );
+        }
+        let ws = &doc.workspace;
+        // The workspace's very first tab is the only one apply can
+        // recreate as a genuine remote reattach (via new_remote_workspace)
+        // — the same inherited limitation as restore_session; every other
+        // remote tab downgrades to a local shell with a loud Status.
+        let first_tab = &ws.screens[0].panes[0].tabs[0];
+        let first_surface = match first_tab {
+            crate::layout_doc::LayoutTab::Remote {
+                host, slot, session_id, local_binary_path, ..
+            } => {
+                let spec = crate::remote_pty::RemoteSpec {
+                    host: host.clone(),
+                    slot: slot.clone(),
+                    session_id: session_id.clone(),
+                    local_binary_path: local_binary_path.clone().into(),
+                };
+                self.new_remote_workspace(spec, Some(name.to_string()), None)?
+            }
+            tab => {
+                let overrides = layout_tab_overrides(tab);
+                self.new_workspace_with_overrides(
+                    Some(name.to_string()),
+                    None,
+                    overrides.as_ref(),
+                )?
+            }
+        };
+        let ws_id = self.with_state(|s| s.workspaces.last().unwrap().id);
+        if let Some(color) = &ws.color {
+            let rgb = crate::server::parse_workspace_color(color)
+                .map_err(|e| anyhow::anyhow!("workspace {name:?}: {e}"))?;
+            self.set_workspace_color(ws_id, Some(rgb));
+        }
+        if let Some(icon) = &ws.icon {
+            let icon = crate::server::parse_workspace_icon(icon)
+                .map_err(|e| anyhow::anyhow!("workspace {name:?}: {e}"))?;
+            self.set_workspace_icon(ws_id, Some(icon));
+        }
+
+        // Screen 0 already exists around `first_surface`.
+        let bootstrap_pane = self.with_state(|s| s.pane_of(first_surface.id).unwrap());
+        let screen0_id =
+            self.with_state(|s| s.screen_of(bootstrap_pane).map(|(wi, si)| s.workspaces[wi].screens[si].id).unwrap());
+        self.apply_layout_screen(&ws.screens[0], screen0_id, bootstrap_pane, Some(bootstrap_pane))?;
+
+        for screen in &ws.screens[1..] {
+            // The new screen's first pane auto-spawns its tab 0: replay
+            // the recorded argv/env when that tab is a pty.
+            let first = &screen.panes[leftmost_layout_index(&screen.layout)].tabs[0];
+            let overrides = layout_tab_overrides(first);
+            let surface =
+                self.new_screen_with_overrides(Some(ws_id), None, overrides.as_ref())?;
+            let (screen_id, pane_id) = self.with_state(|s| {
+                let pane_id = s.pane_of(surface.id).unwrap();
+                let (wi, si) = s.screen_of(pane_id).unwrap();
+                (s.workspaces[wi].screens[si].id, pane_id)
+            });
+            self.apply_layout_screen(screen, screen_id, pane_id, None)?;
+        }
+        self.select_screen(Some(ws.active_screen.min(ws.screens.len() - 1)), None);
+
+        let (panes, surfaces) = self.with_state(|s| {
+            let ws = s.workspaces.iter().find(|w| w.id == ws_id).unwrap();
+            let panes: usize = ws
+                .screens
+                .iter()
+                .map(|sc| {
+                    let mut ids = Vec::new();
+                    sc.root.pane_ids(&mut ids);
+                    ids.len()
+                })
+                .sum();
+            let surfaces = ws.screens.iter().map(|sc| screen_tabs(s, sc).len()).sum();
+            (panes, surfaces)
+        });
+        Ok(crate::layout_doc::ApplySummary { workspace_id: ws_id, panes, surfaces })
+    }
+
+    /// Replay one screen of a layout document. `initial_pane` is the
+    /// pane the screen is built around (the workspace bootstrap pane for
+    /// screen 0, the new screen's first pane otherwise); `bootstrap_pane`
+    /// marks the one pane whose tab 0 was created by `apply_layout`'s
+    /// remote-first-tab handling.
+    fn apply_layout_screen(
+        self: &Arc<Self>,
+        screen: &crate::layout_doc::LayoutScreen,
+        screen_id: ScreenId,
+        initial_pane: PaneId,
+        bootstrap_pane: Option<PaneId>,
+    ) -> anyhow::Result<()> {
+        let pane_ids = self.replay_layout_doc(&screen.layout, screen, initial_pane)?;
+        for (index, pane) in screen.panes.iter().enumerate() {
+            let pane_id = pane_ids[&index];
+            if let Some(name) = &pane.name {
+                self.rename_pane(pane_id, name.clone());
+            }
+            // Tab 0 was auto-spawned while the tree structure was built:
+            // pty tabs already run the recorded argv/env/cwd; a browser
+            // tab replaces its placeholder shell; remote tabs downgrade
+            // loudly everywhere except the workspace bootstrap pane.
+            match &pane.tabs[0] {
+                crate::layout_doc::LayoutTab::Pty { name, .. } => {
+                    let tab0 = self.with_state(|s| s.panes[&pane_id].tabs[0]);
+                    if let Some(surface) = self.surface(tab0) {
+                        if let Some(name) = name {
+                            self.rename_surface(surface.id, name.clone());
+                        }
+                    }
+                }
+                crate::layout_doc::LayoutTab::Browser { name, url } => {
+                    let shell = self.with_state(|s| s.panes[&pane_id].tabs[0]);
+                    let surface = self
+                        .new_browser_tab(url.clone(), Some(pane_id), None)
+                        .map_err(|e| anyhow::anyhow!("pane {index} (pane-id {pane_id}): {e}"))?;
+                    if let Some(name) = name {
+                        self.rename_surface(surface.id, name.clone());
+                    }
+                    self.close_surface(shell);
+                }
+                crate::layout_doc::LayoutTab::Remote { host, session_id, name, .. } => {
+                    if Some(pane_id) != bootstrap_pane {
+                        self.emit(MuxEvent::Status(format!(
+                            "layout apply restored a local shell instead of \
+reattaching to remote session {session_id} on {host} \
+(only a workspace's first pane can do that)"
+                        )));
+                    }
+                    let tab0 = self.with_state(|s| s.panes[&pane_id].tabs[0]);
+                    if let Some(surface) = self.surface(tab0) {
+                        if let Some(name) = name {
+                            self.rename_surface(surface.id, name.clone());
+                        }
+                    }
+                }
+            }
+            for tab in &pane.tabs[1..] {
+                match tab {
+                    tab @ crate::layout_doc::LayoutTab::Pty { name, .. } => {
+                        let overrides = layout_tab_overrides(tab)
+                            .expect("a pty layout tab always maps to spawn overrides");
+                        let surface = self
+                            .new_tab_with_overrides(Some(pane_id), None, None, Some(&overrides))
+                            .map_err(|e| anyhow::anyhow!("pane {index} (pane-id {pane_id}): {e}"))?;
+                        if let Some(name) = name {
+                            self.rename_surface(surface.id, name.clone());
+                        }
+                    }
+                    crate::layout_doc::LayoutTab::Browser { name, url } => {
+                        let surface = self
+                            .new_browser_tab(url.clone(), Some(pane_id), None)
+                            .map_err(|e| anyhow::anyhow!("pane {index} (pane-id {pane_id}): {e}"))?;
+                        if let Some(name) = name {
+                            self.rename_surface(surface.id, name.clone());
+                        }
+                    }
+                    crate::layout_doc::LayoutTab::Remote { host, session_id, name, .. } => {
+                        self.emit(MuxEvent::Status(format!(
+                            "layout apply restored a local shell instead of \
+reattaching to remote session {session_id} on {host} \
+(only a workspace's first pane can do that)"
+                        )));
+                        let surface = self
+                            .new_tab(Some(pane_id), None, None)
+                            .map_err(|e| anyhow::anyhow!("pane {index} (pane-id {pane_id}): {e}"))?;
+                        if let Some(name) = name {
+                            self.rename_surface(surface.id, name.clone());
+                        }
+                    }
+                }
+            }
+            self.select_tab(Some(pane_id), Some(pane.active_tab), None);
+        }
+        if let Some(name) = &screen.name {
+            self.rename_screen(screen_id, name.clone());
+        }
+        self.focus_pane(pane_ids[&screen.active_pane]);
+        Ok(())
+    }
+
+    /// The layout-doc counterpart of [`Self::replay_layout`]: replays the
+    /// pane-index BSP as `split()` calls, spawning each new pane's tab 0
+    /// with the recorded argv/env/cwd when it's a pty tab. Returns every
+    /// leaf's pane id keyed by its document index.
+    fn replay_layout_doc(
+        self: &Arc<Self>,
+        node: &crate::layout_doc::LayoutNode,
+        screen: &crate::layout_doc::LayoutScreen,
+        root: PaneId,
+    ) -> anyhow::Result<HashMap<usize, PaneId>> {
+        match node {
+            crate::layout_doc::LayoutNode::Leaf { pane } => Ok(HashMap::from([(*pane, root)])),
+            crate::layout_doc::LayoutNode::Split { dir, ratio, a, b } => {
+                // `split()` keeps `root` on the "a" side and auto-spawns
+                // the new pane's tab 0 (the agent-start primitive when
+                // the recorded tab is a pty).
+                let new_index = leftmost_layout_index(b);
+                let tab0 = &screen.panes[new_index].tabs[0];
+                let overrides = layout_tab_overrides(tab0);
+                let new_surface = self
+                    .split_with_overrides(root, (*dir).into(), None, overrides.as_ref())
+                    .map_err(|e| anyhow::anyhow!("pane {new_index}: {e} (pane not created)"))?;
+                let new_pane = self.with_state(|s| s.pane_of(new_surface.id).unwrap());
+                self.set_ratio(root, (*dir).into(), *ratio);
+                let mut map = self.replay_layout_doc(a, screen, root)?;
+                map.extend(self.replay_layout_doc(b, screen, new_pane)?);
+                Ok(map)
+            }
+        }
+    }
+
     /// Applies a restored tab's name and cwd to an already-spawned
     /// surface (see the module doc on why this is a live `cd`, not a
     /// spawn-time option).
@@ -1462,6 +1697,29 @@ impl Mux {
     }
 }
 
+/// Spawn overrides for a layout tab's recorded argv/env/cwd. Browser and
+/// remote tabs have no pty overrides — structure spawns a default shell
+/// and `apply_layout_screen` fixes the tab up (or downgrades it loudly).
+fn layout_tab_overrides(tab: &crate::layout_doc::LayoutTab) -> Option<SpawnOverrides> {
+    match tab {
+        crate::layout_doc::LayoutTab::Pty { command, env, cwd, .. } => Some(SpawnOverrides {
+            command: command.clone(),
+            extra_env: env.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+            cwd: cwd.clone(),
+        }),
+        _ => None,
+    }
+}
+
+/// The pane index `split()` auto-creates for a subtree: its leftmost
+/// leaf (replay only ever recurses down the "a" side of its root).
+fn leftmost_layout_index(node: &crate::layout_doc::LayoutNode) -> usize {
+    match node {
+        crate::layout_doc::LayoutNode::Leaf { pane } => *pane,
+        crate::layout_doc::LayoutNode::Split { a, .. } => leftmost_layout_index(a),
+    }
+}
+
 /// Every surface in a screen (all panes, all tabs).
 fn screen_tabs(state: &State, screen: &Screen) -> Vec<SurfaceId> {
     let mut pane_ids = Vec::new();
@@ -2041,6 +2299,207 @@ mod tests {
             matches!(e, MuxEvent::AgentStateChanged { report, .. } if report.state == AgentState::Done)
         });
         assert!(fired, "an applied report must emit agent-state-changed");
+    }
+
+    // -- issue #76: layout apply ------------------------------------------
+
+    use crate::layout_doc::{
+        LayoutDir, LayoutDocument, LayoutNode, LayoutPane, LayoutScreen, LayoutTab,
+        LayoutWorkspace,
+    };
+    use crate::LAYOUT_SCHEMA_VERSION;
+    use std::collections::BTreeMap;
+
+    fn layout_cat_tab() -> LayoutTab {
+        LayoutTab::Pty {
+            name: None,
+            cwd: None,
+            command: Some(vec!["/bin/cat".to_string()]),
+            env: BTreeMap::new(),
+        }
+    }
+
+    fn layout_doc_with(name: &str, layout: LayoutNode, panes: Vec<LayoutPane>) -> LayoutDocument {
+        LayoutDocument {
+            schema_version: LAYOUT_SCHEMA_VERSION,
+            cmux_version: crate::VERSION.to_string(),
+            workspace: LayoutWorkspace {
+                name: name.to_string(),
+                color: Some("#ff0000".into()),
+                icon: Some("robot".into()),
+                active_screen: 0,
+                screens: vec![LayoutScreen {
+                    name: Some("main".into()),
+                    active_pane: 0,
+                    layout,
+                    panes,
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn apply_layout_creates_missing_workspace_by_name() {
+        let mux = test_mux();
+        let doc = layout_doc_with(
+            "resurrected",
+            LayoutNode::Leaf { pane: 0 },
+            vec![LayoutPane {
+                name: Some("build".into()),
+                active_tab: 0,
+                tabs: vec![layout_cat_tab()],
+            }],
+        );
+        let summary = mux.apply_layout("resurrected", &doc).unwrap();
+        mux.with_state(|s| {
+            assert_eq!(s.workspaces.len(), 1);
+            let ws = &s.workspaces[0];
+            assert_eq!(ws.name, "resurrected");
+            assert_eq!(Some(ws.id), Some(summary.workspace_id));
+            assert_eq!(ws.color, Some(Rgb { r: 255, g: 0, b: 0 }));
+            assert_eq!(ws.icon.as_ref().map(|i| i.as_str()), Some("\u{1f916}"));
+            assert_eq!(ws.screens[0].name.as_deref(), Some("main"));
+            let pane = s.panes[&ws.screens[0].active_pane].name.clone();
+            assert_eq!(pane.as_deref(), Some("build"));
+        });
+        assert_eq!(summary.panes, 1);
+        assert_eq!(summary.surfaces, 1);
+
+        // Applying onto an existing name is refused (non-destructive, v1).
+        let err = mux.apply_layout("resurrected", &doc).unwrap_err().to_string();
+        assert!(err.contains("already exists"), "error was: {err}");
+    }
+
+    #[test]
+    fn apply_layout_recreates_split_tree_ratios_and_selections() {
+        let mux = test_mux();
+        let mut doc = layout_doc_with(
+            "splitdoc",
+            LayoutNode::Split {
+                dir: LayoutDir::Right,
+                ratio: 0.3,
+                a: Box::new(LayoutNode::Leaf { pane: 0 }),
+                b: Box::new(LayoutNode::Split {
+                    dir: LayoutDir::Down,
+                    ratio: 0.4,
+                    a: Box::new(LayoutNode::Leaf { pane: 1 }),
+                    b: Box::new(LayoutNode::Leaf { pane: 2 }),
+                }),
+            },
+            vec![
+                LayoutPane { name: None, active_tab: 0, tabs: vec![layout_cat_tab()] },
+                LayoutPane {
+                    name: Some("logs".into()),
+                    active_tab: 0,
+                    tabs: vec![layout_cat_tab()],
+                },
+                LayoutPane { name: None, active_tab: 0, tabs: vec![layout_cat_tab()] },
+            ],
+        );
+        doc.workspace.screens[0].active_pane = 2;
+        mux.apply_layout("splitdoc", &doc).unwrap();
+
+        mux.with_state(|s| {
+            let ws = &s.workspaces[0];
+            assert_eq!(ws.name, "splitdoc");
+            let mut ids = Vec::new();
+            ws.screens[0].root.pane_ids(&mut ids);
+            assert_eq!(ids.len(), 3, "all three panes should exist");
+            let Node::Split { dir, ratio, a: _, b } = &ws.screens[0].root else {
+                panic!("expected split root");
+            };
+            assert!(matches!(dir, SplitDir::Right));
+            assert!((ratio - 0.3).abs() < 1e-6, "root ratio was {ratio}");
+            let Node::Split { dir: inner_dir, ratio: inner_ratio, a: inner_a, b: inner_b } =
+                b.as_ref()
+            else {
+                panic!("expected inner split on the b side");
+            };
+            assert!(matches!(inner_dir, SplitDir::Down));
+            assert!((inner_ratio - 0.4).abs() < 1e-6, "inner ratio was {inner_ratio}");
+            assert!(matches!(**inner_a, Node::Leaf(id) if id == ids[1]));
+            assert!(matches!(**inner_b, Node::Leaf(id) if id == ids[2]));
+            assert_eq!(ws.screens[0].active_pane, ids[2], "recorded selection should be focused");
+            assert_eq!(s.panes[&ids[1]].name.as_deref(), Some("logs"));
+        });
+    }
+
+    #[test]
+    fn apply_layout_spawns_recorded_argv_and_env() {
+        let mux = test_mux();
+        let tab = LayoutTab::Pty {
+            name: Some("worker-9".into()),
+            cwd: None,
+            command: Some(vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "test \"$CMUX_LAYOUT_FLAG\" = yes && printf CMUX_LAYOUT_ARGV_OK; sleep 30"
+                    .to_string(),
+            ]),
+            env: BTreeMap::from([("CMUX_LAYOUT_FLAG".to_string(), "yes".to_string())]),
+        };
+        let doc = layout_doc_with(
+            "argv",
+            LayoutNode::Leaf { pane: 0 },
+            vec![LayoutPane { name: None, active_tab: 0, tabs: vec![tab] }],
+        );
+        mux.apply_layout("argv", &doc).unwrap();
+
+        let sid = mux.with_state(|s| {
+            let ws = &s.workspaces[0];
+            s.panes[&ws.screens[0].active_pane].tabs[0]
+        });
+        let surface = mux.surface(sid).unwrap();
+        assert_eq!(surface.name().as_deref(), Some("worker-9"));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut saw = false;
+        while std::time::Instant::now() < deadline {
+            if let Ok(Ok(text)) = surface.try_with_terminal(|t| t.plain_text()) {
+                if text.contains("CMUX_LAYOUT_ARGV_OK") {
+                    saw = true;
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        assert!(saw, "recorded argv + env should have produced the marker");
+    }
+
+    #[test]
+    fn apply_layout_failure_names_pane_index_and_id() {
+        let mux = test_mux();
+        let bad_tab = LayoutTab::Pty {
+            name: None,
+            cwd: None,
+            command: Some(vec!["/nonexistent/cmux-layout-fail".to_string()]),
+            env: BTreeMap::new(),
+        };
+        let doc = layout_doc_with(
+            "faildoc",
+            LayoutNode::Split {
+                dir: LayoutDir::Right,
+                ratio: 0.5,
+                a: Box::new(LayoutNode::Leaf { pane: 0 }),
+                b: Box::new(LayoutNode::Leaf { pane: 1 }),
+            },
+            vec![
+                LayoutPane { name: None, active_tab: 0, tabs: vec![layout_cat_tab()] },
+                LayoutPane {
+                    name: None,
+                    active_tab: 0,
+                    tabs: vec![layout_cat_tab(), bad_tab],
+                },
+            ],
+        );
+        let err = mux.apply_layout("faildoc", &doc).unwrap_err().to_string();
+        assert!(err.contains("pane 1"), "error should name pane index 1: {err}");
+        // The already-created pane id is named too (AC7).
+        let pane_id = mux.with_state(|s| {
+            let mut ids = Vec::new();
+            s.workspaces[0].screens[0].root.pane_ids(&mut ids);
+            ids[1]
+        });
+        assert!(err.contains(&format!("pane-id {pane_id}")), "error was: {err}");
     }
 
     #[test]

--- a/mux/crates/mux-core/src/mux.rs
+++ b/mux/crates/mux-core/src/mux.rs
@@ -10,7 +10,8 @@ use std::sync::{Arc, Mutex};
 use crate::browser::{self, BrowserBootstrap, BrowserRuntime};
 use crate::model::{IconName, Node, Pane, Screen, State, Workspace};
 use crate::surface::{
-    AgentReport, AgentState, AgentStateSource, DefaultColors, Surface, SurfaceOptions,
+    AgentReport, AgentState, AgentStateSource, DefaultColors, SpawnOverrides, Surface,
+    SurfaceOptions,
 };
 use crate::{PaneId, Rgb, ScreenId, SplitDir, SurfaceId, WorkspaceId};
 
@@ -182,6 +183,7 @@ impl Mux {
         self: &Arc<Self>,
         cwd: Option<String>,
         size: Option<(u16, u16)>,
+        overrides: Option<&SpawnOverrides>,
     ) -> anyhow::Result<Arc<Surface>> {
         let id = self.next_id();
         let mut opts = self.surface_options.clone();
@@ -189,7 +191,22 @@ impl Mux {
         // AC4): existing panes keep what they got at spawn; panes spawned
         // after a rename get the new path.
         self.refresh_socket_env(&mut opts);
-        if cwd.is_some() {
+        // Issue #76: layer explicit spawn overrides (recorded agent argv /
+        // env / cwd from a layout apply or `new-tab --exec`) on top of the
+        // refreshed template. Precedence: override > cwd param > template.
+        if let Some(overrides) = overrides {
+            if let Some(command) = &overrides.command {
+                opts.command = Some(command.clone());
+            }
+            for (key, value) in &overrides.extra_env {
+                opts.extra_env.retain(|(k, _)| k != key);
+                opts.extra_env.push((key.clone(), value.clone()));
+            }
+            if overrides.cwd.is_some() {
+                opts.cwd = overrides.cwd.clone();
+            }
+        }
+        if cwd.is_some() && opts.cwd.is_none() {
             opts.cwd = cwd;
         }
         // Spawn at the final size when the frontend knows it: starting at
@@ -608,7 +625,19 @@ impl Mux {
         name: Option<String>,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
-        let surface = self.spawn_surface(None, size)?;
+        self.new_workspace_with_overrides(name, size, None)
+    }
+
+    /// Issue #76: [`Self::new_workspace`] with explicit spawn overrides
+    /// (the recorded first-tab argv/env/cwd of a layout apply, or a
+    /// socket `new-workspace` carrying `command`/`env`).
+    pub fn new_workspace_with_overrides(
+        self: &Arc<Self>,
+        name: Option<String>,
+        size: Option<(u16, u16)>,
+        overrides: Option<&SpawnOverrides>,
+    ) -> anyhow::Result<Arc<Surface>> {
+        let surface = self.spawn_surface(None, size, overrides)?;
         Ok(self.attach_new_workspace(surface, name))
     }
 
@@ -671,6 +700,17 @@ impl Mux {
         workspace: Option<WorkspaceId>,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
+        self.new_screen_with_overrides(workspace, size, None)
+    }
+
+    /// Issue #76: [`Self::new_screen`] with explicit spawn overrides for
+    /// the new screen's first tab.
+    pub fn new_screen_with_overrides(
+        self: &Arc<Self>,
+        workspace: Option<WorkspaceId>,
+        size: Option<(u16, u16)>,
+        overrides: Option<&SpawnOverrides>,
+    ) -> anyhow::Result<Arc<Surface>> {
         // Validate the target before spawning a child.
         {
             let state = self.state.lock().unwrap();
@@ -680,12 +720,12 @@ impl Mux {
                 }
                 None if state.workspaces.is_empty() => {
                     drop(state);
-                    return self.new_workspace(None, size);
+                    return self.new_workspace_with_overrides(None, size, overrides);
                 }
                 _ => {}
             }
         }
-        let surface = self.spawn_surface(None, size)?;
+        let surface = self.spawn_surface(None, size, overrides)?;
         let (pane_id, pane) = self.make_pane(surface.id);
         let screen_id = self.next_id();
         let attached = {
@@ -731,6 +771,19 @@ impl Mux {
         cwd: Option<String>,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
+        self.new_tab_with_overrides(pane, cwd, size, None)
+    }
+
+    /// Issue #76: [`Self::new_tab`] with explicit spawn overrides — the
+    /// agent-start primitive (`cmux new-tab --exec -- <argv>` on the CLI,
+    /// `command`/`env` fields on the socket command).
+    pub fn new_tab_with_overrides(
+        self: &Arc<Self>,
+        pane: Option<PaneId>,
+        cwd: Option<String>,
+        size: Option<(u16, u16)>,
+        overrides: Option<&SpawnOverrides>,
+    ) -> anyhow::Result<Arc<Surface>> {
         // Resolve and validate the target before spawning a child.
         let target = {
             let state = self.state.lock().unwrap();
@@ -745,13 +798,13 @@ impl Mux {
             }
         };
         let Some(target) = target else {
-            return self.new_workspace(None, size);
+            return self.new_workspace_with_overrides(None, size, overrides);
         };
 
         let cwd = cwd.or_else(|| self.pane_cwd(target));
         // A sibling tab renders at the size the pane already has.
         let size = size.or_else(|| self.pane_size(target));
-        let surface = self.spawn_surface(cwd, size)?;
+        let surface = self.spawn_surface(cwd, size, overrides)?;
         let active_at = self.next_active_at();
         let attached = {
             let mut state = self.state.lock().unwrap();
@@ -927,6 +980,18 @@ impl Mux {
         dir: SplitDir,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<Arc<Surface>> {
+        self.split_with_overrides(target, dir, size, None)
+    }
+
+    /// Issue #76: [`Self::split`] with explicit spawn overrides for the
+    /// new pane's first tab.
+    pub fn split_with_overrides(
+        self: &Arc<Self>,
+        target: PaneId,
+        dir: SplitDir,
+        size: Option<(u16, u16)>,
+        overrides: Option<&SpawnOverrides>,
+    ) -> anyhow::Result<Arc<Surface>> {
         let cwd = self.pane_cwd(target);
         // Halve the split axis as a fallback estimate; the frontend sends
         // the exact size on its next layout pass.
@@ -936,7 +1001,7 @@ impl Mux {
                 SplitDir::Down => (cols, (rows.saturating_sub(1) / 2).max(1)),
             })
         });
-        let surface = self.spawn_surface(cwd, size)?;
+        let surface = self.spawn_surface(cwd, size, overrides)?;
         let pane_id = self.next_id();
         let active_at = self.next_active_at();
         let mut done = false;

--- a/mux/crates/mux-core/src/process.rs
+++ b/mux/crates/mux-core/src/process.rs
@@ -53,17 +53,35 @@ pub fn is_alive(pid: u32) -> bool {
 pub fn direct_children(pid: u32) -> Vec<u32> {
     #[cfg(target_os = "linux")]
     {
-        let path = format!("/proc/{pid}/task/{pid}/children");
-        if let Ok(contents) = std::fs::read_to_string(&path) {
-            let kids: Vec<u32> = contents
-                .split_whitespace()
-                .filter_map(|s| s.parse::<u32>().ok())
-                .collect();
-            // Some kernels expose the file but leave it empty for the
-            // calling process in certain contexts; fall through to a scan.
-            if !kids.is_empty() {
-                return kids;
+        // The per-task `children` file lists children of THAT task
+        // (thread), not of the thread group: children forked by worker
+        // threads (every socket-driven pane spawn in the daemon) and
+        // orphans reparented to a subreaper appear on other tasks'
+        // lists, never the leader's. Reading only the leader's file
+        // returned a stale partial list whenever any such child existed,
+        // silently skipping the rest (and making the
+        // `direct_children_finds_spawned_child` test order-dependent).
+        // Union every task's list instead; fall back to a full /proc
+        // scan when no list is readable at all.
+        let task_dir = format!("/proc/{pid}/task");
+        let mut kids: Vec<u32> = Vec::new();
+        if let Ok(entries) = std::fs::read_dir(&task_dir) {
+            for entry in entries.flatten() {
+                let children_path = entry.path().join("children");
+                let Ok(contents) = std::fs::read_to_string(&children_path) else {
+                    continue;
+                };
+                for token in contents.split_whitespace() {
+                    if let Ok(child) = token.parse::<u32>() {
+                        if !kids.contains(&child) {
+                            kids.push(child);
+                        }
+                    }
+                }
             }
+        }
+        if !kids.is_empty() {
+            return kids;
         }
         scan_proc_for_children(pid)
     }

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -43,7 +43,7 @@
 //! handled by the next `serve()` stale-clear / `kill-stale` (an L3
 //! follow-up can respawn the watchdog for the new path).
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -223,6 +223,15 @@ enum Command {
         cols: Option<u16>,
         #[serde(default)]
         rows: Option<u16>,
+        /// Issue #76: explicit child argv (agent start) — absent means
+        /// the default login shell. Recorded at spawn so `layout-export`
+        /// can replay it.
+        #[serde(default)]
+        command: Option<Vec<String>>,
+        /// Issue #76: extra env for the child, as a JSON object of
+        /// string → string.
+        #[serde(default)]
+        env: Option<BTreeMap<String, String>>,
     },
     NewBrowserTab {
         url: String,
@@ -340,6 +349,11 @@ enum Command {
         cols: Option<u16>,
         #[serde(default)]
         rows: Option<u16>,
+        /// Issue #76: explicit argv/env for the new pane's first tab.
+        #[serde(default)]
+        command: Option<Vec<String>>,
+        #[serde(default)]
+        env: Option<BTreeMap<String, String>>,
     },
     SetRatio {
         pane: PaneId,
@@ -844,6 +858,22 @@ fn sanitise_text(mode: ShellMode, text: &str) -> String {
     }
 }
 
+/// Issue #76: the socket `command`/`env` spawn fields → `SpawnOverrides`
+/// (agent start). `None` when neither is present keeps the legacy spawn.
+fn spawn_overrides(
+    command: Option<Vec<String>>,
+    env: Option<BTreeMap<String, String>>,
+) -> Option<crate::SpawnOverrides> {
+    if command.is_none() && env.is_none() {
+        return None;
+    }
+    Some(crate::SpawnOverrides {
+        command,
+        extra_env: env.map(|m| m.into_iter().collect()).unwrap_or_default(),
+        cwd: None,
+    })
+}
+
 fn get_surface(mux: &Mux, id: SurfaceId) -> anyhow::Result<Arc<crate::Surface>> {
     mux.surface(id).ok_or_else(|| anyhow::anyhow!("unknown surface {id}"))
 }
@@ -1046,8 +1076,9 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                 "data": base64::engine::general_purpose::STANDARD.encode(replay),
             }))
         }
-        Command::NewTab { pane, cwd, cols, rows } => {
-            let surface = mux.new_tab(pane, cwd, cols.zip(rows))?;
+        Command::NewTab { pane, cwd, cols, rows, command, env } => {
+            let overrides = spawn_overrides(command, env);
+            let surface = mux.new_tab_with_overrides(pane, cwd, cols.zip(rows), overrides.as_ref())?;
             Ok(json!({ "surface": surface.id }))
         }
         Command::NewBrowserTab { url, pane, cols, rows } => {
@@ -1164,13 +1195,14 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             let surface = mux.new_screen(workspace, cols.zip(rows))?;
             Ok(json!({ "surface": surface.id }))
         }
-        Command::Split { pane, dir, cols, rows } => {
+        Command::Split { pane, dir, cols, rows, command, env } => {
             let dir = match dir.as_str() {
                 "right" => SplitDir::Right,
                 "down" => SplitDir::Down,
                 other => anyhow::bail!("bad dir {other:?} (want \"right\" or \"down\")"),
             };
-            let surface = mux.split(pane, dir, cols.zip(rows))?;
+            let overrides = spawn_overrides(command, env);
+            let surface = mux.split_with_overrides(pane, dir, cols.zip(rows), overrides.as_ref())?;
             Ok(json!({ "surface": surface.id }))
         }
         Command::SetRatio { pane, dir, ratio } => {

--- a/mux/crates/mux-core/src/server.rs
+++ b/mux/crates/mux-core/src/server.rs
@@ -494,6 +494,26 @@ enum Command {
     RenameSession {
         new_name: String,
     },
+    /// Issue #76: export one workspace's tab/pane/agent-argv topology as
+    /// a versioned `LayoutDocument` (the response `data` IS the document).
+    /// `workspace` resolves name-first, then numeric workspace id; an
+    /// omitted field means the active workspace.
+    LayoutExport {
+        #[serde(default)]
+        workspace: Option<String>,
+    },
+    /// Issue #76: export every workspace in the session, as
+    /// `{"files":[{"filename":"<sanitized>.json","document":{...}}]}`
+    /// for the CLI's `--output-dir` fan-out.
+    LayoutExportAll,
+    /// Issue #76: replay a layout document under `workspace` (created if
+    /// missing, AC2). The document is structurally parsed by serde (parse
+    /// errors propagate as `bad request`); `validate()` then hard-fails
+    /// any schema/geometry drift (AC7) before a single pane is spawned.
+    LayoutApply {
+        workspace: String,
+        document: crate::layout_doc::LayoutDocument,
+    },
 }
 
 #[derive(Serialize)]
@@ -945,6 +965,35 @@ fn browser_state_json(
     value
 }
 
+/// Resolve a `layout-export` workspace selector: exact name first, then
+/// numeric workspace id (ids are session-local; names are the stable
+/// fleet identity — issue #76 builder decision D2). `None` selects the
+/// active workspace.
+fn resolve_workspace_index(mux: &Mux, selector: Option<&str>) -> anyhow::Result<usize> {
+    mux.with_state(|s| {
+        if s.workspaces.is_empty() {
+            anyhow::bail!("no workspaces in this session");
+        }
+        match selector {
+            None => Ok(s.active_workspace),
+            Some(sel) => s
+                .workspaces
+                .iter()
+                .position(|ws| ws.name == sel)
+                .or_else(|| {
+                    sel.parse::<u64>()
+                        .ok()
+                        .and_then(|id| s.workspaces.iter().position(|ws| ws.id == id))
+                })
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "unknown workspace {sel:?} (matched neither a name nor a numeric id)"
+                    )
+                }),
+        }
+    })
+}
+
 fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::Result<Value> {
     match cmd {
         Command::Identify => Ok(json!({
@@ -1382,6 +1431,36 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                 "session": new_name,
                 "socket_path": new_sock,
                 "pid": std::process::id(),
+            }))
+        }
+        Command::LayoutExport { workspace } => {
+            let index = resolve_workspace_index(mux, workspace.as_deref())?;
+            let doc = mux.with_state(|s| crate::layout_doc::capture_workspace(s, index))?;
+            Ok(serde_json::to_value(&doc)?)
+        }
+        Command::LayoutExportAll => {
+            let files = mux.with_state(|s| -> anyhow::Result<Vec<Value>> {
+                (0..s.workspaces.len())
+                    .map(|i| {
+                        let doc = crate::layout_doc::capture_workspace(s, i)?;
+                        let filename = format!(
+                            "{}.json",
+                            crate::layout_doc::sanitize_filename(&s.workspaces[i].name)
+                        );
+                        Ok(json!({ "filename": filename, "document": doc }))
+                    })
+                    .collect()
+            })?;
+            Ok(json!({ "files": files }))
+        }
+        Command::LayoutApply { workspace, document } => {
+            document.validate()?;
+            let summary = mux.apply_layout(&workspace, &document)?;
+            Ok(json!({
+                "workspace": workspace,
+                "workspace_id": summary.workspace_id,
+                "panes": summary.panes,
+                "surfaces": summary.surfaces,
             }))
         }
         Command::Subscribe => {

--- a/mux/crates/mux-core/src/surface.rs
+++ b/mux/crates/mux-core/src/surface.rs
@@ -95,6 +95,22 @@ pub struct DefaultColors {
     pub bg: Option<Rgb>,
 }
 
+/// Per-spawn overrides layered onto a [`Mux`](crate::Mux)'s default
+/// [`SurfaceOptions`] (issue #76): the recorded argv/env/cwd a layout
+/// `apply` or a `new-tab --exec` replays. `None`/empty fields keep the
+/// mux default.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SpawnOverrides {
+    /// Explicit child argv (e.g. an agent command). `None` = the default
+    /// login shell.
+    pub command: Option<Vec<String>>,
+    /// Extra env entries layered on top of the template (a repeated key
+    /// replaces the template's entry).
+    pub extra_env: Vec<(String, String)>,
+    /// Explicit working directory for the child.
+    pub cwd: Option<String>,
+}
+
 /// Coding-agent lifecycle state for a surface, as reported by `report-agent`
 /// (see `spec/commands.md`). Not detected automatically; a frontend or a
 /// hook script is the source of truth.
@@ -261,6 +277,17 @@ pub struct PtySurface {
     /// `persist.rs` capture enough to reattach the same remote session on
     /// restore, instead of recreating this tab as a local shell.
     remote: Option<crate::remote_pty::RemoteSpec>,
+    /// The argv this surface was spawned with (`None` = the default
+    /// login shell), recorded at spawn time so `layout export` (issue
+    /// #76) can replay the agent command. Reading it back from
+    /// `/proc/<child>` at export time is insufficient: agents typed into
+    /// a shell via `cmux send` are grandchildren of the pty child.
+    spawn_command: Option<Vec<String>>,
+    /// The `extra_env` entries in force at spawn time (post
+    /// socket-env refresh), for the same reason. cmux's auto-injected
+    /// `CMUX_MUX_SOCKET`/`CMUX_SOCKET_PATH` are filtered out again at
+    /// capture time (`layout_doc::capture_tab`).
+    spawn_env: Vec<(String, String)>,
     agent: Mutex<Option<AgentReport>>,
     size: Mutex<(u16, u16)>,
     /// Live output subscribers (attach streams). Guarded by the terminal
@@ -394,6 +421,8 @@ impl Surface {
             pwd: Mutex::new(None),
             initial_cwd,
             remote: opts.remote.clone(),
+            spawn_command: opts.command.clone().filter(|argv| !argv.is_empty()),
+            spawn_env: opts.extra_env.clone(),
             agent: Mutex::new(None),
             size: Mutex::new((opts.cols, opts.rows)),
             taps: Mutex::new(Vec::new()),
@@ -605,6 +634,20 @@ impl Surface {
     /// `cmuxd-remote` session rather than a local shell.
     pub fn remote_spec(&self) -> Option<crate::remote_pty::RemoteSpec> {
         self.as_pty().and_then(|pty| pty.remote.clone())
+    }
+
+    /// The argv this surface was spawned with (`None` for the default
+    /// login shell or a browser surface) — recorded at spawn time for
+    /// layout export (issue #76).
+    pub fn spawn_command(&self) -> Option<Vec<String>> {
+        self.as_pty().and_then(|pty| pty.spawn_command.clone())
+    }
+
+    /// The extra env entries injected at spawn time (`[]` for browser
+    /// surfaces). Includes cmux's auto-injected socket keys; layout
+    /// capture filters those back out.
+    pub fn spawn_env(&self) -> Vec<(String, String)> {
+        self.as_pty().map(|pty| pty.spawn_env.clone()).unwrap_or_default()
     }
 
     pub fn agent_report(&self) -> Option<AgentReport> {

--- a/mux/crates/mux-tui/src/cli.rs
+++ b/mux/crates/mux-tui/src/cli.rs
@@ -29,6 +29,10 @@ pub(crate) struct GlobalArgs {
 #[derive(Default)]
 struct FlagMap {
     values: BTreeMap<String, String>,
+    /// The verbatim argv captured by `--exec -- <argv...>` (issue #76).
+    /// Kept out of `values`: it is a list, not a `--flag value` pair, and
+    /// it consumes the rest of the command line.
+    exec: Option<Vec<String>>,
 }
 
 struct VerbSpec {
@@ -89,8 +93,11 @@ const VERBS: &[VerbSpec] = &[
         stream: false,
     },
     VerbSpec {
+        // "exec"/"env" (issue #76) carry an explicit child argv/env —
+        // `cmux new-tab --exec -- <argv...>` is the agent-start primitive
+        // that `layout export` records and `layout apply` replays.
         name: "new-tab",
-        allowed: &["pane", "cwd", "cols", "rows"],
+        allowed: &["pane", "cwd", "cols", "rows", "exec", "env"],
         build: build_new_tab,
         print: print_surface,
         stream: false,
@@ -118,7 +125,7 @@ const VERBS: &[VerbSpec] = &[
     },
     VerbSpec {
         name: "split",
-        allowed: &["pane", "dir", "cols", "rows"],
+        allowed: &["pane", "dir", "cols", "rows", "exec", "env"],
         build: build_split,
         print: print_surface,
         stream: false,
@@ -347,6 +354,31 @@ const VERBS: &[VerbSpec] = &[
         print: print_empty,
         stream: false,
     },
+    // Issue #76: the layout export/apply verbs are special-cased in
+    // `run_command` (they do local file I/O around the socket round-trip,
+    // like list/kill/rename-session). The VerbSpecs exist so `parse`
+    // recognises the verbs and their flags.
+    VerbSpec {
+        name: "layout-export",
+        allowed: &["workspace", "output"],
+        build: build_layout_export,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "layout-apply",
+        allowed: &["input", "workspace"],
+        build: build_layout_apply,
+        print: print_empty,
+        stream: false,
+    },
+    VerbSpec {
+        name: "layout-export-all",
+        allowed: &["output-dir"],
+        build: build_layout_export_all,
+        print: print_empty,
+        stream: false,
+    },
 ];
 
 pub fn is_cli_invocation(args: &[String]) -> bool {
@@ -423,6 +455,30 @@ fn parse(args: &[String]) -> Result<Parsed, UsageError> {
                 verb = verb_by_name(arg);
                 i += 1;
             }
+            // Issue #76: `--exec -- <argv...>` — everything after the
+            // literal `--` is the child's verbatim argv (no quoting
+            // loss). Must be the verb's LAST flag: it eats the rest of
+            // the command line.
+            _ if arg == "--exec" && verb.is_some() => {
+                let spec = verb.unwrap();
+                if !spec.allowed.contains(&"exec") {
+                    return Err(UsageError(format!("unknown flag --exec for {}", spec.name)));
+                }
+                if flags.exec.is_some() {
+                    return Err(UsageError("duplicate --exec".to_string()));
+                }
+                if args.get(i + 1).map(|s| s.as_str()) != Some("--") {
+                    return Err(UsageError(
+                        "--exec must be followed by \"--\" and the command argv".to_string(),
+                    ));
+                }
+                let argv: Vec<String> = args[i + 2..].to_vec();
+                if argv.is_empty() {
+                    return Err(UsageError("--exec needs a command after \"--\"".to_string()));
+                }
+                flags.exec = Some(argv);
+                i = args.len();
+            }
             _ if arg.starts_with("--") => {
                 let Some(spec) = verb else {
                     return Err(UsageError(format!("unknown global flag {arg:?}")));
@@ -462,6 +518,9 @@ fn run_command(args: CliArgs) -> i32 {
         "kill-session" => return run_kill_session(&args.global, &args.flags),
         "kill-stale" => return run_kill_stale(&args.global, &args.flags),
         "rename-session" => return run_rename_session(&args.global, &args.flags),
+        "layout-export" => return run_layout_export(&args.global, &args.flags),
+        "layout-apply" => return run_layout_apply(&args.global, &args.flags),
+        "layout-export-all" => return run_layout_export_all(&args.global, &args.flags),
         _ => {}
     }
     let request = match (args.verb.build)(&args.flags) {
@@ -700,7 +759,31 @@ fn build_new_tab(flags: &FlagMap) -> Result<Value, UsageError> {
     flags.insert_optional_u64(&mut value, "pane")?;
     flags.insert_optional_string(&mut value, "cwd");
     flags.insert_optional_size(&mut value)?;
+    insert_exec_env(flags, &mut value)?;
     Ok(value)
+}
+
+/// Issue #76: `--exec -- <argv...>` (verbatim argv passthrough) and
+/// `--env K=V,K2=V2` (comma-separated pairs) → the socket command's
+/// `command` / `env` fields.
+fn insert_exec_env(flags: &FlagMap, value: &mut Value) -> Result<(), UsageError> {
+    if let Some(argv) = &flags.exec {
+        value["command"] = json!(argv);
+    }
+    if let Some(env) = flags.optional("env") {
+        let mut map = serde_json::Map::new();
+        for pair in env.split(',') {
+            let Some((key, val)) = pair.split_once('=') else {
+                return Err(UsageError(format!("--env entries must be K=V (got {pair:?})")));
+            };
+            if key.is_empty() {
+                return Err(UsageError("--env keys cannot be empty".to_string()));
+            }
+            map.insert(key.to_string(), json!(val));
+        }
+        value["env"] = Value::Object(map);
+    }
+    Ok(())
 }
 
 fn build_new_browser_tab(flags: &FlagMap) -> Result<Value, UsageError> {
@@ -727,6 +810,7 @@ fn build_new_screen(flags: &FlagMap) -> Result<Value, UsageError> {
 fn build_split(flags: &FlagMap) -> Result<Value, UsageError> {
     let mut value = json!({ "pane": flags.required_u64("pane")?, "dir": flags.required_dir()? });
     flags.insert_optional_size(&mut value)?;
+    insert_exec_env(flags, &mut value)?;
     Ok(value)
 }
 
@@ -857,6 +941,29 @@ fn build_list_agents(flags: &FlagMap) -> Result<Value, UsageError> {
 fn build_kill_session(flags: &FlagMap) -> Result<Value, UsageError> {
     let mut value = json!({});
     flags.insert_optional_string(&mut value, "session");
+    Ok(value)
+}
+
+/// Layout-verb parsers carry their flags; the runners below do the
+/// required-flag checks, the file I/O, and their own exit-code maps
+/// (issue #76).
+fn build_layout_export(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_string(&mut value, "workspace");
+    flags.insert_optional_string(&mut value, "output");
+    Ok(value)
+}
+
+fn build_layout_apply(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_string(&mut value, "input");
+    flags.insert_optional_string(&mut value, "workspace");
+    Ok(value)
+}
+
+fn build_layout_export_all(flags: &FlagMap) -> Result<Value, UsageError> {
+    let mut value = json!({});
+    flags.insert_optional_string(&mut value, "output-dir");
     Ok(value)
 }
 
@@ -1311,6 +1418,218 @@ fn run_rename_session(global: &GlobalArgs, flags: &FlagMap) -> i32 {
             eprintln!("{err}");
             3
         }
+    }
+}
+
+// -- issue #76: layout export/apply runners ------------------------------
+
+/// `cmux layout-export --workspace <name-or-id> --output <path>.json`.
+/// The server produces the document; the CLIENT writes the file (tmp +
+/// rename, refusing symlinked targets) so no daemon ever touches the
+/// invoker's filesystem. Exit codes: 0 ok · 1 server/file error · 2 bad
+/// flags · 3 transport.
+fn run_layout_export(global: &GlobalArgs, flags: &FlagMap) -> i32 {
+    let (workspace, output) = match (flags.required("workspace"), flags.required("output")) {
+        (Ok(w), Ok(o)) => (w, o),
+        (Err(e), _) | (_, Err(e)) => {
+            eprintln!("cmux: {}", e.0);
+            return 2;
+        }
+    };
+    let output = PathBuf::from(output);
+    if let Err(e) = refuse_symlink(&output) {
+        eprintln!("cmux: {e}");
+        return 1;
+    }
+    let request = json!({ "cmd": "layout-export", "workspace": workspace, "id": REQUEST_ID });
+    match one_shot_rpc(&resolve_socket(global), request) {
+        OneShotOutcome::Ok(value) => {
+            let doc = value.get("data").cloned().unwrap_or(Value::Null);
+            let pretty = match serde_json::to_string_pretty(&doc) {
+                Ok(p) => p,
+                Err(e) => {
+                    eprintln!("cmux: encoding layout document: {e}");
+                    return 1;
+                }
+            };
+            if let Err(e) = write_json_atomic(&output, &pretty) {
+                eprintln!("cmux: writing {}: {e}", output.display());
+                return 1;
+            }
+            if global.json {
+                println!("{}", json!({ "output": output.display().to_string() }));
+            } else {
+                println!("{}", output.display());
+            }
+            0
+        }
+        OneShotOutcome::ServerErr(e) => {
+            eprintln!("cmux: {e}");
+            1
+        }
+        OneShotOutcome::ConnectErr(e) => {
+            eprintln!("{e}");
+            3
+        }
+    }
+}
+
+/// `cmux layout-apply --input <path>.json --workspace <name>` (issue #76
+/// AC2): replay a saved layout, creating the workspace if missing. The
+/// file is parsed structurally here (parse errors propagate, exit 2);
+/// the schema gate lives server-side so a version mismatch surfaces as
+/// the daemon's loud error (exit 1).
+fn run_layout_apply(global: &GlobalArgs, flags: &FlagMap) -> i32 {
+    let (input, workspace) = match (flags.required("input"), flags.required("workspace")) {
+        (Ok(i), Ok(w)) => (i, w),
+        (Err(e), _) | (_, Err(e)) => {
+            eprintln!("cmux: {}", e.0);
+            return 2;
+        }
+    };
+    let contents = match std::fs::read_to_string(&input) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("cmux: reading layout {input:?}: {e}");
+            return 2;
+        }
+    };
+    let document: mux_core::LayoutDocument = match serde_json::from_str(&contents) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("cmux: parsing layout {input:?}: {e}");
+            return 2;
+        }
+    };
+    let request =
+        json!({ "cmd": "layout-apply", "workspace": workspace, "document": document, "id": REQUEST_ID });
+    match one_shot_rpc(&resolve_socket(global), request) {
+        OneShotOutcome::Ok(value) => {
+            if global.json {
+                if let Some(data) = value.get("data") {
+                    println!("{data}");
+                }
+            }
+            0
+        }
+        OneShotOutcome::ServerErr(e) => {
+            eprintln!("cmux: {e}");
+            1
+        }
+        OneShotOutcome::ConnectErr(e) => {
+            eprintln!("{e}");
+            3
+        }
+    }
+}
+
+/// `cmux layout-export-all --output-dir <dir>` (issue #76 AC3): fetch one
+/// document per workspace and fan them out as `<dir>/<sanitized>.json`.
+fn run_layout_export_all(global: &GlobalArgs, flags: &FlagMap) -> i32 {
+    let dir = match flags.required("output-dir") {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("cmux: {}", e.0);
+            return 2;
+        }
+    };
+    let dir = PathBuf::from(dir);
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("cmux: creating {}: {e}", dir.display());
+        return 2;
+    }
+    let request = json!({ "cmd": "layout-export-all", "id": REQUEST_ID });
+    match one_shot_rpc(&resolve_socket(global), request) {
+        OneShotOutcome::Ok(value) => {
+            let files = value
+                .get("data")
+                .and_then(|d| d.get("files"))
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if files.is_empty() {
+                eprintln!("cmux: no workspaces to export");
+                return 1;
+            }
+            let mut written = Vec::new();
+            for file in &files {
+                let Some(name) = file.get("filename").and_then(Value::as_str) else {
+                    eprintln!("cmux: export-all response entry missing filename");
+                    return 1;
+                };
+                // The server sanitizes, but never trust a path component
+                // off the wire: refuse anything that could escape --output-dir.
+                if name.is_empty()
+                    || name == "."
+                    || name == ".."
+                    || name.contains('/')
+                    || name.contains('\\')
+                {
+                    eprintln!("cmux: refusing unsafe export filename {name:?}");
+                    return 1;
+                }
+                let path = dir.join(name);
+                if let Err(e) = refuse_symlink(&path) {
+                    eprintln!("cmux: {e}");
+                    return 1;
+                }
+                let pretty = match serde_json::to_string_pretty(file.get("document").unwrap_or(&Value::Null)) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        eprintln!("cmux: encoding layout document: {e}");
+                        return 1;
+                    }
+                };
+                if let Err(e) = write_json_atomic(&path, &pretty) {
+                    eprintln!("cmux: writing {}: {e}", path.display());
+                    return 1;
+                }
+                written.push(path.display().to_string());
+            }
+            if global.json {
+                println!("{}", json!({ "files": written }));
+            } else {
+                for path in &written {
+                    println!("{path}");
+                }
+            }
+            0
+        }
+        OneShotOutcome::ServerErr(e) => {
+            eprintln!("cmux: {e}");
+            1
+        }
+        OneShotOutcome::ConnectErr(e) => {
+            eprintln!("{e}");
+            3
+        }
+    }
+}
+
+/// Atomic pretty-JSON write (write-to-temp then rename — the
+/// `persist::SessionSnapshot::save` pattern) so a crash or a concurrent
+/// reader never observes a truncated file.
+fn write_json_atomic(path: &std::path::Path, contents: &str) -> std::io::Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    // A leftover tmp from a crashed run could itself be a symlink; the
+    // rename must never write through one.
+    let _ = std::fs::remove_file(&tmp);
+    std::fs::write(&tmp, contents)?;
+    std::fs::rename(&tmp, path)
+}
+
+/// `fs::write` on a symlink path overwrites the TARGET, not the link —
+/// refuse symlinked output paths outright (AGENTS.md review checklist).
+fn refuse_symlink(path: &std::path::Path) -> Result<(), String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_symlink() => {
+            Err(format!("refusing to write through symlink {}", path.display()))
+        }
+        Ok(_) => Ok(()),
+        Err(_) => Ok(()), // nothing there yet — fine
     }
 }
 

--- a/mux/crates/mux-tui/src/main.rs
+++ b/mux/crates/mux-tui/src/main.rs
@@ -148,7 +148,8 @@ CLI VERBS
   focus-pane, select-tab, select-screen, select-workspace, move-tab,
   move-workspace, scroll-surface, subscribe, attach-surface, report-agent,
   list-agents, browser-reload, list-sessions, kill-session, kill-stale,
-  rename-session, theme list
+  rename-session, layout-export, layout-apply, layout-export-all,
+  theme list
 
 SEND
   cmux send --surface <id> --text <text> [--shell auto|fish|bash|zsh|sh|nu|raw]
@@ -160,6 +161,27 @@ SEND
       instead of being interpreted by the shell's line editor. auto
       resolves the pane's shell from /proc on Linux. Default: raw
       (verbatim passthrough, unchanged from before).
+
+LAYOUT EXPORT/APPLY (issue #76)
+  cmux layout-export --workspace <name-or-id> --output <file>.json
+      Save one workspace's tab/pane/agent-argv topology as versioned JSON
+      (schema 1, see spec/layout-schema.md). Client-side atomic write
+      (tmp + rename); symlinked outputs are refused.
+  cmux layout-export-all --output-dir <dir>
+      Save every workspace in the session as <dir>/<name>.json (mkdir -p).
+  cmux layout-apply --input <file>.json --workspace <name>
+      Replay a saved layout: the workspace is created if missing; applying
+      onto an existing name is refused (close it first or pick a new
+      name). Panes spawn with the recorded argv/env/cwd; a failure aborts
+      loudly naming the pane (index + pane-id).
+  cmux new-tab [--pane N] [--cwd P] [--env K=V,...] --exec -- <argv...>
+  cmux split --pane N --dir <right|down> [--env K=V,...] --exec -- <argv...>
+      Spawn with an explicit command (agent start): everything after the
+      literal `--` that follows --exec is the verbatim argv, so --exec
+      must be the LAST flag. --env is a comma-separated K=V list.
+      Layout-export records these argv/env pairs; for remote sessions
+      compose `layout-apply` against the remote socket with a follow-up
+      `cmux attach --apply-local-config`.
 
 RENAME-SESSION
   cmux rename-session --old <name> --new <name> [--json]

--- a/mux/crates/mux-tui/tests/cli.rs
+++ b/mux/crates/mux-tui/tests/cli.rs
@@ -2503,3 +2503,286 @@ fn first_attach_to_dead_socket_still_exits_nonzero() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+
+// -- issue #76: layout export/apply --------------------------------------
+
+/// Helper: the parsed `--json list-workspaces` payload.
+fn list_workspaces_json(server: &HeadlessServer) -> serde_json::Value {
+    let listed = cli(server, &["--json", "list-workspaces"]);
+    assert_success(&listed);
+    serde_json::from_slice(&listed.stdout).unwrap()
+}
+
+#[test]
+fn layout_export_writes_versioned_workspace_json() {
+    let server = HeadlessServer::start("layout-export");
+    let ws = cli(&server, &["new-workspace", "--name", "fleet"]);
+    assert_success(&ws);
+
+    let value = list_workspaces_json(&server);
+    let pane = value["workspaces"][0]["screens"][0]["panes"][0]["id"].as_u64().unwrap();
+    let split = cli(&server, &["split", "--pane", &pane.to_string(), "--dir", "right"]);
+    assert_success(&split);
+    let ratio = cli(&server, &[
+        "set-ratio",
+        "--pane",
+        &pane.to_string(),
+        "--dir",
+        "right",
+        "--ratio",
+        "0.6",
+    ]);
+    assert_success(&ratio);
+
+    let out = server.dir.join("fleet.json");
+    let export = cli(&server, &[
+        "layout-export",
+        "--workspace",
+        "fleet",
+        "--output",
+        out.to_str().unwrap(),
+    ]);
+    assert_success(&export);
+    assert_eq!(
+        String::from_utf8_lossy(&export.stdout).trim(),
+        out.display().to_string(),
+        "plain mode prints the written path"
+    );
+
+    let doc: serde_json::Value = serde_json::from_str(&fs::read_to_string(&out).unwrap()).unwrap();
+    assert_eq!(doc["schema_version"].as_u64(), Some(1), "doc was {doc}");
+    assert_eq!(doc["cmux_version"].as_str(), Some(mux_core::VERSION));
+    assert_eq!(doc["workspace"]["name"].as_str(), Some("fleet"));
+    let layout = &doc["workspace"]["screens"][0]["layout"];
+    assert_eq!(layout["type"].as_str(), Some("split"));
+    assert_eq!(layout["dir"].as_str(), Some("right"));
+    assert!((layout["ratio"].as_f64().unwrap() - 0.6).abs() < 1e-5);
+    assert_eq!(layout["a"]["type"].as_str(), Some("leaf"));
+    assert_eq!(layout["a"]["pane"].as_u64(), Some(0));
+    assert_eq!(
+        doc["workspace"]["screens"][0]["panes"].as_array().unwrap().len(),
+        2,
+        "both split panes should be recorded"
+    );
+}
+
+#[test]
+fn layout_apply_round_trips_topology_and_argv() {
+    let server = HeadlessServer::start("layout-apply");
+    let ws = cli(&server, &["new-workspace", "--name", "fleet"]);
+    assert_success(&ws);
+
+    let value = list_workspaces_json(&server);
+    let pane = value["workspaces"][0]["screens"][0]["panes"][0]["id"].as_u64().unwrap();
+    let ws_id = value["workspaces"][0]["id"].as_u64().unwrap();
+
+    // An agent tab with explicit argv + env (the `--exec` spawn path).
+    let marker = format!("FLEETMARKER_{}", std::process::id());
+    let exec = cli(
+        &server,
+        &[
+            "new-tab",
+            "--pane",
+            &pane.to_string(),
+            "--env",
+            "FLEET_TIER=A",
+            "--exec",
+            "--",
+            "/bin/sh",
+            "-c",
+            &format!("printf '{marker}'; sleep 60"),
+        ],
+    );
+    assert_success(&exec);
+    let split = cli(&server, &["split", "--pane", &pane.to_string(), "--dir", "down"]);
+    assert_success(&split);
+
+    let out = server.dir.join("fleet.json");
+    let export = cli(&server, &[
+        "layout-export",
+        "--workspace",
+        "fleet",
+        "--output",
+        out.to_str().unwrap(),
+    ]);
+    assert_success(&export);
+    let doc: serde_json::Value = serde_json::from_str(&fs::read_to_string(&out).unwrap()).unwrap();
+    let tabs = &doc["workspace"]["screens"][0]["panes"][0]["tabs"];
+    assert_eq!(tabs.as_array().unwrap().len(), 2);
+    assert_eq!(
+        tabs[1]["command"].as_array().map(|a| a.len()),
+        Some(3),
+        "recorded argv should round-trip into the file: {tabs}"
+    );
+    assert_eq!(tabs[1]["env"]["FLEET_TIER"].as_str(), Some("A"));
+
+    let close = cli(&server, &["close-workspace", "--workspace", &ws_id.to_string()]);
+    assert_success(&close);
+
+    let apply = cli(&server, &[
+        "layout-apply",
+        "--input",
+        out.to_str().unwrap(),
+        "--workspace",
+        "fleet",
+    ]);
+    assert_success(&apply);
+
+    // Topology is back: one workspace, two panes, the exec tab re-spawned.
+    let value = list_workspaces_json(&server);
+    let workspaces = value["workspaces"].as_array().unwrap();
+    assert_eq!(workspaces.len(), 1);
+    assert_eq!(workspaces[0]["name"].as_str(), Some("fleet"));
+    let layout = &workspaces[0]["screens"][0]["layout"];
+    assert_eq!(layout["type"].as_str(), Some("split"), "split geometry restored");
+    assert_eq!(layout["dir"].as_str(), Some("down"));
+    let panes = workspaces[0]["screens"][0]["panes"].as_array().unwrap();
+    assert_eq!(panes.len(), 2);
+    assert_eq!(panes[0]["tabs"].as_array().unwrap().len(), 2);
+
+    // The re-spawned argv actually ran: poll every surface for the marker.
+    let surfaces: Vec<u64> = panes
+        .iter()
+        .flat_map(|p| p["tabs"].as_array().unwrap().iter())
+        .map(|t| t["surface"].as_u64().unwrap())
+        .collect();
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut saw = false;
+    while Instant::now() < deadline && !saw {
+        for &sid in &surfaces {
+            let read = cli(&server, &["read-screen", "--surface", &sid.to_string()]);
+            if read.status.success()
+                && String::from_utf8_lossy(&read.stdout).contains(&marker)
+            {
+                saw = true;
+                break;
+            }
+        }
+        if !saw {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+    assert!(saw, "apply should re-spawn the recorded argv and print {marker}");
+}
+
+#[test]
+fn layout_export_all_writes_one_file_per_workspace() {
+    let server = HeadlessServer::start("layout-export-all");
+    for name in ["alpha", "beta"] {
+        let ws = cli(&server, &["new-workspace", "--name", name]);
+        assert_success(&ws);
+    }
+
+    let dir = server.dir.join("fleet");
+    let export = cli(&server, &["layout-export-all", "--output-dir", dir.to_str().unwrap()]);
+    assert_success(&export);
+    for name in ["alpha", "beta"] {
+        let path = dir.join(format!("{name}.json"));
+        let doc: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(doc["schema_version"].as_u64(), Some(1), "{name} doc: {doc}");
+        assert_eq!(doc["workspace"]["name"].as_str(), Some(name));
+    }
+}
+
+#[test]
+fn layout_apply_rejects_unknown_schema_version_loudly() {
+    let server = HeadlessServer::start("layout-apply-v2");
+    let bad = server.dir.join("v2.json");
+    fs::write(
+        &bad,
+        r#"{"schema_version":2,"cmux_version":"x","workspace":{"name":"w","active_screen":0,"screens":[{"active_pane":0,"layout":{"type":"leaf","pane":0},"panes":[{"tabs":[{"kind":"pty"}]}]}]}}"#,
+    )
+    .unwrap();
+
+    let apply = cli(&server, &[
+        "layout-apply",
+        "--input",
+        bad.to_str().unwrap(),
+        "--workspace",
+        "w",
+    ]);
+    assert_eq!(
+        apply.status.code(),
+        Some(1),
+        "schema mismatch is a server-reported error (exit 1), got {:?}\nstderr: {}",
+        apply.status.code(),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&apply.stderr);
+    assert!(stderr.contains("schema_version"), "stderr was: {stderr}");
+    assert!(stderr.contains('2'), "stderr should name the file's version: {stderr}");
+}
+
+#[test]
+fn layout_apply_creates_missing_workspace() {
+    let server = HeadlessServer::start("layout-apply-create");
+    let ws = cli(&server, &["new-workspace", "--name", "solo"]);
+    assert_success(&ws);
+    let out = server.dir.join("solo.json");
+    let export = cli(&server, &[
+        "layout-export",
+        "--workspace",
+        "solo",
+        "--output",
+        out.to_str().unwrap(),
+    ]);
+    assert_success(&export);
+
+    // Applying under a NEW name creates that workspace (AC2).
+    let apply = cli(&server, &[
+        "layout-apply",
+        "--input",
+        out.to_str().unwrap(),
+        "--workspace",
+        "solo2",
+    ]);
+    assert_success(&apply);
+    let value = list_workspaces_json(&server);
+    let names: Vec<&str> =
+        value["workspaces"].as_array().unwrap().iter().map(|w| w["name"].as_str().unwrap()).collect();
+    assert_eq!(names, vec!["solo", "solo2"], "both the original and the applied copy exist");
+
+    // Applying onto an existing name is refused, loudly and non-destructively.
+    let again = cli(&server, &[
+        "layout-apply",
+        "--input",
+        out.to_str().unwrap(),
+        "--workspace",
+        "solo",
+    ]);
+    assert_eq!(again.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&again.stderr).contains("already exists"));
+}
+
+#[test]
+fn layout_export_refuses_symlinked_output() {
+    let server = HeadlessServer::start("layout-export-symlink");
+    let ws = cli(&server, &["new-workspace", "--name", "sec"]);
+    assert_success(&ws);
+
+    let target = server.dir.join("real-target.json");
+    fs::write(&target, "").unwrap();
+    let link = server.dir.join("link.json");
+    symlink(&target, &link).unwrap();
+
+    let export = cli(&server, &[
+        "layout-export",
+        "--workspace",
+        "sec",
+        "--output",
+        link.to_str().unwrap(),
+    ]);
+    assert_eq!(
+        export.status.code(),
+        Some(1),
+        "symlinked output must be refused, got {:?}",
+        export.status.code()
+    );
+    assert!(String::from_utf8_lossy(&export.stderr).contains("symlink"));
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        "",
+        "the symlink target must be untouched"
+    );
+}

--- a/spec/layout-schema.md
+++ b/spec/layout-schema.md
@@ -1,0 +1,175 @@
+# cmux layout JSON schema (v1)
+
+Issue #76 — `layout export` / `layout apply`: save a workspace's
+workspace + screen + pane-BSP + tab + agent-argv topology to a
+versioned JSON file, and replay it later (the "save this fleet so I can
+boot it tomorrow" daily-resume workflow).
+
+The verbs:
+
+```
+cmux layout-export --workspace <name-or-id> --output fleet.json
+cmux layout-export-all --output-dir ./fleet/          # one file per workspace
+cmux layout-apply --input fleet.json --workspace <name>
+```
+
+The internal sibling of this format is `persist.rs`'s session snapshot
+(what the daemon writes to `$XDG_STATE_HOME/cmux/sessions/<name>.json`
+on every tree change). That format deliberately does **not** record tab
+commands; this one does, which is the whole point.
+
+## Versioning
+
+```json
+{ "schema_version": 1, "cmux_version": "0.17.2", "workspace": { ... } }
+```
+
+- `schema_version` is the only gate. A file with any other version is
+  **rejected loudly** by `layout-apply` (exit 1, error names the file's
+  version) — never silently misparsed.
+- `cmux_version` is the exporting build's `mux_core::VERSION`
+  (informational; never `CARGO_PKG_VERSION` — see issue #71).
+- Additive, optional fields use `#[serde(default)]` liberally, so a
+  future v1 writer adding a field stays readable by older v1 readers.
+  The version bumps to 2 only on a breaking change.
+
+## Document shape
+
+```json
+{
+  "schema_version": 1,
+  "cmux_version": "0.17.2",
+  "workspace": {
+    "name": "fleet",
+    "color": "#ff8800",              // optional, "#rrggbb" or a named preset
+    "icon": "robot",                  // optional
+    "active_screen": 0,
+    "screens": [
+      {
+        "name": "main",               // optional
+        "active_pane": 0,
+        "layout": {                   // BSP tree, pane-INDEX leaves
+          "type": "split",
+          "dir": "right",
+          "ratio": 0.6,
+          "a": { "type": "leaf", "pane": 0 },
+          "b": { "type": "leaf", "pane": 1 }
+        },
+        "panes": [
+          {
+            "name": "build",          // optional
+            "active_tab": 0,
+            "tabs": [ { ... } ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`layout` mirrors the socket's `list-workspaces` `node_json` shape
+(`{"type":"split","dir":"right"|"down","ratio":f32,"a":…,"b":…}` /
+`{"type":"leaf","pane":<index>}`), but leaves index the sibling
+`panes` array (the `persist.rs` pattern) instead of live pane ids —
+ids are session-local and never stable across restarts.
+
+### Tab kinds
+
+| kind | fields | notes |
+|---|---|---|
+| `pty` | `name?`, `cwd?`, `command?`, `env?` | `command` is the exact argv the tab was spawned with, recorded **at spawn time**. `null` for a default login shell. `env` is a map of injected variables. |
+| `browser` | `name?`, `url` | the browser tab's URL. |
+| `remote` | `name?`, `host`, `slot`, `session_id`, `local_binary_path` | a `cmuxd-remote` session (see below for the reattach limits). |
+
+### Env exclusion list
+
+`env` never contains `CMUX_MUX_SOCKET` or `CMUX_SOCKET_PATH`: those are
+auto-injected (and dual-written) into every spawn from the *applying*
+daemon's live socket path. Round-tripping a stale socket path would
+detach the restored fleet, so capture filters them out and apply
+re-derives them.
+
+## How argv is captured
+
+`PtySurface` records `SurfaceOptions.command` / `extra_env` at spawn
+time. Reading `/proc/<child>/cmdline` back at export time is not enough:
+agents started by *typing into a shell* (`cmux send`) are grandchildren
+of the PTY child — the direct child is the shell, and the agent argv is
+unrecoverable. Consequences:
+
+- Tabs spawned via `new-tab --exec -- <argv...>` (or the socket
+  `command`/`env` fields) round-trip exactly (AC5 parity).
+- Tabs where a human typed `pi --print hi` into a shell export with
+  `command: null`; apply restores a shell in the recorded `cwd`
+  (**R1**). Migrate fleets to `--exec` spawns for full parity
+  (follow-up: pifactory bootstrap scripts).
+
+## Validation (apply-time, fail-loud)
+
+`LayoutDocument::validate` gates every apply (AC7) — nothing is spawned
+before the whole document checks out:
+
+- `schema_version == 1` (hard fail naming the version otherwise),
+- every layout leaf indexes an existing pane, exactly once, and every
+  pane is referenced (no orphaned/dead panes),
+- split ratios strictly inside `(0,1)`,
+- `active_screen` / `active_pane` / `active_tab` in range,
+- ≥1 screen, ≥1 pane per screen, ≥1 tab per pane,
+- workspace `color`/`icon` parse.
+
+During replay, a pane whose tabs cannot be recreated aborts the apply
+with `pane <index> (pane-id <id>): <error>`; a pane that could not even
+be created names its index. **Already-created panes are left in place**
+— apply is fail-loud, not transactional; a `--replace`/rollback flag is
+follow-up scope (**R2**). Re-run `layout-apply` under a fresh name after
+closing the partial workspace.
+
+## Round-trip guarantees and limits
+
+- Split geometry (directions + ratios), names (workspace/screen/pane/
+  tab), colors, icons, and selections (active screen/pane/tab) restore
+  exactly.
+- Ratios are re-clamped to cmux's `[0.05, 0.95]` on apply.
+- `layout-apply --workspace <name>` uses the **flag's** name, not the
+  document's embedded name — one fleet file can be booted under many
+  names. The workspace is created if missing (AC2); applying onto an
+  existing name is refused (close it first).
+- Short-lived recorded commands close their pane when they exit — normal
+  cmux pane semantics; long-running agents should self-daemonize or
+  `exec sleep` as their tail.
+- Browser tabs re-open their URL (the page state itself — logins,
+  scroll — is not captured).
+- **Remote tabs (R3):** only a workspace's *first* tab can reattach to
+  the same `cmuxd-remote` session (via the `new-remote` workspace
+  bootstrap — the inherited `persist.rs` limitation). A remote tab
+  anywhere else downgrades to a local shell with a loud
+  `MuxEvent::Status` rather than failing silently. If the recorded
+  `local_binary_path` is gone or stale, the reattach fails cleanly —
+  reconnect manually via `cmux ssh <host>`.
+
+## Composing with `--apply-local-config` (AC6)
+
+`--apply-local-config` (issue #40) is a *client-side, attach-path*
+chrome overlay (theme/tabs/sidebar/keys); the layout document is
+*server-side topology*. They compose without any extra flag:
+
+```
+cmux --socket /path/to/remote.sock layout-apply --input fleet.json --workspace ops
+cmux --socket /path/to/remote.sock attach --apply-local-config
+```
+
+The first command rebuilds the fleet on the remote daemon; the second
+attaches the local TUI with the local `mux.local.toml`/`mux.json`
+layered over the remote server's resolved chrome
+(`get-resolved-config`). `workspace.color`/`icon` are server state and
+ride in the layout document itself.
+
+## Exit codes (CLI)
+
+| code | meaning |
+|---|---|
+| 0 | success |
+| 1 | server-reported error (unknown workspace, schema mismatch, apply failure) or file write error |
+| 2 | bad/missing flags, unreadable/unparseable `--input` file, unsafe output dir |
+| 3 | socket connect/transport failure |


### PR DESCRIPTION
Closes #76

Herdr-spirit feature chain. scout(GLM5.3) -> build(GLM5.3/M3-sub) -> review(GLM) -> verify(GLM5.3, cross-family relaxed per operator directive: Kimi K3 quota exhausted). Live-exercise verified in headless sessions; see .pifactory artifacts in the worktree.